### PR TITLE
test: correct align-time expectation in navigation test

### DIFF
--- a/backend/pkg/evedb/navigation/navigation_test.go
+++ b/backend/pkg/evedb/navigation/navigation_test.go
@@ -116,7 +116,7 @@ func TestGetEffectiveParams(t *testing.T) {
 				InertiaModifier: ptrFloat64(0.4),
 			},
 			wantWarpSpeed:   DefaultWarpSpeed,
-			wantAlignTime:   13.3, // Approximate
+			wantAlignTime:   6.65, // ln(2) × 0.4 × 12_000_000 / 500_000 ≈ 6.65s
 			wantAvgWarpDist: DefaultAvgWarpDistance,
 			wantSource:      "calculated",
 		},


### PR DESCRIPTION
The `getEffectiveParams` "Calculated align time from ship params" case hardcoded `wantAlignTime: 13.3 // Approximate`, which never matched the actual formula output (~6.65).

**Root cause:** wrong hardcoded constant. EVE's align-to-75%-velocity time is `ln(4)·I·M / 1e6 = ln(2)·I·M / 500000`, used consistently by `CalculateAlignTime`, its dedicated `TestCalculateAlignTimeFormula`, and the inertia scenario tests — all green. For `I=0.4, M=12_000_000` that yields ~6.65s. The code is correct; only this expectation was wrong.

`go test ./pkg/evedb/navigation/` green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)