### PR TITLE
feat(app): move logout into bottom navigation bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ frontend/node_modules/
 # Docker
 .dockerignore
 
+
+# Superpowers brainstorming visual companion (local, not committed)
+.superpowers/

--- a/app/lib/core/router.dart
+++ b/app/lib/core/router.dart
@@ -104,12 +104,15 @@ final goRouterProvider = Provider<GoRouter>((ref) {
 // Navigation shell — bottom NavigationBar
 // ---------------------------------------------------------------------------
 
-class _AppShell extends StatelessWidget {
+class _AppShell extends ConsumerWidget {
   const _AppShell({required this.location, required this.child});
 
   final String location;
   final Widget child;
 
+  // Trading + Character are real routes; "Abmelden" is an action (it opens a
+  // confirm dialog instead of navigating), kept here so logout lives next to
+  // the primary navigation rather than hidden in a screen's AppBar.
   static const _destinations = [
     NavigationDestination(
       icon: Icon(Icons.currency_exchange_rounded),
@@ -120,15 +123,19 @@ class _AppShell extends StatelessWidget {
       selectedIcon: Icon(Icons.person_rounded),
       label: 'Character',
     ),
+    NavigationDestination(
+      icon: Icon(Icons.logout_rounded),
+      label: 'Abmelden',
+    ),
   ];
 
   int get _selectedIndex {
     if (location.startsWith('/character')) return 1;
-    return 0; // /trading is default
+    return 0; // /trading is default; "Abmelden" is never a selected state
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       body: child,
       bottomNavigationBar: NavigationBar(
@@ -139,10 +146,37 @@ class _AppShell extends StatelessWidget {
               context.go('/trading');
             case 1:
               context.go('/character');
+            case 2:
+              _confirmLogout(context, ref);
           }
         },
         destinations: _destinations,
       ),
     );
+  }
+
+  Future<void> _confirmLogout(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Abmelden?'),
+        content: const Text(
+          'Du wirst von EVE-O Provit abgemeldet und musst dich erneut anmelden.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Abbrechen'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Abmelden'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed ?? false) {
+      await ref.read(authControllerProvider.notifier).logout();
+    }
   }
 }

--- a/app/lib/features/character/character_screen.dart
+++ b/app/lib/features/character/character_screen.dart
@@ -7,7 +7,6 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../auth/auth_controller.dart';
 import 'character_models.dart';
 import 'providers.dart';
 
@@ -32,13 +31,6 @@ class CharacterScreen extends ConsumerWidget {
         centerTitle: false,
         elevation: 0,
         scrolledUnderElevation: 1,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.logout_rounded),
-            tooltip: 'Abmelden',
-            onPressed: () => _confirmLogout(context, ref),
-          ),
-        ],
       ),
       body: characterAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
@@ -46,31 +38,6 @@ class CharacterScreen extends ConsumerWidget {
         data: (character) => _CharacterContent(character: character),
       ),
     );
-  }
-
-  Future<void> _confirmLogout(BuildContext context, WidgetRef ref) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Abmelden?'),
-        content: const Text(
-          'Du wirst von EVE-O Provit abgemeldet und musst dich erneut anmelden.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('Abbrechen'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('Abmelden'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed ?? false) {
-      await ref.read(authControllerProvider.notifier).logout();
-    }
   }
 }
 

--- a/app/test/e2e/app_flow_test.dart
+++ b/app/test/e2e/app_flow_test.dart
@@ -292,4 +292,76 @@ void main() {
       expect(find.text('My Badger'), findsOneWidget);
     });
   });
