### PR TITLE
test: deflake authenticated trading E2E workflow

### DIFF
--- a/frontend/tests/e2e/auth/trading-authed.spec.ts
+++ b/frontend/tests/e2e/auth/trading-authed.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Locator } from '@playwright/test';
 import { mockWaypoint } from '../helpers/waypoint-mock';
 import { REGION_THE_FORGE } from '../helpers/constants';
 
@@ -21,8 +21,34 @@ async function selectRegion(page: Page, optionRe: RegExp) {
   await page.getByRole('option', { name: optionRe }).first().click();
 }
 
+// Click "Berechnen" and return the route count, tolerating a cold-cache miss:
+// the first heavy calculation right after a fresh ~890k-order market refresh can
+// hit the backend's calculation-timeout and return zero (partial) routes with a
+// warning. That is a transient, not a regression — re-run the calculation a
+// bounded number of times until The Forge yields its reliably-present routes.
+// Returns 0 if every attempt comes back empty (a genuine regression then fails
+// the caller's `> 0` assertion).
+async function calculateRoutes(page: Page, calc: Locator, counter: Locator, attempts = 3): Promise<number> {
+  const empty = page.getByText(/Keine Routen gefunden/i);
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    await expect(calc).toBeEnabled({ timeout: 30000 });
+    await calc.click();
+    // The calculation resolves to either the route counter or the empty state.
+    await expect(counter.or(empty).first()).toBeVisible({ timeout: 45000 });
+    if (await counter.isVisible()) return countFromText(await counter.textContent());
+  }
+  return 0;
+}
+
 test.describe('Authenticated trading workflow', () => {
   test('calculate, inspect, set waypoint (mocked), filter, paginate', async ({ page }) => {
+    // Legitimately slow: this single workflow runs a live market refresh plus two
+    // heavy route calculations against The Forge sequentially, each with its own
+    // calculate-retry budget (see calculateRoutes). Raise the wall-clock envelope
+    // well past the 60s default so the cumulative live work fits; per-step timeouts
+    // below still catch a genuinely hung operation.
+    test.setTimeout(240_000);
+
     const waypoint = mockWaypoint(page);
     await page.goto('/trading');
     await expect(page.locator('h1')).toContainText('Trading');
@@ -50,15 +76,11 @@ test.describe('Authenticated trading workflow', () => {
     await refresh.click();
     await expect(refresh).toBeEnabled({ timeout: 30000 });
 
-    // Calculate routes.
-    await expect(calc).toBeEnabled({ timeout: 30000 });
-    await calc.click();
-
-    // The Forge reliably has profitable routes — require them (an empty result
-    // here signals a regression rather than a tolerable data gap).
+    // Calculate routes. The Forge reliably has profitable routes — require them
+    // (an empty result after the bounded retries signals a regression, not a
+    // tolerable data gap).
     const counter = page.getByText(/\d+ Routen gefunden/);
-    await expect(counter).toBeVisible({ timeout: 45000 });
-    const total = countFromText(await counter.textContent());
+    const total = await calculateRoutes(page, calc, counter);
     expect(total).toBeGreaterThan(0);
 
     // Authenticated: the "Route in EVE setzen" action is enabled. Clicking fires
@@ -72,9 +94,7 @@ test.describe('Authenticated trading workflow', () => {
     // Filter effect: widening allowed security zones cannot reduce the count.
     await page.getByRole('checkbox', { name: /Low Sec/i }).check();
     await page.getByRole('checkbox', { name: /Null Sec/i }).check();
-    await calc.click();
-    await expect(counter).toBeVisible({ timeout: 45000 });
-    const widened = countFromText(await counter.textContent());
+    const widened = await calculateRoutes(page, calc, counter);
     expect(widened).toBeGreaterThanOrEqual(total);
 
     // Pagination: "Mehr anzeigen" reveals more route cards when present.


### PR DESCRIPTION
The `trading-authed` E2E test was flaky for two distinct reasons, both diagnosed against the live stack:

1. **Wall-clock envelope.** The single workflow runs a market refresh plus two heavy The-Forge route calculations sequentially; their per-step timeouts (~30+30+45+45s) sum well past the default 60s test cap, so a slow-but-correct backend tripped the *test* timeout (not a step timeout). Raised to `test.setTimeout(240_000)`; per-step timeouts are unchanged so a genuinely hung step still fails fast.

2. **Cold-cache empty result.** The first calculation right after a fresh ~890k-order refresh occasionally hits the backend's calculation-timeout (`route_service.go`) and returns zero (partial) routes + a warning — a transient, not a regression. Added a bounded `calculateRoutes()` helper that re-runs the calculation until The Forge yields routes; it returns 0 (failing the caller's `> 0` assertion) if every attempt comes back empty, so real regressions are still caught.

**Verification:** green across repeated local runs (single + `--repeat-each=2`) against the live stack. Note: deterministic proof of a de-flake against a live backend isn't possible; a `--repeat-each=3` burst failed once (3 heavy live workflows back-to-back overloaded the single backend — harsher than CI, which runs the test once with `retries: 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)