### PR TITLE
fix: serve /version from CHANGELOG-derived build version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - SemVer-Quelle ist jetzt ausschließlich `CHANGELOG.md` + git-Tags. `release-check`/`release` lesen die Version aus dem CHANGELOG.
+- `/api/v1/version` liefert nicht mehr hardcoded `0.1.0`, sondern die zur Build-Zeit injizierte Version (`internal/version.Version` via `-ldflags`). `APP_VERSION` wird im Makefile aus dem obersten veröffentlichten CHANGELOG-Eintrag abgeleitet und über den Docker-Build-Arg an das Backend gereicht; Fallback `dev` für lokale Builds.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ MIGRATIONS_DIR ?= $(BACKEND_DIR)/migrations
 EVE_SDE_DIR ?= ../eve-sde
 SDE_SOURCE := $(EVE_SDE_DIR)/data/sqlite/eve-sde.db
 SDE_TARGET := $(BACKEND_DIR)/data/sde/eve-sde.db
+# API-Version: oberster veröffentlichter CHANGELOG-Eintrag (SemVer-Single-Source-of-Truth),
+# wird in den Backend-Build injiziert (siehe backend/Dockerfile ARG APP_VERSION).
+APP_VERSION ?= $(shell grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+export APP_VERSION
 
 .DEFAULT_GOAL := help
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,8 +13,12 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build binary
-RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o api ./cmd/api
+# Build binary. APP_VERSION is the top released CHANGELOG version (SemVer source
+# of truth), injected into internal/version; defaults to "dev" for plain builds.
+ARG APP_VERSION=dev
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
+	-ldflags "-X github.com/Sternrassler/eve-o-provit/backend/internal/version.Version=${APP_VERSION}" \
+	-o api ./cmd/api
 
 # Runtime stage
 FROM alpine:latest

--- a/backend/internal/handlers/base_handlers_test.go
+++ b/backend/internal/handlers/base_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Sternrassler/eve-o-provit/backend/internal/version"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -30,9 +31,9 @@ func TestVersion(t *testing.T) {
 		t.Fatalf("Failed to decode response: %v", err)
 	}
 
-	version, ok := response["version"].(string)
-	if !ok || version != "0.1.0" {
-		t.Errorf("Version = %v, want '0.1.0'", response["version"])
+	got, ok := response["version"].(string)
+	if !ok || got != version.Version {
+		t.Errorf("Version = %v, want %q", response["version"], version.Version)
 	}
 
 	service, ok := response["service"].(string)

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
 	_ "github.com/Sternrassler/eve-o-provit/backend/internal/models" // For OpenAPI
 	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/version"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
 	"github.com/gofiber/fiber/v2"
 )
@@ -113,7 +114,7 @@ func (h *Handler) Health(c *fiber.Ctx) error {
 // @Router /api/v1/version [get]
 func (h *Handler) Version(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
-		"version": "0.1.0",
+		"version": version.Version,
 		"service": "eve-o-provit-api",
 	})
 }

--- a/backend/internal/handlers/handlers_mock_test.go
+++ b/backend/internal/handlers/handlers_mock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
 	"github.com/Sternrassler/eve-o-provit/backend/internal/handlers"
 	"github.com/Sternrassler/eve-o-provit/backend/internal/testutil"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/version"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
@@ -89,7 +90,7 @@ func TestVersion_Success(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Contains(t, string(body), `"version":"0.1.0"`)
+	assert.Contains(t, string(body), `"version":"`+version.Version+`"`)
 	assert.Contains(t, string(body), `"service":"eve-o-provit-api"`)
 }
 

--- a/backend/internal/handlers/handlers_simple_test.go
+++ b/backend/internal/handlers/handlers_simple_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/version"
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,7 +29,7 @@ func TestVersion_Unit(t *testing.T) {
 	var result map[string]interface{}
 	err = parseJSON(resp.Body, &result)
 	assert.NoError(t, err)
-	assert.Equal(t, "0.1.0", result["version"])
+	assert.Equal(t, version.Version, result["version"])
 	assert.Equal(t, "eve-o-provit-api", result["service"])
 }
 

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,0 +1,7 @@
+// Package version exposes the application version.
+package version
+
+// Version is the API version reported by the /version endpoint. It is injected
+// at build time via -ldflags from the top released CHANGELOG.md entry (the
+// SemVer single source of truth); "dev" is the default for local builds.
+var Version = "dev"

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -44,6 +44,8 @@ services:
     build:
       context: ../backend
       dockerfile: Dockerfile
+      args:
+        APP_VERSION: ${APP_VERSION:-dev}
     container_name: eve-o-provit-api
     ports:
       - "9001:8080"


### PR DESCRIPTION
`/api/v1/version` returned a hardcoded `"0.1.0"` that had drifted from the CHANGELOG (`0.5.0`).

- New `internal/version.Version`, injected at build time via `-ldflags`.
- Makefile derives `APP_VERSION` from the top released CHANGELOG entry (SemVer single source of truth) and passes it through the Docker build arg (`backend/Dockerfile` `ARG APP_VERSION`, `docker-compose.yml` build args).
- Local builds (`go run`) fall back to `"dev"`.
- Version tests assert against `version.Version` instead of a literal.

**Verified end-to-end:** rebuilt stack via `make docker-up` → `GET /api/v1/version` returns `{"version":"0.5.0"}`.

Note: pre-existing, unrelated unit-test failures in `internal/handlers` (market/regions/skills/routes panic) exist on `main` and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)