### PR TITLE
test: align handler tests with hardened auth + sanitized errors

### DIFF
--- a/backend/internal/handlers/character_test.go
+++ b/backend/internal/handlers/character_test.go
@@ -199,5 +199,4 @@ func TestCharacterHandler_GetCharacterSkills_ServiceError(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "Failed to fetch character skills", result["error"])
-	assert.NotNil(t, result["details"])
 }

--- a/backend/internal/handlers/handlers_market_staleness_test.go
+++ b/backend/internal/handlers/handlers_market_staleness_test.go
@@ -132,7 +132,6 @@ func TestGetMarketDataStaleness_InvalidRegion_Unit(t *testing.T) {
 	err = parseJSON(resp.Body, &result)
 	assert.NoError(t, err)
 	assert.Contains(t, result["error"], "invalid region ID")
-	assert.NotEmpty(t, result["details"]) // strconv.Atoi error details
 }
 
 // TestGetMarketDataStaleness_QueryError_Unit tests database query error

--- a/backend/internal/handlers/handlers_mock_test.go
+++ b/backend/internal/handlers/handlers_mock_test.go
@@ -66,7 +66,8 @@ func TestHealth_DatabaseUnhealthy(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"status":"unhealthy"`)
-	assert.Contains(t, string(body), "database connection lost")
+	// Handler returns a generic message; the raw DB error is logged, not leaked.
+	assert.Contains(t, string(body), "database unavailable")
 }
 
 func TestVersion_Success(t *testing.T) {
@@ -171,5 +172,6 @@ func TestGetType_NotFound(t *testing.T) {
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	assert.Contains(t, string(body), "type 99999 not found")
+	// Handler returns a generic message; the raw lookup error is logged, not leaked.
+	assert.Contains(t, string(body), "type not found")
 }

--- a/backend/internal/handlers/handlers_regions_test.go
+++ b/backend/internal/handlers/handlers_regions_test.go
@@ -119,7 +119,7 @@ func TestGetRegions_QueryError_Unit(t *testing.T) {
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	body := string(bodyBytes)
 	assert.Contains(t, body, "Failed to fetch regions")
-	assert.Contains(t, body, "database connection lost")
+	// The raw DB error is logged server-side, not leaked in the response body.
 }
 
 // TestGetRegions_NilQuerier_Unit tests handler with nil region querier

--- a/backend/internal/handlers/trading_calculate_routes_test.go
+++ b/backend/internal/handlers/trading_calculate_routes_test.go
@@ -36,9 +36,21 @@ func (m *MockRouteCalculator) CalculateWithFilters(ctx context.Context, req *mod
 	return m.Calculate(ctx, req.RegionID, req.ShipTypeID, req.CargoCapacity, nil, nil)
 }
 
+// setTradingAuth installs middleware that mimics AuthMiddleware by seeding the
+// character_id/access_token locals CalculateRoutes requires for authenticated
+// trading operations.
+func setTradingAuth(app *fiber.App) {
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("character_id", 12345)
+		c.Locals("access_token", "test-token")
+		return c.Next()
+	})
+}
+
 // TestCalculateRoutes_Success_Unit tests successful route calculation
 func TestCalculateRoutes_Success_Unit(t *testing.T) {
 	app := fiber.New()
+	setTradingAuth(app)
 
 	// Mock RouteCalculator
 	mockCalc := &MockRouteCalculator{
@@ -104,6 +116,7 @@ func TestCalculateRoutes_Success_Unit(t *testing.T) {
 // TestCalculateRoutes_WithCargoCapacity_Unit tests with custom cargo capacity
 func TestCalculateRoutes_WithCargoCapacity_Unit(t *testing.T) {
 	app := fiber.New()
+	setTradingAuth(app)
 
 	mockCalc := &MockRouteCalculator{
 		CalculateFunc: func(ctx context.Context, regionID, shipTypeID int, cargoCapacity float64, warpSpeed, alignTime *float64) (*models.RouteCalculationResponse, error) {
@@ -246,6 +259,7 @@ func TestCalculateRoutes_InvalidShipTypeID_Unit(t *testing.T) {
 // TestCalculateRoutes_CalculatorError_Unit tests calculator service error
 func TestCalculateRoutes_CalculatorError_Unit(t *testing.T) {
 	app := fiber.New()
+	setTradingAuth(app)
 
 	mockCalc := &MockRouteCalculator{
 		CalculateFunc: func(ctx context.Context, regionID, shipTypeID int, cargoCapacity float64, warpSpeed, alignTime *float64) (*models.RouteCalculationResponse, error) {
@@ -273,12 +287,13 @@ func TestCalculateRoutes_CalculatorError_Unit(t *testing.T) {
 	err = parseJSON(resp.Body, &result)
 	assert.NoError(t, err)
 	assert.Equal(t, "Failed to calculate routes", result["error"])
-	assert.Contains(t, result["details"], "failed to fetch market orders")
+	// Internal error detail is logged server-side, not leaked in the response.
 }
 
 // TestCalculateRoutes_PartialResults_Unit tests timeout warning with partial results
 func TestCalculateRoutes_PartialResults_Unit(t *testing.T) {
 	app := fiber.New()
+	setTradingAuth(app)
 
 	mockCalc := &MockRouteCalculator{
 		CalculateFunc: func(ctx context.Context, regionID, shipTypeID int, cargoCapacity float64, warpSpeed, alignTime *float64) (*models.RouteCalculationResponse, error) {
@@ -327,6 +342,7 @@ func TestCalculateRoutes_PartialResults_Unit(t *testing.T) {
 // TestCalculateRoutes_EmptyRoutes_Unit tests successful calculation with no profitable routes
 func TestCalculateRoutes_EmptyRoutes_Unit(t *testing.T) {
 	app := fiber.New()
+	setTradingAuth(app)
 
 	mockCalc := &MockRouteCalculator{
 		CalculateFunc: func(ctx context.Context, regionID, shipTypeID int, cargoCapacity float64, warpSpeed, alignTime *float64) (*models.RouteCalculationResponse, error) {


### PR DESCRIPTION
The `internal/handlers` unit tests asserted pre-remediation behavior and failed. A panic in `TestCalculateRoutes_Success_Unit` (index-out-of-range on an empty routes slice after an unexpected 401) masked several of them.

**Root cause:** the security remediation hardened the handlers (auth required on trading; no raw errors or `details` leaked in responses), but the tests were never updated. The handlers are correct — the tests were stale.

Changes (test-only):
- `setTradingAuth` helper seeds `character_id`/`access_token` locals for the 5 valid-input `CalculateRoutes` tests (Success, WithCargoCapacity, CalculatorError, PartialResults, EmptyRoutes).
- Drop stale `details` assertions (character skills, market staleness, calculator error).
- Drop stale raw-error-leak assertions (regions `"database connection lost"`, health → now `"database unavailable"`, GetType → now `"type not found"`).

`go test ./internal/handlers/` is green; `go vet` and `gofmt` clean.

Out of scope (pre-existing, separate packages): `pkg/evedb/cargo` (`Nereus_Scenario4`), `pkg/evedb/navigation` (`GetEffectiveParams`), `internal/database` integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)