### PR TITLE
chore: docker-up baut Images neu + nutzt selbst-gebaute SDE (obsolete Targets entfernt)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile – Zentrale Orchestrierung für Projekt-Automationen
 # Referenz: copilot-instructions.md Abschnitt 3.1
 
-.PHONY: help test test-be test-be-unit test-be-int test-be-bench test-be-examples test-be-ex-cargo test-be-ex-nav test-fe lint lint-be lint-fe lint-ci adr-ref commit-lint release-check security-blockers scan scan-json secrets-scan secrets-check pr-check release ci-local clean ensure-trivy ensure-gitleaks push-ci pr-quality-gates-ci docker-up docker-down docker-logs docker-ps docker-build docker-clean docker-restart docker-rebuild docker-shell-api docker-shell-db docker-shell-redis migrate migrate-up migrate-down migrate-create
+.PHONY: help test test-be test-be-unit test-be-int test-be-bench test-be-examples test-be-ex-cargo test-be-ex-nav test-fe lint lint-be lint-fe lint-ci adr-ref commit-lint release-check security-blockers scan scan-json secrets-scan secrets-check pr-check release ci-local clean ensure-trivy ensure-gitleaks push-ci pr-quality-gates-ci sde docker-up docker-down docker-logs docker-ps docker-build docker-clean docker-shell-api docker-shell-db docker-shell-redis migrate migrate-up migrate-down migrate-create
 
 # Standardwerte
 TRIVY_FAIL_ON ?= HIGH,CRITICAL
@@ -13,6 +13,10 @@ COMPOSE_FILE ?= deployments/docker-compose.yml
 DOCKER_COMPOSE ?= $(shell command -v docker-compose 2>/dev/null || echo "docker compose")
 DATABASE_URL ?= postgresql://eveprovit:dev@localhost:5432/eveprovit?sslmode=disable
 MIGRATIONS_DIR ?= $(BACKEND_DIR)/migrations
+# Selbst-gebaute SDE: erzeugt vom eve-sde-Projekt (nicht vom GitHub-Release)
+EVE_SDE_DIR ?= ../eve-sde
+SDE_SOURCE := $(EVE_SDE_DIR)/data/sqlite/eve-sde.db
+SDE_TARGET := $(BACKEND_DIR)/data/sde/eve-sde.db
 
 .DEFAULT_GOAL := help
 
@@ -57,7 +61,7 @@ help: ## Zeigt verfügbare Targets (gruppiert)
 	@echo "└───────────────────────────────────────────────────────────────────────────────────────────────────────"
 	@echo ""
 	@echo "┌─ Docker & Compose ────────────────────────────────────────────────────────────────────────────────────"
-	@grep -E '^docker.*:.*?## .*$$' $(MAKEFILE_LIST) | \
+	@grep -E '^(sde|docker).*:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "│ \033[36m%-26s\033[0m %-68s\n", $$1, $$2}'
 	@echo "└───────────────────────────────────────────────────────────────────────────────────────────────────────"
 	@echo ""
@@ -342,14 +346,16 @@ ensure-gitleaks: ## Stellt sicher, dass Gitleaks verfügbar ist
 
 # Docker & Compose Targets
 
-db-load: ## Lädt EVE SDE SQLite DB vom offiziellen GitHub Release
-	@echo "[make db-load] Lade EVE SDE Datenbank..."
-	@bash scripts/download-sde.sh
-	@echo "[make db-load] ✅ SDE Datenbank geladen"
+sde: ## Baut/aktualisiert die selbst-gebaute EVE SDE (eve-sde sync) und kopiert sie ins Backend
+	@echo "[make sde] Aktualisiere selbst-gebaute SDE via eve-sde sync (versionsgeprüft)..."
+	@$(MAKE) -C $(EVE_SDE_DIR) sync
+	@mkdir -p $(dir $(SDE_TARGET))
+	@cp $(SDE_SOURCE) $(SDE_TARGET)
+	@echo "[make sde] ✅ Aktuelle SDE bereitgestellt: $(SDE_TARGET)"
 
-docker-up: ## Startet alle Services (PostgreSQL, Redis, Backend)
-	@echo "[make docker-up] Starte Docker Compose Services..."
-	@$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) up -d
+docker-up: sde ## Startet alle Services mit aktuellem Code (Image-Rebuild) und aktueller SDE
+	@echo "[make docker-up] Starte Docker Compose Services (mit Image-Rebuild)..."
+	@$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) up -d --build
 	@echo "[make docker-up] ✅ Services gestartet"
 	@echo ""
 	@echo "Services verfügbar unter:"
@@ -385,10 +391,6 @@ docker-clean: ## Entfernt alle Container, Volumes und Images
 	@echo "[make docker-clean] Räume Docker Ressourcen auf..."
 	@$(DOCKER_COMPOSE) -f $(COMPOSE_FILE) down -v --rmi all
 	@echo "[make docker-clean] ✅ Cleanup abgeschlossen"
