### PR TITLE
docs(deploy): add Hetzner production deploy runbook

### DIFF
--- a/deployments/.env.example
+++ b/deployments/.env.example
@@ -1,0 +1,37 @@
+# Production env-file template for eve-o-provit-api on the Hetzner backend host.
+#
+# The live file lives ONLY on the server at /opt/apps/env/eve-o-provit.env (mode 600,
+# owner root) and is loaded by the shared apps compose via env_file. Secrets are NEVER
+# committed — master copy in KeePass. This template documents the shape with real public
+# values and placeholders for secrets. See deployments/HETZNER-DEPLOY.md.
+#
+# (For LOCAL development use deployments/.env instead — different callback/CORS, COOKIE_SECURE=false.)
+
+# --- EVE SSO (production application "EVE Profit Maximirer (prod)") ---
+# Client ID is public (PKCE / public client — no client_secret used by the backend).
+# The callback below MUST be registered in the EVE application's Callback URL list.
+EVE_CLIENT_ID=4d0514c205af4e898b0569badd59a38e
+EVE_CALLBACK_URL=https://eveonline.sternrassler.de/callback
+
+# Optional: enable native (Flutter) mobile auth against this backend by setting the
+# mobile application's client_id. Leave unset to disable /auth/mobile/* endpoints.
+#EVE_MOBILE_CLIENT_ID=
+#EVE_MOBILE_REDIRECT_URI=eveauth-eveoprovit://callback
+
+# --- Datastores (secrets — generate per environment, keep in KeePass) ---
+# POSTGRES_PASSWORD must match the password embedded in DATABASE_URL (env_file does not
+# cross-interpolate). Same for REDIS_PASSWORD / REDIS_URL. Hosts are the compose service
+# names on the shared `apps` network.
+POSTGRES_PASSWORD=<generate: openssl rand -hex 24>
+REDIS_PASSWORD=<generate: openssl rand -hex 24>
+DATABASE_URL=postgres://eveprovit:<POSTGRES_PASSWORD>@eve-o-provit-postgres:5432/eveprovit?sslmode=disable
+REDIS_URL=redis://:<REDIS_PASSWORD>@eve-o-provit-redis:6379/0
+
+# --- HTTP ---
+CORS_ORIGINS=https://eveonline.sternrassler.de
+ESI_USER_AGENT=eve-o-provit/0.1.0 (sternrassler@gmail.com)
+
+# COOKIE_SECURE is intentionally NOT set → defaults to true (fail-closed) over HTTPS.
+# Only set COOKIE_SECURE=false for local HTTP development.
+
+# Note: PORT and SDE_PATH are set by the compose service (environment:), not here.

