### PR TITLE
test: align market_orders test schema PK with real migration

### DIFF
--- a/backend/internal/database/testcontainer.go
+++ b/backend/internal/database/testcontainer.go
@@ -140,7 +140,7 @@ func (tc *TestPostgresContainer) CreateTestSchema(t *testing.T) {
 	// Create minimal schema for testing
 	schema := `
 		CREATE TABLE IF NOT EXISTS market_orders (
-			order_id BIGINT NOT NULL,
+			order_id BIGINT PRIMARY KEY,
 			type_id INTEGER NOT NULL,
 			region_id INTEGER NOT NULL,
 			location_id BIGINT NOT NULL,
@@ -151,8 +151,7 @@ func (tc *TestPostgresContainer) CreateTestSchema(t *testing.T) {
 			min_volume INTEGER,
 			issued_at TIMESTAMP NOT NULL,
 			duration INTEGER NOT NULL,
-			cached_at TIMESTAMP NOT NULL,
-			PRIMARY KEY (order_id, cached_at)
+			cached_at TIMESTAMP NOT NULL
 		);
 
 		CREATE INDEX IF NOT EXISTS idx_market_orders_region_type 
@@ -196,7 +195,7 @@ func (tc *TestPostgresContainer) SeedTestData(t *testing.T) {
 			(123456789, 34, 10000002, 60003760, false, 5.50, 1000, 500, 1, NOW() - INTERVAL '1 day', 90, NOW()),
 			(987654321, 34, 10000002, 60003760, true, 5.25, 5000, 5000, 10, NOW() - INTERVAL '2 days', 90, NOW()),
 			(111222333, 35, 10000002, 60003760, false, 10.00, 2000, 1500, 5, NOW() - INTERVAL '3 hours', 30, NOW())
-		ON CONFLICT (order_id, cached_at) DO NOTHING;
+		ON CONFLICT (order_id) DO NOTHING;
 	`
 
 	_, err := tc.Pool.Exec(ctx, seedSQL)


### PR DESCRIPTION
The `internal/database` integration tests (testcontainers) failed with `SQLSTATE 42P10` — "no unique or exclusion constraint matching the ON CONFLICT specification".

**Root cause:** the tests build their own schema via `CreateTestSchema`, which had drifted to a composite `PRIMARY KEY (order_id, cached_at)`. Production `UpsertMarketOrders` uses `ON CONFLICT (order_id)`, and the real migration declares `order_id BIGINT PRIMARY KEY` (single column). The composite test PK had no unique constraint on `order_id` alone, so the upsert couldn't resolve its conflict target. The `UpdateExisting` test also confirms single-PK upsert semantics are intended.

**Fix (test-only):** match the test schema to the migration (single-column `order_id` PK) and update `SeedTestData`'s `ON CONFLICT` accordingly. Production schema and query were already correct — this was test-schema drift.

Full backend suite green, including testcontainer integration tests. `go vet` + `gofmt` clean.

Follow-up worth considering: have the integration tests apply the real `migrations/` instead of a hand-maintained `CreateTestSchema` to prevent future drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)