+
+  // ── 7. Logout flow ──────────────────────────────────────────────────────────
+
+  group('Logout flow', () {
+    // The logout "Abmelden" destination lives in the bottom NavigationBar next
+    // to Trading/Character (not hidden in a screen AppBar). Tapping it opens a
+    // confirm dialog; it is an action, not a navigation target.
+
+    testWidgets(
+        'Tapping "Abmelden" opens the confirm dialog without changing the tab',
+        (tester) async {
+      _setViewSize(tester, 1280, 800);
+
+      await _pumpApp(tester, authenticatedOverrides());
+
+      // Starts on Trading.
+      expect(find.text('Trading'), findsWidgets);
+
+      // Tap the bottom-bar "Abmelden" destination (only the nav label so far).
+      await tester.tap(find.text('Abmelden'));
+      await tester.pumpAndSettle();
+
+      // Confirm dialog appears; still authenticated (login button absent).
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(find.text('Abmelden?'), findsOneWidget);
+      expect(find.text('Login mit EVE'), findsNothing);
+    });
+
+    testWidgets(
+        'Confirming logout clears the session and redirects to LoginScreen',
+        (tester) async {
+      _setViewSize(tester, 1280, 800);
+
+      await _pumpApp(tester, authenticatedOverrides());
+
+      await tester.tap(find.text('Abmelden'));
+      await tester.pumpAndSettle();
+
+      // Tap the dialog's "Abmelden" confirm button (disambiguated from the
+      // nav-bar label by scoping to the AlertDialog).
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('Abmelden'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Auth state → Unauthenticated → router redirects to the login screen.
+      expect(find.text('Login mit EVE'), findsOneWidget);
+      expect(find.byType(TradingScreen), findsNothing);
+    });
+
+    testWidgets(
+        'Cancelling the dialog keeps the user logged in on Trading',
+        (tester) async {
+      _setViewSize(tester, 1280, 800);
+
+      await _pumpApp(tester, authenticatedOverrides());
+
+      await tester.tap(find.text('Abmelden'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Abbrechen'));
+      await tester.pumpAndSettle();
+
+      // Dialog dismissed, still authenticated and on the trading screen.
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(find.byType(TradingScreen), findsOneWidget);
+      expect(find.text('Login mit EVE'), findsNothing);
+    });
+  });
 }

--- a/app/test/e2e/support/fakes.dart
+++ b/app/test/e2e/support/fakes.dart
@@ -262,6 +262,14 @@ class FakeAuthControllerAuthenticated extends AuthController {
   @override
   Future<AuthState> build() async =>
       const Authenticated(character: fakeCharacter);
+
+  /// Mirrors the real controller's end state without touching the
+  /// [AuthRepository] / [TokenStore] (whose `clear()` calls the
+  /// flutter_secure_storage platform plugin, unavailable under `flutter test`).
+  @override
+  Future<void> logout() async {
+    state = const AsyncData(Unauthenticated());
+  }
 }
 
 /// Always returns [Unauthenticated].


### PR DESCRIPTION
## Was

Logout war ein icon-only Button, versteckt in der `CharacterScreen`-AppBar — schwer auffindbar. Er wandert jetzt als dritter Eintrag **„Abmelden"** in die untere `NavigationBar` neben Trading/Character. Tippen öffnet den Bestätigungsdialog und meldet ab, ohne den aktiven Tab zu wechseln (Aktion, kein Navigationsziel).

## Änderungen

- `app/lib/core/router.dart` — `_AppShell` → `ConsumerWidget`; dritter NavigationBar-Eintrag „Abmelden" (`Icons.logout_rounded`); Logout-Bestätigungsdialog hierher verschoben.
- `app/lib/features/character/character_screen.dart` — Logout-IconButton + `_confirmLogout` aus der AppBar entfernt, ungenutzter Import bereinigt.
- `app/test/e2e/support/fakes.dart` — `logout()`-Override im Fake-Controller (vermeidet `flutter_secure_storage`-Plattformaufruf unter `flutter test`).
- `app/test/e2e/app_flow_test.dart` — neue Gruppe **„Logout flow"**: Dialog öffnet ohne Tab-Wechsel · Bestätigen → Redirect zum LoginScreen · Abbrechen → bleibt eingeloggt.

## Verifiziert

- ✅ `flutter analyze` — keine Issues
- ✅ `flutter test test/e2e/` — **16/16 grün** (13 bestehende + 3 neue)
- ✅ Live auf physischem Tablet (SM X236B) bestätigt — Session blieb erhalten

🤖 Generated with [Claude Code](https://claude.com/claude-code)