--- a/deployments/HETZNER-DEPLOY.md
+++ b/deployments/HETZNER-DEPLOY.md
@@ -1,0 +1,116 @@
+# eve-o-provit Backend — Hetzner Production Deploy Runbook
+
+Onboards the **backend** onto the shared `backend` host (cx23, 46.225.188.34) behind
+`edge-caddy`, per the [edge-caddy single-edge ADR](https://github.com/Sternrassler/brain/blob/main/docs/superpowers/specs/2026-05-20-adr-edge-caddy-single-entry.md).
+
+- **Domain:** `eveonline.sternrassler.de` (DNS A/AAAA already registered)
+- **App key (deploy-app.sh / apps-config):** `eveoprovit` (no hyphens — `EVEOPROVIT_TAG`)
+- **Containers:** `eve-o-provit-api`, `eve-o-provit-postgres`, `eve-o-provit-redis`
+- **Image:** `ghcr.io/sternrassler/eve-o-provit-backend:<sha>`
+- **Validated locally:** image builds (CGO/sqlite, linux/amd64); full stack boots with
+  `/api/v1/health` → `{postgres:ok, sde:ok}` and real SDE region data.
+
+## Why this app is special
+
+Unlike the other portfolio apps (SQLite-only), eve-o-provit hard-requires **Postgres**
+(`DATABASE_URL`, market data) + **Redis** (ESI cache) + a **~474 MB SDE SQLite** mounted
+read-only. Postgres/Redis are scoped to this app inside the shared `apps` compose;
+`deploy-app.sh eveoprovit` recreates **only** the api, never the DB.
+
+## Prerequisites (one-time, need operator)
+
+1. **GHCR push credentials** — GitHub PAT with `write:packages`.
+2. **SSH access** to `root@46.225.188.34` (keys `ix-local` / `mac-local`).
+3. **Hetzner infra repo** branch `feat/onboard-eve-o-provit` merged to `main` →
+   CD scps `compose.yaml` + `Caddyfile` + `deploy-app.sh` to `/opt/apps/` and reloads Caddy.
+
+## Step 1 — Build & push image
+
+```sh
+cd eve-o-provit/backend
+TAG="sha-$(git rev-parse --short HEAD)"
+docker build -t ghcr.io/sternrassler/eve-o-provit-backend:$TAG \
+             --build-arg APP_VERSION=$TAG .
+echo "$GHCR_PAT" | docker login ghcr.io -u Sternrassler --password-stdin
+docker push ghcr.io/sternrassler/eve-o-provit-backend:$TAG
+```
+
+## Step 2 — Merge hetzner infra branch
+
+Merge `feat/onboard-eve-o-provit` (in `~/vscode/hetzner`) to `main`. CD syncs the new
+compose services + Caddy block to the server. (Caddy reload provisions the TLS cert for
+`eveonline.sternrassler.de` on first request.)
+
+## Step 3 — Provision secrets on server
+
+Create `/opt/apps/env/eve-o-provit.env` (mode 600, root). Store the master copy in KeePass.
+
+```sh
+ssh root@46.225.188.34 'umask 077; cat > /opt/apps/env/eve-o-provit.env' <<'EOF'
+EVE_CLIENT_ID=0828b4bcd20242aeb9b8be10f5451094
+POSTGRES_PASSWORD=<generate: openssl rand -hex 24>
+REDIS_PASSWORD=<generate: openssl rand -hex 24>
+DATABASE_URL=postgres://eveprovit:<POSTGRES_PASSWORD>@eve-o-provit-postgres:5432/eveprovit?sslmode=disable
+REDIS_URL=redis://:<REDIS_PASSWORD>@eve-o-provit-redis:6379/0
+CORS_ORIGINS=https://eveonline.sternrassler.de
+EVE_CALLBACK_URL=https://eveonline.sternrassler.de/callback
+ESI_USER_AGENT=eve-o-provit/0.1.0 (sternrassler@gmail.com)
+# COOKIE_SECURE intentionally unset → defaults to true (fail-closed) over HTTPS.
+EOF
+```
+
+> `POSTGRES_PASSWORD` and the password embedded in `DATABASE_URL` must match (env_file does
+> not cross-interpolate). Same for `REDIS_PASSWORD` / `REDIS_URL`.
+
+Register the `EVEOPROVIT_TAG` line so `deploy-app.sh`'s `sed` can update it:
+
+```sh
+ssh root@46.225.188.34 "grep -q '^EVEOPROVIT_TAG=' /opt/apps/.env || echo 'EVEOPROVIT_TAG=$TAG' >> /opt/apps/.env"
+```
+
+## Step 4 — Seed the SDE into its volume
+
+```sh
+docker --context ... volume create apps_eve_o_provit_sde   # or let compose create it
+# copy the 474MB SDE from local repo into the named volume
+scp eve-o-provit/backend/data/sde/eve-sde.db root@46.225.188.34:/tmp/eve-sde.db
+ssh root@46.225.188.34 'docker run --rm -v apps_eve_o_provit_sde:/dst -v /tmp/eve-sde.db:/src.db:ro \
+    alpine sh -c "cp /src.db /dst/eve-sde.db" && rm -f /tmp/eve-sde.db'
+```
+
+## Step 5 — First deploy (manual) + schema
+
+```sh
+ssh root@46.225.188.34 'cd /opt/apps && docker compose up -d \
+    eve-o-provit-postgres eve-o-provit-redis eve-o-provit-api'
+```
+
+Apply the Postgres schema (idempotent, `CREATE … IF NOT EXISTS`). Copy `init-db/01-init.sql`
+to the server, then:
+
+```sh
+ssh root@46.225.188.34 'docker compose -f /opt/apps/compose.yaml exec -T eve-o-provit-postgres \
+    psql -U eveprovit -d eveprovit' < deployments/init-db/01-init.sql
+ssh root@46.225.188.34 'cd /opt/apps && docker compose restart eve-o-provit-api'
+```
+
+## Step 6 — Verify
+
+```sh
+ssh root@46.225.188.34 'curl -fsS http://localhost:8080/api/v1/health'      # in-container? use service net
+curl -fsS https://eveonline.sternrassler.de/api/v1/health   # → {"status":"ok",...}
+curl -fsS https://eveonline.sternrassler.de/api/v1/version
+curl -fsS 'https://eveonline.sternrassler.de/api/v1/sde/regions' | head -c 300
+```
+
+## Follow-ups (not done here)
+
+- **Backup:** `apps-backup.sh` is SQLite-`.backup`-based and would corrupt a live Postgres
+  data dir. eve-o-provit needs a **`pg_dump`** path before it joins the nightly backup.
+  Currently only health monitoring is wired (`apps-config.sh`).
+- **CD:** No `deploy.yml`/release workflow exists in this repo yet. First deploy is manual
+  (per convention); add CI build+push + `deploy-app.sh eveoprovit` trigger afterwards.
+- **RAM:** `backend` host is 4 GB and already runs 6 containers. Watch memory after adding
+  Postgres + Redis + the api.
+- **SSO login round-trip** needs the frontend (callback page) at the domain; backend-only
+  deploy serves health/SDE/market/public endpoints. Full login is out of scope here.

--- a/deployments/HETZNER-DEPLOY.md
+++ b/deployments/HETZNER-DEPLOY.md
@@ -45,9 +45,13 @@ compose services + Caddy block to the server. (Caddy reload provisions the TLS c
 
 Create `/opt/apps/env/eve-o-provit.env` (mode 600, root). Store the master copy in KeePass.
 
+Use [`.env.example`](.env.example) as the template. Production uses the dedicated EVE
+application "EVE Profit Maximirer (prod)" (client_id `4d0514c205af4e898b0569badd59a38e`),
+with `https://eveonline.sternrassler.de/callback` registered in its Callback URL list.
+
 ```sh
 ssh root@46.225.188.34 'umask 077; cat > /opt/apps/env/eve-o-provit.env' <<'EOF'
-EVE_CLIENT_ID=0828b4bcd20242aeb9b8be10f5451094
+EVE_CLIENT_ID=4d0514c205af4e898b0569badd59a38e
 POSTGRES_PASSWORD=<generate: openssl rand -hex 24>
 REDIS_PASSWORD=<generate: openssl rand -hex 24>
 DATABASE_URL=postgres://eveprovit:<POSTGRES_PASSWORD>@eve-o-provit-postgres:5432/eveprovit?sslmode=disable


### PR DESCRIPTION
Adds `deployments/HETZNER-DEPLOY.md` — the runbook for the production deploy that just went live.

The backend is now running at **https://eveonline.sternrassler.de** behind `edge-caddy` on the shared `backend` host, image `ghcr.io/sternrassler/eve-o-provit-backend:sha-5fbadd3`, with scoped Postgres+Redis and the SDE mounted read-only. Smoke-tested: `/api/v1/health` 200 `{postgres:ok,sde:ok}`, valid TLS, SDE/market/auth endpoints verified.

Infra changes live in `Sternrassler/hetzner` PR #47 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)