### PR TITLE
test: gate testcontainers behind integration tag; vuln gate blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           go-version: "1.26"
           cache-dependency-path: backend/go.sum
-      # Docker-free unit lane: -tags=unit drops the `!unit` integration files,
-      # -short makes the remaining testcontainers-based tests skip.
-      # Full integration suite runs separately via `make test-be-int`.
+      # Docker-free unit lane: integration tests (testcontainers/docker) are gated behind
+      # the `integration` build tag, so the default test set needs no Docker.
+      # Full integration suite runs separately via `make test-be-int` (-tags=integration).
       - name: Unit tests with coverage
         run: go test -race -short -tags=unit -coverprofile=cover.out ./...
       - name: Coverage summary
@@ -53,10 +53,8 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
-      # Report-only: fixable findings are kept current (Go 1.26 stdlib, x/crypto v0.52.0,
-      # fiber v2.52.12). The only remaining advisory is github.com/docker/docker (GO-2026-4883/4887,
-      # "Fixed in: N/A") pulled in by testcontainers — test-path only, not reachable from cmd/api.
-      # continue-on-error keeps the check green while still surfacing new advisories.
+      # Blocking: testcontainers/docker are gated behind the `integration` build tag, so the
+      # default build graph that govulncheck analyzes has no test-only deps. With Go 1.26 +
+      # current deps (x/crypto, fiber) the gate is expected clean; a new advisory fails CI.
       - name: Scan
-        continue-on-error: true
         run: govulncheck ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Gate all testcontainers-based tests + the `testcontainer.go` helper behind the `integration` build tag (previously a mix of `integration || !unit` and untagged). The default build graph no longer pulls in `github.com/docker/docker`, so `govulncheck` is now a **blocking** CI gate. No change to the production binary.
+
 ## [0.8.0] - 2026-05-27
 
 ### Security

--- a/backend/internal/database/market_integration_test.go
+++ b/backend/internal/database/market_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration || !unit
+//go:build integration
 
 package database
 

--- a/backend/internal/database/market_test.go
+++ b/backend/internal/database/market_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package database
 
 import (

--- a/backend/internal/database/migrations_test.go
+++ b/backend/internal/database/migrations_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package database
 
 import (

--- a/backend/internal/database/testcontainer.go
+++ b/backend/internal/database/testcontainer.go
@@ -1,5 +1,5 @@
 // Package database - Testcontainer utilities for integration tests
-//go:build integration || !unit
+//go:build integration
 
 package database
 

--- a/backend/internal/handlers/handlers_integration_test.go
+++ b/backend/internal/handlers/handlers_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration || !unit
+//go:build integration
 
 package handlers
 


### PR DESCRIPTION
Removes the test-only `github.com/docker/docker` advisory (GO-2026-4883/4887, *Fixed in: N/A*) from the default build graph by gating all testcontainers usage behind `//go:build integration`, then flips `govulncheck` to a **blocking** CI gate.

- Tagged: `testcontainer.go`, `migrations_test.go`, `market_test.go`, `market_integration_test.go`, `handlers_integration_test.go` → `integration` (consistent with the already-`integration` cache/trading tests).
- Verified locally: default build, unit lane (`-short -tags=unit`), and integration compile (`-tags=integration`) all green; govulncheck no longer reports docker/fiber/x-crypto.
- No production binary change (testcontainer.go was never in `cmd/api`). Full integration suite still runs via `make test-be-int`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)