-
-docker-restart: docker-down docker-up ## Neustart aller Services (ohne Rebuild)
-
-docker-rebuild: docker-down docker-build docker-up ## Kompletter Rebuild: Down → Build → Up
 
 docker-shell-api: ## Shell im Backend Container
 	@docker exec -it eve-o-provit-api /bin/sh

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -123,8 +123,10 @@ curl http://localhost:9001/health
 
 ### Rebuild nach Code-Änderungen
 
+`make docker-up` baut geänderte Images automatisch neu (und stellt die aktuelle SDE bereit):
+
 ```bash
-make docker-restart
+make docker-up
 ```
 
 ### Database Shell
@@ -276,13 +278,13 @@ Alle Services laufen im gleichen Docker Network `eve-network`:
 
 | Target | Beschreibung |
 |--------|--------------|
-| `make docker-up` | Startet alle Services |
+| `make docker-up` | Startet alle Services (Image-Rebuild + aktuelle SDE) |
 | `make docker-down` | Stoppt alle Services |
+| `make sde` | Aktualisiert die selbst-gebaute EVE SDE (eve-sde sync) |
 | `make docker-logs` | Zeigt Logs (SERVICE=name für einzelnen) |
 | `make docker-ps` | Status aller Container |
-| `make docker-build` | Rebuild alle Images |
+| `make docker-build` | Rebuild aller Images (--no-cache) |
 | `make docker-clean` | Entfernt Container + Volumes + Images |
-| `make docker-restart` | Down → Up |
 | `make docker-shell-api` | Shell im Backend Container |
 | `make docker-shell-db` | PostgreSQL psql CLI |
 | `make docker-shell-redis` | Redis CLI |

--- a/docs/testing/e2e-quick-start.md
+++ b/docs/testing/e2e-quick-start.md
@@ -23,7 +23,7 @@
 3. **Docker Services starten:**
 
    ```bash
-   make docker-rebuild
+   make docker-up
    ```
 
 ## Tests ausführen
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: make docker-rebuild
+      - run: make docker-up
       - run: make fe-install
       - run: make test-e2e
         env:
@@ -243,7 +243,7 @@ jobs:
 ```bash
 make docker-ps       # Status prüfen
 make docker-logs     # Logs anschauen
-make docker-restart  # Neustart
+make docker-up       # Neustart (mit Image-Rebuild + aktueller SDE)
 ```
 
 ### Playwright Browser fehlt

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -8,7 +8,7 @@ End-to-End Tests für EVE-O-Provit Frontend mit echtem EVE SSO OAuth Flow.
 
    ```bash
    cd /home/ix/vscode/eve-o-provit
-   make docker-rebuild
+   make docker-up
    ```
 
 2. **EVE Test Account Credentials:**
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: make docker-rebuild
+      - run: make docker-up
       - run: cd frontend && npm ci
       - run: cd frontend && npx playwright install --with-deps chromium
       - run: cd frontend && npm run test:e2e


### PR DESCRIPTION
## Summary

- **`make sde`** (neu): baut/aktualisiert die **selbst-gebaute** EVE SDE über `eve-sde`s versionsgeprüftes `sync` (billig wenn aktuell, Rebuild bei neuer CCP-Version) und kopiert sie nach `backend/data/sde/eve-sde.db`.
- **`make docker-up`**: hängt jetzt von `sde` ab und nutzt `up -d --build` → bei Code-Änderungen werden Images automatisch neu gebaut (Layer-Cache, schnell wenn unverändert); es läuft immer die aktuelle selbst-gebaute SDE.
- **Entfernt (obsolet):** `db-load` (lud die *fremde* GitHub-Release-SDE), `docker-restart` (Neustart ohne Rebuild — widerspricht der Policy), `docker-rebuild` (durch `docker-up` abgedeckt). `docker-build` (`--no-cache`) bleibt als expliziter Clean-Rebuild.
- Docs aktualisiert: `frontend/tests/README.md`, `deployments/README.md`, `docs/testing/e2e-quick-start.md`.

Hintergrund: Stellt sicher, dass lokal/CI immer der aktuelle Code **und** die selbst-gebaute SDE genutzt werden. Beim ersten Lauf deckte das prompt einen `eve-sde`-Bug mit der neuen Mai-2026-SDE auf (Sternrassler/eve-sde#8).

## Test Plan

- [x] `make help` zeigt `sde` unter Docker & Compose; entfernte Targets weg
- [x] `make docker-up` startet alle Services healthy (api/frontend/postgres/redis), Backend nutzt die aktuelle SDE (Build 3351823)
- [x] Keine verwaisten Referenzen auf entfernte Targets außerhalb `docs/archive/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)