### PR TITLE
feat: Multi-Hub Comparison (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-Hub Comparison (#43):** `POST /api/v1/trading/hubs/compare` compares an item's station-trading profitability across the five major hubs (Jita, Amarr, Dodixie, Rens, Hek) — buy/sell/spread, skill-adjusted net margin (sales tax + broker fee via Accounting/Broker Relations/standings), volume and an order-update-frequency competition indicator. The competition indicator combines a live snapshot-churn metric (periodic background collector over lazily-tracked `(type, region)` pairs) with a daily `order_count` baseline fallback (`source: live|baseline`). New migration `000002_competition_tracking`. Hub price/ranking logic lives in a reusable `MultiHubComparisonService` (consumed later by #107).
+
 ### Changed
 
 - Gate all testcontainers-based tests + the `testcontainer.go` helper behind the `integration` build tag (previously a mix of `integration || !unit` and untagged). The default build graph no longer pulls in `github.com/docker/docker`, so `govulncheck` is now a **blocking** CI gate. No change to the production binary.

--- a/app/lib/api/hub_comparison_models.dart
+++ b/app/lib/api/hub_comparison_models.dart
@@ -1,0 +1,271 @@
+/// Multi-Hub Comparison DTOs — field names map exactly to the backend json
+/// tags for POST /api/v1/trading/hubs/compare.
+///
+/// CRITICAL: parsing is null/float-robust (mirrors trading_models.dart). A past
+/// production bug was caused by non-robust mobile DTO parsing, so every numeric
+/// field tolerates absent/null values and accepts any [num] (int or double).
+library;
+
+// ---------------------------------------------------------------------------
+// CompetitionInfo
+// ---------------------------------------------------------------------------
+
+/// Per-hub competition indicator.
+/// Backend: `competition` object on each hub row.
+class CompetitionInfo {
+  const CompetitionInfo({
+    required this.changesPerHour,
+    required this.source,
+  });
+
+  /// Backend: `changes_per_hour` — order changes/hour (proxy for competition).
+  final double changesPerHour;
+
+  /// Backend: `source` — "live" | "baseline".
+  final String source;
+
+  factory CompetitionInfo.fromJson(Map<String, dynamic> json) {
+    return CompetitionInfo(
+      changesPerHour: (json['changes_per_hour'] as num?)?.toDouble() ?? 0,
+      source: json['source'] as String? ?? 'baseline',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SkillsApplied
+// ---------------------------------------------------------------------------
+
+/// Whether/how trading skills were applied to the net-margin computation.
+/// Backend: `skills_applied` object.
+class SkillsApplied {
+  const SkillsApplied({
+    required this.applied,
+    required this.accounting,
+    required this.brokerRelations,
+    required this.salesTaxRate,
+    required this.brokerFeeRate,
+  });
+
+  /// Backend: `applied`
+  final bool applied;
+
+  /// Backend: `accounting` — skill level 0-5.
+  final int accounting;
+
+  /// Backend: `broker_relations` — skill level 0-5.
+  final int brokerRelations;
+
+  /// Backend: `sales_tax_rate` — effective fractional rate (e.g. 0.025).
+  final double salesTaxRate;
+
+  /// Backend: `broker_fee_rate` — effective fractional rate (e.g. 0.015).
+  final double brokerFeeRate;
+
+  factory SkillsApplied.fromJson(Map<String, dynamic> json) {
+    return SkillsApplied(
+      applied: json['applied'] as bool? ?? false,
+      accounting: (json['accounting'] as num?)?.toInt() ?? 0,
+      brokerRelations: (json['broker_relations'] as num?)?.toInt() ?? 0,
+      salesTaxRate: (json['sales_tax_rate'] as num?)?.toDouble() ?? 0,
+      brokerFeeRate: (json['broker_fee_rate'] as num?)?.toDouble() ?? 0,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HubRow
+// ---------------------------------------------------------------------------
+
+/// A single hub's station-trading metrics for the compared item.
+/// Backend: an element of the `hubs` array.
+///
+/// When [hasData] is false the numeric fields are absent/null on the wire and
+/// default to 0 here; the UI must gate display on [hasData].
+class HubRow {
+  const HubRow({
+    required this.regionId,
+    required this.regionName,
+    required this.hubName,
+    required this.systemId,
+    required this.tier,
+    required this.hasData,
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.spreadPercent,
+    required this.netMarginPercent,
+    required this.netProfitPerUnit,
+    required this.dailyVolume,
+    required this.liquidityScore,
+    this.competition,
+  });
+
+  /// Backend: `region_id`
+  final int regionId;
+
+  /// Backend: `region_name`
+  final String regionName;
+
+  /// Backend: `hub_name`
+  final String hubName;
+
+  /// Backend: `system_id`
+  final int systemId;
+
+  /// Backend: `tier` — e.g. "primary" | "secondary".
+  final String tier;
+
+  /// Backend: `has_data` — false when the hub has no market data.
+  final bool hasData;
+
+  /// Backend: `buy_price`
+  final double buyPrice;
+
+  /// Backend: `sell_price`
+  final double sellPrice;
+
+  /// Backend: `spread_percent`
+  final double spreadPercent;
+
+  /// Backend: `net_margin_percent` — skill-adjusted net margin.
+  final double netMarginPercent;
+
+  /// Backend: `net_profit_per_unit`
+  final double netProfitPerUnit;
+
+  /// Backend: `daily_volume`
+  final double dailyVolume;
+
+  /// Backend: `liquidity_score` — 0-100.
+  final int liquidityScore;
+
+  /// Backend: `competition` (object) — null when absent.
+  final CompetitionInfo? competition;
+
+  factory HubRow.fromJson(Map<String, dynamic> json) {
+    final compRaw = json['competition'];
+    return HubRow(
+      regionId: (json['region_id'] as num?)?.toInt() ?? 0,
+      regionName: json['region_name'] as String? ?? '',
+      hubName: json['hub_name'] as String? ?? '',
+      systemId: (json['system_id'] as num?)?.toInt() ?? 0,
+      tier: json['tier'] as String? ?? '',
+      hasData: json['has_data'] as bool? ?? false,
+      buyPrice: (json['buy_price'] as num?)?.toDouble() ?? 0,
+      sellPrice: (json['sell_price'] as num?)?.toDouble() ?? 0,
+      spreadPercent: (json['spread_percent'] as num?)?.toDouble() ?? 0,
+      netMarginPercent: (json['net_margin_percent'] as num?)?.toDouble() ?? 0,
+      netProfitPerUnit: (json['net_profit_per_unit'] as num?)?.toDouble() ?? 0,
+      dailyVolume: (json['daily_volume'] as num?)?.toDouble() ?? 0,
+      liquidityScore: (json['liquidity_score'] as num?)?.toInt() ?? 0,
+      competition: compRaw is Map<String, dynamic>
+          ? CompetitionInfo.fromJson(compRaw)
+          : null,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HubComparisonResponse
+// ---------------------------------------------------------------------------
+
+/// Response from POST /api/v1/trading/hubs/compare.
+///
+/// [hubs] is pre-sorted by the backend (best net margin first, no-data rows
+/// last). [bestHubRegionId] identifies the recommended hub.
+class HubComparisonResponse {
+  const HubComparisonResponse({
+    required this.typeId,
+    required this.itemName,
+    required this.bestHubRegionId,
+    required this.skillsApplied,
+    required this.hubs,
+  });
+
+  /// Backend: `type_id`
+  final int typeId;
+
+  /// Backend: `item_name`
+  final String itemName;
+
+  /// Backend: `best_hub_region_id` — region id of the recommended hub.
+  final int bestHubRegionId;
+
+  /// Backend: `skills_applied`
+  final SkillsApplied skillsApplied;
+
+  /// Backend: `hubs` — pre-sorted hub rows.
+  final List<HubRow> hubs;
+
+  factory HubComparisonResponse.fromJson(Map<String, dynamic> json) {
+    final rawHubs = json['hubs'] as List<dynamic>? ?? const [];
+    final skillsRaw = json['skills_applied'];
+    return HubComparisonResponse(
+      typeId: (json['type_id'] as num?)?.toInt() ?? 0,
+      itemName: json['item_name'] as String? ?? '',
+      bestHubRegionId: (json['best_hub_region_id'] as num?)?.toInt() ?? 0,
+      skillsApplied: skillsRaw is Map<String, dynamic>
+          ? SkillsApplied.fromJson(skillsRaw)
+          : const SkillsApplied(
+              applied: false,
+              accounting: 0,
+              brokerRelations: 0,
+              salesTaxRate: 0,
+              brokerFeeRate: 0,
+            ),
+      hubs: rawHubs
+          .whereType<Map<String, dynamic>>()
+          .map(HubRow.fromJson)
+          .toList(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ItemSearchResult / ItemSearchResponse
+// ---------------------------------------------------------------------------
+
+/// A single item-search hit.
+/// Backend: an element of the `items` array from GET /api/v1/items/search.
+class ItemSearchResult {
+  const ItemSearchResult({
+    required this.typeId,
+    required this.name,
+    required this.groupName,
+  });
+
+  /// Backend: `type_id`
+  final int typeId;
+
+  /// Backend: `name`
+  final String name;
+
+  /// Backend: `group_name`
+  final String groupName;
+
+  factory ItemSearchResult.fromJson(Map<String, dynamic> json) {
+    return ItemSearchResult(
+      typeId: (json['type_id'] as num?)?.toInt() ?? 0,
+      name: json['name'] as String? ?? '',
+      groupName: json['group_name'] as String? ?? '',
+    );
+  }
+}
+
+/// Response wrapper for GET /api/v1/items/search.
+class ItemSearchResponse {
+  const ItemSearchResponse({required this.items});
+
+  /// Backend: `items`
+  final List<ItemSearchResult> items;
+
+  factory ItemSearchResponse.fromJson(Map<String, dynamic> json) {
+    final raw = json['items'] as List<dynamic>? ?? const [];
+    return ItemSearchResponse(
+      items: raw
+          .whereType<Map<String, dynamic>>()
+          .map(ItemSearchResult.fromJson)
+          .toList(),
+    );
+  }
+}

--- a/app/lib/api/trading_api.dart
+++ b/app/lib/api/trading_api.dart
@@ -7,12 +7,37 @@ library;
 
 import 'package:dio/dio.dart';
 
+import 'hub_comparison_models.dart';
 import 'trading_models.dart';
 
 class TradingApi {
   TradingApi(this._dio);
 
   final Dio _dio;
+
+  // ── GET /api/v1/items/search?q=&limit= ─────────────────────────────────────
+
+  /// Searches EVE items by name. [q] must be at least 3 characters; callers
+  /// are responsible for that gate. [limit] caps the number of hits (≤20).
+  Future<ItemSearchResponse> searchItems(String q, {int limit = 20}) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/api/v1/items/search',
+      queryParameters: {'q': q, 'limit': limit},
+    );
+    return ItemSearchResponse.fromJson(response.data!);
+  }
+
+  // ── POST /api/v1/trading/hubs/compare ──────────────────────────────────────
+
+  /// Compares an item's station-trading profitability across the major hubs.
+  /// Returns a [HubComparisonResponse] with pre-sorted hub rows.
+  Future<HubComparisonResponse> compareHubs(int typeId) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/api/v1/trading/hubs/compare',
+      data: {'type_id': typeId},
+    );
+    return HubComparisonResponse.fromJson(response.data!);
+  }
 
   // ── POST /api/v1/trading/routes/calculate ──────────────────────────────────
 

--- a/app/lib/core/router.dart
+++ b/app/lib/core/router.dart
@@ -20,6 +20,7 @@ import 'package:go_router/go_router.dart';
 import '../auth/auth_controller.dart';
 import '../auth/login_screen.dart';
 import '../features/character/character_screen.dart';
+import '../features/trading/hub_comparison_screen.dart';
 import '../features/trading/trading_screen.dart';
 
 // ---------------------------------------------------------------------------
@@ -91,6 +92,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             builder: (context, state) => const TradingScreen(),
           ),
           GoRoute(
+            path: '/hub-comparison',
+            builder: (context, state) => const HubComparisonScreen(),
+          ),
+          GoRoute(
             path: '/character',
             builder: (context, state) => const CharacterScreen(),
           ),
@@ -119,6 +124,10 @@ class _AppShell extends ConsumerWidget {
       label: 'Trading',
     ),
     NavigationDestination(
+      icon: Icon(Icons.compare_arrows_rounded),
+      label: 'Hub-Vergleich',
+    ),
+    NavigationDestination(
       icon: Icon(Icons.person_outline_rounded),
       selectedIcon: Icon(Icons.person_rounded),
       label: 'Character',
@@ -130,7 +139,8 @@ class _AppShell extends ConsumerWidget {
   ];
 
   int get _selectedIndex {
-    if (location.startsWith('/character')) return 1;
+    if (location.startsWith('/hub-comparison')) return 1;
+    if (location.startsWith('/character')) return 2;
     return 0; // /trading is default; "Abmelden" is never a selected state
   }
 
@@ -145,8 +155,10 @@ class _AppShell extends ConsumerWidget {
             case 0:
               context.go('/trading');
             case 1:
-              context.go('/character');
+              context.go('/hub-comparison');
             case 2:
+              context.go('/character');
+            case 3:
               _confirmLogout(context, ref);
           }
         },

--- a/app/lib/features/trading/hub_comparison_providers.dart
+++ b/app/lib/features/trading/hub_comparison_providers.dart
@@ -1,0 +1,61 @@
+/// Riverpod providers for the Multi-Hub Comparison feature.
+///
+/// Provider graph (reuses [tradingApiProvider] from providers.dart):
+///   tradingApiProvider → hubComparisonProvider (AsyncNotifier)
+///
+/// State leaves:
+///   selectedSearchItemProvider — the item the user picked from search results.
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/hub_comparison_models.dart';
+import 'providers.dart' show tradingApiProvider;
+
+// ---------------------------------------------------------------------------
+// Selected search item
+// ---------------------------------------------------------------------------
+
+/// Notifier for the currently selected search result; null until a pick.
+class SelectedSearchItemNotifier extends Notifier<ItemSearchResult?> {
+  @override
+  ItemSearchResult? build() => null;
+
+  /// Sets the selected item.
+  void select(ItemSearchResult? item) => state = item;
+}
+
+/// Provider for the currently selected [ItemSearchResult].
+final selectedSearchItemProvider =
+    NotifierProvider<SelectedSearchItemNotifier, ItemSearchResult?>(
+  SelectedSearchItemNotifier.new,
+);
+
+// ---------------------------------------------------------------------------
+// HubComparisonNotifier — AsyncNotifier<HubComparisonResponse?>
+// ---------------------------------------------------------------------------
+
+/// Owns the hub-comparison lifecycle.
+///
+/// [build] returns null — no comparison has been performed yet. Call
+/// [search] with an item type id to trigger a comparison; it sets
+/// [AsyncLoading] then guards the API call.
+class HubComparisonNotifier extends AsyncNotifier<HubComparisonResponse?> {
+  @override
+  Future<HubComparisonResponse?> build() async => null;
+
+  /// Runs a hub comparison for [typeId].
+  Future<void> search(int typeId) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final api = ref.read(tradingApiProvider);
+      return api.compareHubs(typeId);
+    });
+  }
+}
+
+/// Provider for [HubComparisonNotifier].
+final hubComparisonProvider =
+    AsyncNotifierProvider<HubComparisonNotifier, HubComparisonResponse?>(
+  HubComparisonNotifier.new,
+);

--- a/app/lib/features/trading/hub_comparison_screen.dart
+++ b/app/lib/features/trading/hub_comparison_screen.dart
@@ -1,0 +1,427 @@
+/// Adaptive Multi-Hub Comparison screen.
+///
+/// The user searches for an EVE item, picks one, and sees that item's
+/// station-trading profitability compared across the major trade hubs
+/// (Jita, Amarr, Dodixie, Rens, Hek): buy/sell price, spread%, skill-adjusted
+/// net margin, volume and a competition indicator, with the recommended hub
+/// highlighted.
+///
+/// Layout (via [isTwoPane] / [kTwoPaneBreakpoint] = 840 dp):
+///   • <840 dp  → single-pane: search form above a scrollable comparison table.
+///   • ≥840 dp  → two-pane: search form on the left, table on the right.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/hub_comparison_models.dart';
+import '../../core/breakpoint.dart';
+import 'hub_comparison_providers.dart';
+import 'providers.dart' show tradingApiProvider;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// The hub-comparison screen.
+class HubComparisonScreen extends ConsumerWidget {
+  const HubComparisonScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Hub-Vergleich'),
+        centerTitle: false,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final twoPane = isTwoPane(constraints.maxWidth);
+          if (twoPane) {
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: const [
+                SizedBox(
+                  width: 320,
+                  child: SingleChildScrollView(
+                    padding: EdgeInsets.all(16),
+                    child: _SearchForm(),
+                  ),
+                ),
+                VerticalDivider(width: 1),
+                Expanded(child: _ComparisonTable()),
+              ],
+            );
+          }
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(16),
+                child: _SearchForm(),
+              ),
+              Divider(height: 1),
+              Expanded(child: _ComparisonTable()),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Search form — item lookup + pick + compare
+// ---------------------------------------------------------------------------
+
+class _SearchForm extends ConsumerStatefulWidget {
+  const _SearchForm();
+
+  @override
+  ConsumerState<_SearchForm> createState() => _SearchFormState();
+}
+
+class _SearchFormState extends ConsumerState<_SearchForm> {
+  final _controller = TextEditingController();
+  List<ItemSearchResult> _results = const [];
+  bool _searching = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _runSearch() async {
+    final q = _controller.text.trim();
+    if (q.length < 3) {
+      setState(() {
+        _error = 'Mindestens 3 Zeichen eingeben.';
+        _results = const [];
+      });
+      return;
+    }
+    setState(() {
+      _searching = true;
+      _error = null;
+    });
+    try {
+      final api = ref.read(tradingApiProvider);
+      final resp = await api.searchItems(q);
+      if (!mounted) return;
+      setState(() => _results = resp.items);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = 'Suche fehlgeschlagen: $e');
+    } finally {
+      if (mounted) setState(() => _searching = false);
+    }
+  }
+
+  Future<void> _pick(ItemSearchResult item) async {
+    ref.read(selectedSearchItemProvider.notifier).select(item);
+    setState(() => _results = const []);
+    await ref.read(hubComparisonProvider.notifier).search(item.typeId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = ref.watch(selectedSearchItemProvider);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        TextField(
+          controller: _controller,
+          textInputAction: TextInputAction.search,
+          onSubmitted: (_) => _runSearch(),
+          decoration: InputDecoration(
+            labelText: 'Item suchen',
+            hintText: 'min. 3 Zeichen',
+            border: const OutlineInputBorder(),
+            isDense: true,
+            suffixIcon: _searching
+                ? const Padding(
+                    padding: EdgeInsets.all(12),
+                    child: SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  )
+                : IconButton(
+                    icon: const Icon(Icons.search_rounded),
+                    onPressed: _searching ? null : _runSearch,
+                    tooltip: 'Suchen',
+                  ),
+          ),
+        ),
+        if (_error != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            _error!,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.error,
+            ),
+          ),
+        ],
+        if (_results.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 280),
+            child: Material(
+              color: Theme.of(context).colorScheme.surface,
+              shape: RoundedRectangleBorder(
+                side: BorderSide(
+                  color: Theme.of(context).dividerColor,
+                ),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: ListView.separated(
+                shrinkWrap: true,
+                itemCount: _results.length,
+                separatorBuilder: (context, index) => const Divider(height: 1),
+                itemBuilder: (context, i) {
+                  final item = _results[i];
+                  return ListTile(
+                    dense: true,
+                    title: Text(item.name),
+                    subtitle: item.groupName.isEmpty
+                        ? null
+                        : Text(item.groupName),
+                    onTap: () => _pick(item),
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+        if (selected != null) ...[
+          const SizedBox(height: 16),
+          Text(
+            'Ausgewählt: ${selected.name}',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Comparison table — async-aware
+// ---------------------------------------------------------------------------
+
+class _ComparisonTable extends ConsumerWidget {
+  const _ComparisonTable();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(hubComparisonProvider);
+
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (err, _) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Vergleich fehlgeschlagen.\n$err',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ),
+      ),
+      data: (resp) {
+        if (resp == null) {
+          return const _EmptyHint();
+        }
+        return _HubDataTable(response: resp);
+      },
+    );
+  }
+}
+
+class _EmptyHint extends StatelessWidget {
+  const _EmptyHint();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.compare_arrows_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Item suchen und auswählen',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(120),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The actual data table
+// ---------------------------------------------------------------------------
+
+class _HubDataTable extends StatelessWidget {
+  const _HubDataTable({required this.response});
+
+  final HubComparisonResponse response;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.primary;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            response.itemName,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            response.skillsApplied.applied
+                ? 'Skill-bereinigt (Accounting ${response.skillsApplied.accounting}, '
+                    'Broker Relations ${response.skillsApplied.brokerRelations})'
+                : 'Ohne Skill-Bereinigung',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 16),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              columns: const [
+                DataColumn(label: Text('Hub')),
+                DataColumn(label: Text('Buy'), numeric: true),
+                DataColumn(label: Text('Sell'), numeric: true),
+                DataColumn(label: Text('Spread%'), numeric: true),
+                DataColumn(label: Text('Net Margin%'), numeric: true),
+                DataColumn(label: Text('Volume'), numeric: true),
+                DataColumn(label: Text('Competition')),
+              ],
+              rows: [
+                for (final hub in response.hubs)
+                  _hubRow(context, hub, accent),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  DataRow _hubRow(BuildContext context, HubRow hub, Color accent) {
+    final isBest =
+        hub.hasData && hub.regionId == response.bestHubRegionId;
+    final highlight = accent.withAlpha(30);
+
+    if (!hub.hasData) {
+      return DataRow(
+        color: WidgetStateProperty.all(
+          Theme.of(context).colorScheme.onSurface.withAlpha(8),
+        ),
+        cells: [
+          DataCell(_hubName(context, hub, isBest: false)),
+          const DataCell(Text('—')),
+          const DataCell(Text('—')),
+          const DataCell(Text('—')),
+          const DataCell(Text('keine Daten')),
+          const DataCell(Text('—')),
+          const DataCell(Text('—')),
+        ],
+      );
+    }
+
+    return DataRow(
+      color: isBest ? WidgetStateProperty.all(highlight) : null,
+      cells: [
+        DataCell(_hubName(context, hub, isBest: isBest)),
+        DataCell(Text(_fmtIsk(hub.buyPrice))),
+        DataCell(Text(_fmtIsk(hub.sellPrice))),
+        DataCell(Text('${hub.spreadPercent.toStringAsFixed(1)}%')),
+        DataCell(Text('${hub.netMarginPercent.toStringAsFixed(1)}%')),
+        DataCell(Text(_fmtVolume(hub.dailyVolume))),
+        DataCell(_competition(context, hub.competition)),
+      ],
+    );
+  }
+
+  Widget _hubName(BuildContext context, HubRow hub, {required bool isBest}) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (isBest) ...[
+          Icon(
+            Icons.star_rounded,
+            size: 16,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+          const SizedBox(width: 4),
+        ],
+        Text(
+          hub.hubName,
+          style: isBest
+              ? const TextStyle(fontWeight: FontWeight.w700)
+              : null,
+        ),
+      ],
+    );
+  }
+
+  Widget _competition(BuildContext context, CompetitionInfo? comp) {
+    if (comp == null) return const Text('—');
+    final isLive = comp.source == 'live';
+    final color = isLive
+        ? const Color(0xFF66BB6A)
+        : Theme.of(context).colorScheme.onSurface.withAlpha(120);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.circle, size: 8, color: color),
+        const SizedBox(width: 6),
+        Text(
+          '${comp.changesPerHour.toStringAsFixed(1)}/h',
+        ),
+        const SizedBox(width: 4),
+        Text(
+          isLive ? 'live' : 'baseline',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: color),
+        ),
+      ],
+    );
+  }
+
+  // ── Formatting helpers ─────────────────────────────────────────────────────
+
+  static String _fmtIsk(double v) {
+    if (v >= 1e9) return '${(v / 1e9).toStringAsFixed(2)}B';
+    if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(2)}M';
+    if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+    return v.toStringAsFixed(2);
+  }
+
+  static String _fmtVolume(double v) {
+    if (v >= 1e9) return '${(v / 1e9).toStringAsFixed(1)}B';
+    if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(1)}M';
+    if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+    return v.toStringAsFixed(0);
+  }
+}

--- a/app/test/e2e/app_flow_test.dart
+++ b/app/test/e2e/app_flow_test.dart
@@ -26,6 +26,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:eve_o_provit/features/trading/hub_comparison_screen.dart';
 import 'package:eve_o_provit/features/trading/route_detail.dart';
 import 'package:eve_o_provit/features/trading/route_list.dart';
 import 'package:eve_o_provit/features/trading/trading_screen.dart';
@@ -290,6 +291,49 @@ void main() {
 
       expect(find.text('Test Pilot'), findsOneWidget);
       expect(find.text('My Badger'), findsOneWidget);
+    });
+  });
+
+  // ── 6b. Hub Comparison ────────────────────────────────────────────────────
+
+  group('Hub Comparison', () {
+    testWidgets(
+        'Navigating to Hub-Vergleich tab renders the comparison table from '
+        'mocked data (hub names + recommended hub)', (tester) async {
+      _setViewSize(tester, 1280, 800);
+
+      await _pumpApp(tester, authenticatedOverrides());
+
+      // Open the Hub-Vergleich bottom-nav destination.
+      await tester.tap(find.text('Hub-Vergleich').last);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HubComparisonScreen), findsOneWidget);
+      // Item name header from fakeHubResponse.
+      expect(find.text('Tritanium'), findsWidgets);
+      // Hub names render.
+      expect(find.text('Dodixie'), findsOneWidget);
+      expect(find.text('Jita'), findsOneWidget);
+      expect(find.text('Rens'), findsOneWidget);
+      // Recommended hub (Dodixie, best_hub_region_id) shows the star.
+      expect(find.byIcon(Icons.star_rounded), findsOneWidget);
+      // No-data hub placeholder.
+      expect(find.text('keine Daten'), findsOneWidget);
+    });
+
+    testWidgets(
+        'Hub Comparison portrait (800×1280) is single-pane (no VerticalDivider)',
+        (tester) async {
+      _setViewSize(tester, 800, 1280);
+
+      await _pumpApp(tester, authenticatedOverrides());
+
+      await tester.tap(find.text('Hub-Vergleich').last);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HubComparisonScreen), findsOneWidget);
+      expect(find.byType(VerticalDivider), findsNothing);
+      expect(find.text('Dodixie'), findsOneWidget);
     });
   });
 

--- a/app/test/e2e/support/fakes.dart
+++ b/app/test/e2e/support/fakes.dart
@@ -8,6 +8,7 @@ library;
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:eve_o_provit/api/hub_comparison_models.dart';
 import 'package:eve_o_provit/api/trading_api.dart';
 import 'package:eve_o_provit/api/trading_models.dart';
 import 'package:eve_o_provit/auth/auth_controller.dart';
@@ -18,6 +19,7 @@ import 'package:eve_o_provit/features/character/character_api.dart';
 import 'package:eve_o_provit/features/character/character_models.dart';
 import 'package:eve_o_provit/features/character/providers.dart'
     show characterApiProvider;
+import 'package:eve_o_provit/features/trading/hub_comparison_providers.dart';
 import 'package:eve_o_provit/features/trading/providers.dart';
 
 // ---------------------------------------------------------------------------
@@ -109,6 +111,70 @@ RouteCalculationResponse fakeEmptyRouteResponse() => RouteCalculationResponse(
       routes: const [],
     );
 
+/// Canned [HubComparisonResponse] — Dodixie recommended, Rens has no data.
+HubComparisonResponse fakeHubResponse() => const HubComparisonResponse(
+      typeId: 34,
+      itemName: 'Tritanium',
+      bestHubRegionId: 10000032,
+      skillsApplied: SkillsApplied(
+        applied: true,
+        accounting: 5,
+        brokerRelations: 5,
+        salesTaxRate: 0.025,
+        brokerFeeRate: 0.015,
+      ),
+      hubs: [
+        HubRow(
+          regionId: 10000032,
+          regionName: 'Sinq Laison',
+          hubName: 'Dodixie',
+          systemId: 30002659,
+          tier: 'secondary',
+          hasData: true,
+          buyPrice: 100,
+          sellPrice: 110,
+          spreadPercent: 10,
+          netMarginPercent: 3.4,
+          netProfitPerUnit: 4.1,
+          dailyVolume: 125000,
+          liquidityScore: 72,
+          competition:
+              CompetitionInfo(changesPerHour: 42.5, source: 'baseline'),
+        ),
+        HubRow(
+          regionId: 10000002,
+          regionName: 'The Forge',
+          hubName: 'Jita',
+          systemId: 30000142,
+          tier: 'primary',
+          hasData: true,
+          buyPrice: 98,
+          sellPrice: 112,
+          spreadPercent: 14.3,
+          netMarginPercent: 2.1,
+          netProfitPerUnit: 2.4,
+          dailyVolume: 9000000,
+          liquidityScore: 95,
+          competition: CompetitionInfo(changesPerHour: 200, source: 'live'),
+        ),
+        HubRow(
+          regionId: 10000030,
+          regionName: 'Heimatar',
+          hubName: 'Rens',
+          systemId: 30002510,
+          tier: 'tertiary',
+          hasData: false,
+          buyPrice: 0,
+          sellPrice: 0,
+          spreadPercent: 0,
+          netMarginPercent: 0,
+          netProfitPerUnit: 0,
+          dailyVolume: 0,
+          liquidityScore: 0,
+        ),
+      ],
+    );
+
 /// Canned character used in the authenticated auth state.
 const fakeCharacter = Character(
   id: 12345678,
@@ -180,6 +246,22 @@ class FakeTradingApi extends TradingApi {
 
   @override
   Future<void> refreshMarket(int regionId, int typeId) async {}
+
+  @override
+  Future<ItemSearchResponse> searchItems(String q, {int limit = 20}) async =>
+      const ItemSearchResponse(
+        items: [
+          ItemSearchResult(
+            typeId: 34,
+            name: 'Tritanium',
+            groupName: 'Mineral',
+          ),
+        ],
+      );
+
+  @override
+  Future<HubComparisonResponse> compareHubs(int typeId) async =>
+      fakeHubResponse();
 
   @override
   Future<void> setWaypoint({
@@ -254,6 +336,22 @@ class FakeRoutesNotifier extends RoutesNotifier {
 }
 
 // ---------------------------------------------------------------------------
+// Fake HubComparisonNotifier — starts with canned data
+// ---------------------------------------------------------------------------
+
+/// A [HubComparisonNotifier] that initialises with [fakeHubResponse] so the
+/// comparison table is immediately visible without calling search().
+class FakeHubComparisonNotifier extends HubComparisonNotifier {
+  @override
+  Future<HubComparisonResponse?> build() async => fakeHubResponse();
+
+  @override
+  Future<void> search(int typeId) async {
+    state = AsyncData(fakeHubResponse());
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Stub AuthControllers
 // ---------------------------------------------------------------------------
 
@@ -294,6 +392,7 @@ List<dynamic> authenticatedOverrides() => [
       authControllerProvider.overrideWith(FakeAuthControllerAuthenticated.new),
       tradingApiProvider.overrideWithValue(FakeTradingApi()),
       routesProvider.overrideWith(FakeRoutesNotifier.new),
+      hubComparisonProvider.overrideWith(FakeHubComparisonNotifier.new),
       // Provide fake character API so ship selector / fitting card work offline.
       characterApiProvider.overrideWithValue(FakeCharacterApi()),
     ];

--- a/app/test/hub_comparison_models_test.dart
+++ b/app/test/hub_comparison_models_test.dart
@@ -1,0 +1,209 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/hub_comparison_models.dart';
+
+void main() {
+  // ── HubComparisonResponse.fromJson ─────────────────────────────────────────
+
+  group('HubComparisonResponse.fromJson', () {
+    // Realistic sample: one full hub, one no-data hub, one hub with missing /
+    // null numeric fields — exercises the null/float-robust parsing.
+    const Map<String, dynamic> sample = {
+      'type_id': 34,
+      'item_name': 'Tritanium',
+      'best_hub_region_id': 10000032,
+      'skills_applied': {
+        'applied': true,
+        'accounting': 5,
+        'broker_relations': 5,
+        'sales_tax_rate': 0.025,
+        'broker_fee_rate': 0.015,
+      },
+      'hubs': [
+        {
+          'region_id': 10000032,
+          'region_name': 'Sinq Laison',
+          'hub_name': 'Dodixie',
+          'system_id': 30002659,
+          'tier': 'secondary',
+          'has_data': true,
+          'buy_price': 100.0,
+          'sell_price': 110.0,
+          'spread_percent': 10.0,
+          'net_margin_percent': 3.4,
+          'net_profit_per_unit': 4.1,
+          'daily_volume': 125000,
+          'liquidity_score': 72,
+          'competition': {
+            'changes_per_hour': 42.5,
+            'source': 'baseline',
+          },
+        },
+        // Hub with missing/null numeric fields (live competition source).
+        {
+          'region_id': 10000002,
+          'region_name': 'The Forge',
+          'hub_name': 'Jita',
+          'system_id': 30000142,
+          'tier': 'primary',
+          'has_data': true,
+          'buy_price': null,
+          // sell_price absent entirely
+          'spread_percent': 5,
+          'net_margin_percent': null,
+          'daily_volume': null,
+          'liquidity_score': 90,
+          'competition': {
+            'changes_per_hour': 120,
+            'source': 'live',
+          },
+        },
+        // No-data hub: numeric fields absent, competition absent.
+        {
+          'region_id': 10000030,
+          'region_name': 'Heimatar',
+          'hub_name': 'Rens',
+          'system_id': 30002510,
+          'tier': 'tertiary',
+          'has_data': false,
+        },
+      ],
+    };
+
+    test('maps top-level scalar fields', () {
+      final resp = HubComparisonResponse.fromJson(sample);
+      expect(resp.typeId, 34);
+      expect(resp.itemName, 'Tritanium');
+      expect(resp.bestHubRegionId, 10000032);
+      expect(resp.hubs.length, 3);
+    });
+
+    test('maps skills_applied object', () {
+      final s = HubComparisonResponse.fromJson(sample).skillsApplied;
+      expect(s.applied, isTrue);
+      expect(s.accounting, 5);
+      expect(s.brokerRelations, 5);
+      expect(s.salesTaxRate, 0.025);
+      expect(s.brokerFeeRate, 0.015);
+    });
+
+    test('skills_applied defaults when object absent', () {
+      final noSkills = Map<String, dynamic>.from(sample)
+        ..remove('skills_applied');
+      final s = HubComparisonResponse.fromJson(noSkills).skillsApplied;
+      expect(s.applied, isFalse);
+      expect(s.accounting, 0);
+      expect(s.salesTaxRate, 0);
+    });
+
+    group('full hub row', () {
+      late HubRow hub;
+      setUp(() => hub = HubComparisonResponse.fromJson(sample).hubs[0]);
+
+      test('identification + tier', () {
+        expect(hub.regionId, 10000032);
+        expect(hub.regionName, 'Sinq Laison');
+        expect(hub.hubName, 'Dodixie');
+        expect(hub.systemId, 30002659);
+        expect(hub.tier, 'secondary');
+        expect(hub.hasData, isTrue);
+      });
+
+      test('numeric fields (int daily_volume coerced to double)', () {
+        expect(hub.buyPrice, 100.0);
+        expect(hub.sellPrice, 110.0);
+        expect(hub.spreadPercent, 10.0);
+        expect(hub.netMarginPercent, 3.4);
+        expect(hub.netProfitPerUnit, 4.1);
+        expect(hub.dailyVolume, 125000.0);
+        expect(hub.liquidityScore, 72);
+      });
+
+      test('competition object', () {
+        expect(hub.competition, isNotNull);
+        expect(hub.competition!.changesPerHour, 42.5);
+        expect(hub.competition!.source, 'baseline');
+      });
+    });
+
+    group('hub row with null / missing numeric fields', () {
+      late HubRow hub;
+      setUp(() => hub = HubComparisonResponse.fromJson(sample).hubs[1]);
+
+      test('null/absent numeric fields default to 0', () {
+        expect(hub.buyPrice, 0);
+        expect(hub.sellPrice, 0);
+        expect(hub.netMarginPercent, 0);
+        expect(hub.dailyVolume, 0);
+      });
+
+      test('present int field coerced to double', () {
+        expect(hub.spreadPercent, 5.0);
+      });
+
+      test('live competition source preserved (int changes_per_hour)', () {
+        expect(hub.competition!.source, 'live');
+        expect(hub.competition!.changesPerHour, 120.0);
+      });
+    });
+
+    group('no-data hub row', () {
+      late HubRow hub;
+      setUp(() => hub = HubComparisonResponse.fromJson(sample).hubs[2]);
+
+      test('has_data false and competition null', () {
+        expect(hub.hasData, isFalse);
+        expect(hub.competition, isNull);
+      });
+
+      test('all numeric fields default to 0', () {
+        expect(hub.buyPrice, 0);
+        expect(hub.sellPrice, 0);
+        expect(hub.spreadPercent, 0);
+        expect(hub.netMarginPercent, 0);
+        expect(hub.dailyVolume, 0);
+        expect(hub.liquidityScore, 0);
+      });
+    });
+
+    test('hubs is empty list when key absent', () {
+      final resp = HubComparisonResponse.fromJson(const {
+        'type_id': 34,
+        'item_name': 'X',
+        'best_hub_region_id': 0,
+      });
+      expect(resp.hubs, isEmpty);
+    });
+  });
+
+  // ── ItemSearchResponse.fromJson ────────────────────────────────────────────
+
+  group('ItemSearchResponse.fromJson', () {
+    test('maps items', () {
+      final resp = ItemSearchResponse.fromJson(const {
+        'items': [
+          {'type_id': 34, 'name': 'Tritanium', 'group_name': 'Mineral'},
+          {'type_id': 35, 'name': 'Pyerite', 'group_name': 'Mineral'},
+        ],
+      });
+      expect(resp.items.length, 2);
+      expect(resp.items[0].typeId, 34);
+      expect(resp.items[0].name, 'Tritanium');
+      expect(resp.items[0].groupName, 'Mineral');
+    });
+
+    test('empty when items key absent', () {
+      final resp = ItemSearchResponse.fromJson(const {});
+      expect(resp.items, isEmpty);
+    });
+
+    test('tolerates missing group_name', () {
+      final resp = ItemSearchResponse.fromJson(const {
+        'items': [
+          {'type_id': 34, 'name': 'Tritanium'},
+        ],
+      });
+      expect(resp.items.single.groupName, '');
+    });
+  });
+}

--- a/app/test/hub_comparison_screen_layout_test.dart
+++ b/app/test/hub_comparison_screen_layout_test.dart
@@ -1,0 +1,141 @@
+/// Widget tests for HubComparisonScreen adaptive layout.
+///
+/// 1. Small view (<840 dp) → single-pane: no VerticalDivider.
+/// 2. Large view (≥840 dp) → two-pane: at least one VerticalDivider.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/hub_comparison_models.dart';
+import 'package:eve_o_provit/api/trading_api.dart';
+import 'package:eve_o_provit/core/theme.dart';
+import 'package:eve_o_provit/features/trading/hub_comparison_providers.dart';
+import 'package:eve_o_provit/features/trading/hub_comparison_screen.dart';
+import 'package:eve_o_provit/features/trading/providers.dart';
+
+// ---------------------------------------------------------------------------
+// Canned data + fakes
+// ---------------------------------------------------------------------------
+
+HubComparisonResponse _fakeResponse() => const HubComparisonResponse(
+      typeId: 34,
+      itemName: 'Tritanium',
+      bestHubRegionId: 10000032,
+      skillsApplied: SkillsApplied(
+        applied: true,
+        accounting: 5,
+        brokerRelations: 5,
+        salesTaxRate: 0.025,
+        brokerFeeRate: 0.015,
+      ),
+      hubs: [
+        HubRow(
+          regionId: 10000032,
+          regionName: 'Sinq Laison',
+          hubName: 'Dodixie',
+          systemId: 30002659,
+          tier: 'secondary',
+          hasData: true,
+          buyPrice: 100,
+          sellPrice: 110,
+          spreadPercent: 10,
+          netMarginPercent: 3.4,
+          netProfitPerUnit: 4.1,
+          dailyVolume: 125000,
+          liquidityScore: 72,
+          competition: CompetitionInfo(
+            changesPerHour: 42.5,
+            source: 'baseline',
+          ),
+        ),
+        HubRow(
+          regionId: 10000030,
+          regionName: 'Heimatar',
+          hubName: 'Rens',
+          systemId: 30002510,
+          tier: 'tertiary',
+          hasData: false,
+          buyPrice: 0,
+          sellPrice: 0,
+          spreadPercent: 0,
+          netMarginPercent: 0,
+          netProfitPerUnit: 0,
+          dailyVolume: 0,
+          liquidityScore: 0,
+        ),
+      ],
+    );
+
+class _FakeApi extends TradingApi {
+  _FakeApi() : super(Dio());
+
+  @override
+  Future<HubComparisonResponse> compareHubs(int typeId) async =>
+      _fakeResponse();
+}
+
+/// Stub notifier that seeds the comparison response immediately.
+class _StubNotifier extends HubComparisonNotifier {
+  @override
+  Future<HubComparisonResponse?> build() async => _fakeResponse();
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  double width, {
+  double height = 1000,
+}) async {
+  tester.view.physicalSize = Size(width, height);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tradingApiProvider.overrideWithValue(_FakeApi()),
+        hubComparisonProvider.overrideWith(_StubNotifier.new),
+      ],
+      child: MaterialApp(
+        theme: buildTheme(Brightness.light),
+        home: const HubComparisonScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('Single-pane (width 800): no VerticalDivider', (tester) async {
+    await _pumpScreen(tester, 800);
+
+    expect(find.byType(VerticalDivider), findsNothing);
+    // Search field + table both present.
+    expect(find.text('Item suchen'), findsOneWidget);
+    expect(find.text('Tritanium'), findsOneWidget);
+  });
+
+  testWidgets('Two-pane (width 1280): at least one VerticalDivider',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byType(VerticalDivider), findsAtLeastNWidgets(1));
+    expect(find.text('Item suchen'), findsOneWidget);
+    expect(find.text('Tritanium'), findsOneWidget);
+  });
+
+  testWidgets('Table renders hub names + recommended star + no-data row',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.text('Dodixie'), findsOneWidget);
+    expect(find.text('Rens'), findsOneWidget);
+    // No-data hub shows the placeholder.
+    expect(find.text('keine Daten'), findsOneWidget);
+    // Recommended hub (Dodixie) is highlighted with a star icon.
+    expect(find.byIcon(Icons.star_rounded), findsOneWidget);
+  });
+}

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -34,6 +34,10 @@ type AppContainer struct {
 	CharacterHandler   *handlers.CharacterHandler
 	FittingHandler     *handlers.FittingHandler
 	CalculationHandler *handlers.CalculationHandler
+	MultiHubHandler    *handlers.MultiHubHandler
+
+	// Background workers
+	CompetitionCollector *services.CompetitionCollector
 }
 
 // NewContainer initializes all application dependencies and returns a ready-to-use AppContainer.
@@ -139,6 +143,17 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 	c.CharacterHandler = handlers.NewCharacterHandler(skillsService)
 	c.FittingHandler = handlers.NewFittingHandler(fittingService)
 	c.CalculationHandler = handlers.NewCalculationHandler(c.DB.SDE, fittingService)
+
+	// Multi-Hub Comparison (#43): competition tracking + hub comparison service.
+	competitionRepo := database.NewCompetitionRepository(c.DB.Postgres)
+	competitionService := services.NewCompetitionService(competitionRepo, c.MarketRepo, c.AppLogger)
+	c.CompetitionCollector = services.NewCompetitionCollector(competitionRepo, c.ESIClient, c.AppLogger)
+	volumeService := services.NewVolumeService(c.MarketRepo, c.ESIClient)
+	multiHubService := services.NewMultiHubComparisonService(skillsService, c.ESIClient, volumeService, competitionService, c.SDERepo, c.AppLogger)
+	c.MultiHubHandler = handlers.NewMultiHubHandler(multiHubService)
+
+	// Start the competition collector in the background (lazy-tracked pairs).
+	go c.CompetitionCollector.Start(ctx)
 
 	return c, nil
 }

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -152,6 +152,7 @@ func setupApp(c *AppContainer) *fiber.App {
 	api.Get("/market/:region/:type", c.Handlers.GetMarketOrders)
 
 	api.Post("/trading/routes/calculate", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.TradingHandler.CalculateRoutes)
+	api.Post("/trading/hubs/compare", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.MultiHubHandler.CompareHubs)
 	api.Get("/items/search", c.TradingHandler.SearchItems)
 
 	api.Post("/calculations/cargo", c.CalculationHandler.CalculateCargo)

--- a/backend/internal/database/competition.go
+++ b/backend/internal/database/competition.go
@@ -1,0 +1,159 @@
+// Package database - Competition tracking repository (Issue #43)
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// CompetitionRepository persists the lazy-tracking, order snapshots and derived
+// competition metrics that power the Multi-Hub Comparison "order update frequency"
+// indicator.
+type CompetitionRepository struct {
+	db DBPool
+}
+
+// NewCompetitionRepository creates a new competition repository.
+func NewCompetitionRepository(db DBPool) *CompetitionRepository {
+	return &CompetitionRepository{db: db}
+}
+
+// TrackedPair is a (type, region) pair the collector should snapshot.
+type TrackedPair struct {
+	TypeID   int
+	RegionID int
+}
+
+// CompetitionMetric is the derived per-(type,region) competition score.
+type CompetitionMetric struct {
+	ChangesPerHour float64
+	Source         string // "live" | "baseline"
+	UpdatedAt      time.Time
+}
+
+// RegisterTracked upserts a (type, region) pair, refreshing last_requested.
+func (r *CompetitionRepository) RegisterTracked(ctx context.Context, typeID, regionID int) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO competition_tracked (type_id, region_id, last_requested)
+		VALUES ($1, $2, NOW())
+		ON CONFLICT (type_id, region_id) DO UPDATE SET last_requested = NOW()
+	`, typeID, regionID)
+	if err != nil {
+		return fmt.Errorf("register tracked: %w", err)
+	}
+	return nil
+}
+
+// ListTracked returns pairs requested within the given retention window.
+func (r *CompetitionRepository) ListTracked(ctx context.Context, within time.Duration) ([]TrackedPair, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT type_id, region_id FROM competition_tracked
+		WHERE last_requested > NOW() - $1::interval
+	`, fmt.Sprintf("%d seconds", int(within.Seconds())))
+	if err != nil {
+		return nil, fmt.Errorf("list tracked: %w", err)
+	}
+	defer rows.Close()
+	var out []TrackedPair
+	for rows.Next() {
+		var p TrackedPair
+		if err := rows.Scan(&p.TypeID, &p.RegionID); err != nil {
+			return nil, fmt.Errorf("scan tracked: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// SaveSnapshot stores an order fingerprint (order_id -> price of active sell orders).
+func (r *CompetitionRepository) SaveSnapshot(ctx context.Context, typeID, regionID int, fingerprint map[int64]float64) error {
+	data, err := json.Marshal(fingerprint)
+	if err != nil {
+		return fmt.Errorf("marshal fingerprint: %w", err)
+	}
+	_, err = r.db.Exec(ctx, `
+		INSERT INTO competition_snapshot (type_id, region_id, taken_at, fingerprint)
+		VALUES ($1, $2, NOW(), $3)
+	`, typeID, regionID, string(data))
+	if err != nil {
+		return fmt.Errorf("save snapshot: %w", err)
+	}
+	return nil
+}
+
+// LatestSnapshot returns the most recent snapshot fingerprint + its time, or ok=false.
+func (r *CompetitionRepository) LatestSnapshot(ctx context.Context, typeID, regionID int) (map[int64]float64, time.Time, bool, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT taken_at, fingerprint FROM competition_snapshot
+		WHERE type_id = $1 AND region_id = $2
+		ORDER BY taken_at DESC LIMIT 1
+	`, typeID, regionID)
+	if err != nil {
+		return nil, time.Time{}, false, fmt.Errorf("latest snapshot: %w", err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, time.Time{}, false, rows.Err()
+	}
+	var takenAt time.Time
+	var raw []byte
+	if err := rows.Scan(&takenAt, &raw); err != nil {
+		return nil, time.Time{}, false, fmt.Errorf("scan snapshot: %w", err)
+	}
+	fp := map[int64]float64{}
+	if err := json.Unmarshal(raw, &fp); err != nil {
+		return nil, time.Time{}, false, fmt.Errorf("unmarshal fingerprint: %w", err)
+	}
+	return fp, takenAt, true, nil
+}
+
+// UpsertMetric stores the derived competition metric.
+func (r *CompetitionRepository) UpsertMetric(ctx context.Context, typeID, regionID int, changesPerHour float64, windowStart, windowEnd time.Time, source string) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO competition_metric (type_id, region_id, changes_per_hour, window_start, window_end, source, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, NOW())
+		ON CONFLICT (type_id, region_id) DO UPDATE SET
+			changes_per_hour = EXCLUDED.changes_per_hour,
+			window_start = EXCLUDED.window_start,
+			window_end = EXCLUDED.window_end,
+			source = EXCLUDED.source,
+			updated_at = NOW()
+	`, typeID, regionID, changesPerHour, windowStart, windowEnd, source)
+	if err != nil {
+		return fmt.Errorf("upsert metric: %w", err)
+	}
+	return nil
+}
+
+// GetMetric returns the live metric for (type, region), or ok=false if none exists.
+func (r *CompetitionRepository) GetMetric(ctx context.Context, typeID, regionID int) (CompetitionMetric, bool, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT changes_per_hour, source, updated_at FROM competition_metric
+		WHERE type_id = $1 AND region_id = $2
+	`, typeID, regionID)
+	if err != nil {
+		return CompetitionMetric{}, false, fmt.Errorf("get metric: %w", err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return CompetitionMetric{}, false, rows.Err()
+	}
+	var m CompetitionMetric
+	if err := rows.Scan(&m.ChangesPerHour, &m.Source, &m.UpdatedAt); err != nil {
+		return CompetitionMetric{}, false, fmt.Errorf("scan metric: %w", err)
+	}
+	return m, true, nil
+}
+
+// PruneSnapshots deletes snapshots older than the cutoff.
+func (r *CompetitionRepository) PruneSnapshots(ctx context.Context, olderThan time.Duration) error {
+	_, err := r.db.Exec(ctx, `
+		DELETE FROM competition_snapshot WHERE taken_at < NOW() - $1::interval
+	`, fmt.Sprintf("%d seconds", int(olderThan.Seconds())))
+	if err != nil {
+		return fmt.Errorf("prune snapshots: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/database/competition_integration_test.go
+++ b/backend/internal/database/competition_integration_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompetitionRepository_Integration exercises the real schema (migration 000002)
+// through the full register → snapshot → metric → prune lifecycle.
+func TestCompetitionRepository_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	tc := SetupPostgresContainer(t)
+	tc.SetupSchema(t)
+
+	repo := NewCompetitionRepository(tc.Pool)
+	ctx := context.Background()
+	const typeID, regionID = 34, 10000002
+
+	// Register tracking (idempotent upsert).
+	require.NoError(t, repo.RegisterTracked(ctx, typeID, regionID))
+	require.NoError(t, repo.RegisterTracked(ctx, typeID, regionID))
+
+	tracked, err := repo.ListTracked(ctx, time.Hour)
+	require.NoError(t, err)
+	require.Len(t, tracked, 1)
+	assert.Equal(t, typeID, tracked[0].TypeID)
+	assert.Equal(t, regionID, tracked[0].RegionID)
+
+	// No snapshot yet.
+	_, _, ok, err := repo.LatestSnapshot(ctx, typeID, regionID)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// Save two snapshots; the latest must come back intact.
+	require.NoError(t, repo.SaveSnapshot(ctx, typeID, regionID, map[int64]float64{1: 5.0, 2: 6.0}))
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, repo.SaveSnapshot(ctx, typeID, regionID, map[int64]float64{1: 5.5, 3: 7.0}))
+
+	fp, takenAt, ok, err := repo.LatestSnapshot(ctx, typeID, regionID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.False(t, takenAt.IsZero())
+	assert.Equal(t, map[int64]float64{1: 5.5, 3: 7.0}, fp)
+
+	// No live metric yet.
+	_, ok, err = repo.GetMetric(ctx, typeID, regionID)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// Upsert a live metric and read it back.
+	start := time.Now().Add(-time.Hour)
+	require.NoError(t, repo.UpsertMetric(ctx, typeID, regionID, 42.5, start, time.Now(), "live"))
+	m, ok, err := repo.GetMetric(ctx, typeID, regionID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "live", m.Source)
+	assert.InDelta(t, 42.5, m.ChangesPerHour, 1e-9)
+
+	// Prune removes all snapshots older than 0.
+	require.NoError(t, repo.PruneSnapshots(ctx, 0))
+	_, _, ok, err = repo.LatestSnapshot(ctx, typeID, regionID)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/backend/internal/handlers/multi_hub.go
+++ b/backend/internal/handlers/multi_hub.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
+)
+
+// MultiHubHandler serves the Multi-Hub Comparison endpoint (Issue #43).
+type MultiHubHandler struct {
+	service *services.MultiHubComparisonService
+}
+
+// NewMultiHubHandler creates a new multi-hub handler.
+func NewMultiHubHandler(service *services.MultiHubComparisonService) *MultiHubHandler {
+	return &MultiHubHandler{service: service}
+}
+
+// CompareHubs handles POST /api/v1/trading/hubs/compare
+//
+// @Summary Compare an item's station-trading profitability across major hubs
+// @Description For a given item, compares buy/sell/spread, skill-adjusted net margin,
+// @Description volume and competition across Jita, Amarr, Dodixie, Rens, Hek.
+// @Tags Trading
+// @Accept json
+// @Produce json
+// @Param request body models.HubComparisonRequest true "Item to compare"
+// @Success 200 {object} models.HubComparisonResult
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/trading/hubs/compare [post]
+func (h *MultiHubHandler) CompareHubs(c *fiber.Ctx) error {
+	var req models.HubComparisonRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+	if req.TypeID <= 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid type_id"})
+	}
+
+	characterID := c.Locals("character_id")
+	accessToken := c.Locals("access_token")
+	if characterID == nil || accessToken == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Authentication required"})
+	}
+
+	cid, ok := characterID.(int)
+	tok, ok2 := accessToken.(string)
+	if !ok || !ok2 {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid authentication context"})
+	}
+
+	result, err := h.service.CompareHubs(c.UserContext(), req.TypeID, cid, tok)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to compare hubs"})
+	}
+	return c.JSON(result)
+}

--- a/backend/internal/models/hub_comparison.go
+++ b/backend/internal/models/hub_comparison.go
@@ -1,0 +1,53 @@
+package models
+
+// HubComparisonRequest is the body for POST /api/v1/trading/hubs/compare.
+type HubComparisonRequest struct {
+	TypeID int `json:"type_id" example:"34"`
+} // @name HubComparisonRequest
+
+// CompetitionInfo describes the order-update-frequency competition indicator for
+// one (item, hub). Source is "live" when derived from snapshot churn, or
+// "baseline" when derived from daily order_count until live data exists.
+type CompetitionInfo struct {
+	ChangesPerHour float64 `json:"changes_per_hour" example:"42.5"`
+	Source         string  `json:"source" example:"baseline"` // "live" | "baseline"
+} // @name CompetitionInfo
+
+// HubRow is one hub's row in the comparison table for the requested item.
+type HubRow struct {
+	RegionID         int     `json:"region_id" example:"10000002"`
+	RegionName       string  `json:"region_name" example:"The Forge"`
+	HubName          string  `json:"hub_name" example:"Jita"`
+	SystemID         int     `json:"system_id" example:"30000142"`
+	Tier             string  `json:"tier" example:"primary"` // "primary" | "secondary"
+	HasData          bool    `json:"has_data" example:"true"`
+	BuyPrice         float64 `json:"buy_price" example:"5.50"`
+	SellPrice        float64 `json:"sell_price" example:"6.10"`
+	SpreadPercent    float64 `json:"spread_percent" example:"10.9"`
+	NetMarginPercent float64 `json:"net_margin_percent" example:"3.4"`
+	NetProfitPerUnit float64 `json:"net_profit_per_unit" example:"0.18"`
+	DailyVolume      float64 `json:"daily_volume" example:"125000"`
+	LiquidityScore   int     `json:"liquidity_score" example:"72"`
+
+	Competition CompetitionInfo `json:"competition"`
+} // @name HubRow
+
+// SkillsApplied summarizes which character skills were factored into the margins.
+type SkillsApplied struct {
+	Applied         bool    `json:"applied" example:"true"`
+	Accounting      int     `json:"accounting" example:"5"`
+	BrokerRelations int     `json:"broker_relations" example:"5"`
+	SalesTaxRate    float64 `json:"sales_tax_rate" example:"0.025"`
+	BrokerFeeRate   float64 `json:"broker_fee_rate" example:"0.015"`
+} // @name SkillsApplied
+
+// HubComparisonResult is the response for POST /api/v1/trading/hubs/compare.
+// Hubs are sorted by net margin descending; BestHubRegionID points at the top hub
+// that has data.
+type HubComparisonResult struct {
+	TypeID          int           `json:"type_id" example:"34"`
+	ItemName        string        `json:"item_name" example:"Tritanium"`
+	Hubs            []HubRow      `json:"hubs"`
+	BestHubRegionID int           `json:"best_hub_region_id" example:"10000032"`
+	SkillsApplied   SkillsApplied `json:"skills_applied"`
+} // @name HubComparisonResult

--- a/backend/internal/services/competition_collector.go
+++ b/backend/internal/services/competition_collector.go
@@ -1,0 +1,97 @@
+package services
+
+import (
+	"context"
+	"time"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+)
+
+// Collector tuning. Snapshots every CollectInterval; only pairs requested within
+// TrackingWindow are tracked; snapshots older than SnapshotRetention are pruned.
+const (
+	CollectInterval   = 20 * time.Minute
+	TrackingWindow    = 48 * time.Hour
+	SnapshotRetention = 72 * time.Hour
+)
+
+// CompetitionCollector periodically snapshots the sell-order book of lazily-tracked
+// (type, region) pairs and derives the live order-update-frequency metric (Issue #43).
+type CompetitionCollector struct {
+	repo      *database.CompetitionRepository
+	esiClient *esi.Client
+	logger    *logger.Logger
+}
+
+// NewCompetitionCollector creates a new collector.
+func NewCompetitionCollector(repo *database.CompetitionRepository, esiClient *esi.Client, logger *logger.Logger) *CompetitionCollector {
+	return &CompetitionCollector{repo: repo, esiClient: esiClient, logger: logger}
+}
+
+// Start runs the collector loop until ctx is cancelled. Intended to run in a goroutine.
+func (c *CompetitionCollector) Start(ctx context.Context) {
+	ticker := time.NewTicker(CollectInterval)
+	defer ticker.Stop()
+	c.logger.Info("competition collector started", "interval", CollectInterval.String())
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("competition collector stopped")
+			return
+		case <-ticker.C:
+			c.tick(ctx)
+		}
+	}
+}
+
+// tick snapshots all tracked pairs once and updates their live metric.
+func (c *CompetitionCollector) tick(ctx context.Context) {
+	pairs, err := c.repo.ListTracked(ctx, TrackingWindow)
+	if err != nil {
+		c.logger.Warn("competition collector: list tracked failed", "error", err)
+		return
+	}
+	for _, p := range pairs {
+		c.collectPair(ctx, p.TypeID, p.RegionID)
+	}
+	if err := c.repo.PruneSnapshots(ctx, SnapshotRetention); err != nil {
+		c.logger.Warn("competition collector: prune failed", "error", err)
+	}
+}
+
+// collectPair fetches the current sell-order book, diffs it against the previous
+// snapshot to derive churn, persists the live metric and stores the new snapshot.
+func (c *CompetitionCollector) collectPair(ctx context.Context, typeID, regionID int) {
+	orders, err := c.esiClient.FetchMarketOrdersForType(ctx, regionID, typeID)
+	if err != nil {
+		c.logger.Warn("competition collector: fetch orders failed", "error", err, "type", typeID, "region", regionID)
+		return
+	}
+	curr := sellFingerprint(orders)
+
+	if prev, takenAt, ok, err := c.repo.LatestSnapshot(ctx, typeID, regionID); err == nil && ok {
+		hours := time.Since(takenAt).Hours()
+		churn := ComputeChurn(prev, curr, hours)
+		if err := c.repo.UpsertMetric(ctx, typeID, regionID, churn, takenAt, time.Now(), "live"); err != nil {
+			c.logger.Warn("competition collector: upsert metric failed", "error", err)
+		}
+	}
+
+	if err := c.repo.SaveSnapshot(ctx, typeID, regionID, curr); err != nil {
+		c.logger.Warn("competition collector: save snapshot failed", "error", err)
+	}
+}
+
+// sellFingerprint maps order_id -> price for active sell orders.
+func sellFingerprint(orders []esi.ESIMarketOrder) map[int64]float64 {
+	fp := make(map[int64]float64, len(orders))
+	for _, o := range orders {
+		if o.IsBuyOrder || o.VolumeRemain <= 0 {
+			continue
+		}
+		fp[o.OrderID] = o.Price
+	}
+	return fp
+}

--- a/backend/internal/services/competition_service.go
+++ b/backend/internal/services/competition_service.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"context"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+)
+
+// CompetitionService derives the "order update frequency" competition indicator for
+// Multi-Hub Comparison (#43). It serves the live snapshot-churn metric when available
+// and falls back to a daily-order-count baseline (Ansatz A+C).
+type CompetitionService struct {
+	repo       *database.CompetitionRepository
+	marketRepo *database.MarketRepository
+	logger     *logger.Logger
+}
+
+// NewCompetitionService creates a new competition service.
+func NewCompetitionService(repo *database.CompetitionRepository, marketRepo *database.MarketRepository, logger *logger.Logger) *CompetitionService {
+	return &CompetitionService{repo: repo, marketRepo: marketRepo, logger: logger}
+}
+
+// Register lazily marks a (type, region) pair for collector tracking.
+func (s *CompetitionService) Register(ctx context.Context, typeID, regionID int) {
+	if err := s.repo.RegisterTracked(ctx, typeID, regionID); err != nil {
+		s.logger.Warn("competition: register tracked failed", "error", err, "type", typeID, "region", regionID)
+	}
+}
+
+// GetCompetition returns the competition indicator for (type, region). Live churn wins;
+// otherwise a baseline derived from the latest daily order_count (spread over 24h).
+func (s *CompetitionService) GetCompetition(ctx context.Context, typeID, regionID int) models.CompetitionInfo {
+	if m, ok, err := s.repo.GetMetric(ctx, typeID, regionID); err == nil && ok && m.Source == "live" {
+		return models.CompetitionInfo{ChangesPerHour: m.ChangesPerHour, Source: "live"}
+	}
+	return models.CompetitionInfo{ChangesPerHour: s.baseline(ctx, typeID, regionID), Source: "baseline"}
+}
+
+// baseline maps the most recent daily order_count to an hourly figure.
+func (s *CompetitionService) baseline(ctx context.Context, typeID, regionID int) float64 {
+	hist, err := s.marketRepo.GetVolumeHistory(ctx, typeID, regionID, 1)
+	if err != nil || len(hist) == 0 || hist[0].OrderCount == nil {
+		return 0
+	}
+	return float64(*hist[0].OrderCount) / 24.0
+}
+
+// ComputeChurn counts order changes between two consecutive snapshots and expresses
+// them per hour. A change is an order added, removed, or repriced. Pure function.
+func ComputeChurn(prev, curr map[int64]float64, hours float64) float64 {
+	if hours <= 0 {
+		return 0
+	}
+	changes := 0
+	for id, price := range curr {
+		old, existed := prev[id]
+		if !existed {
+			changes++ // added
+		} else if old != price {
+			changes++ // repriced
+		}
+	}
+	for id := range prev {
+		if _, stillThere := curr[id]; !stillThere {
+			changes++ // removed
+		}
+	}
+	return float64(changes) / hours
+}

--- a/backend/internal/services/competition_service_test.go
+++ b/backend/internal/services/competition_service_test.go
@@ -1,0 +1,50 @@
+package services
+
+import "testing"
+
+func TestComputeChurn(t *testing.T) {
+	tests := []struct {
+		name  string
+		prev  map[int64]float64
+		curr  map[int64]float64
+		hours float64
+		want  float64
+	}{
+		{
+			name:  "no changes over 2h",
+			prev:  map[int64]float64{1: 5.0, 2: 6.0},
+			curr:  map[int64]float64{1: 5.0, 2: 6.0},
+			hours: 2,
+			want:  0,
+		},
+		{
+			name:  "one added one removed one repriced over 1h",
+			prev:  map[int64]float64{1: 5.0, 2: 6.0}, // 2 removed
+			curr:  map[int64]float64{1: 5.5, 3: 7.0}, // 1 repriced, 3 added
+			hours: 1,
+			want:  3, // added(3) + repriced(1) + removed(2) = 3 changes / 1h
+		},
+		{
+			name:  "changes spread over 2h halves the rate",
+			prev:  map[int64]float64{1: 5.0},
+			curr:  map[int64]float64{2: 5.0, 3: 5.0}, // 2 added + 1 removed = 3
+			hours: 2,
+			want:  1.5,
+		},
+		{
+			name:  "zero hours guarded",
+			prev:  map[int64]float64{1: 5.0},
+			curr:  map[int64]float64{2: 6.0},
+			hours: 0,
+			want:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComputeChurn(tt.prev, tt.curr, tt.hours)
+			if got != tt.want {
+				t.Errorf("ComputeChurn() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/services/fee_rates_test.go
+++ b/backend/internal/services/fee_rates_test.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"math"
+	"testing"
+)
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestSalesTaxRate(t *testing.T) {
+	cases := map[int]float64{
+		0: 0.05,
+		1: 0.045,
+		5: 0.025,
+		6: 0.025, // clamped at -50%
+	}
+	for level, want := range cases {
+		if got := SalesTaxRate(level); !almostEqual(got, want) {
+			t.Errorf("SalesTaxRate(%d) = %v, want %v", level, got, want)
+		}
+	}
+}
+
+func TestBrokerFeeRate(t *testing.T) {
+	// Base 3%, no skills/standings.
+	if got := BrokerFeeRate(0, 0, 0, 0); !almostEqual(got, 0.03) {
+		t.Errorf("base broker fee = %v, want 0.03", got)
+	}
+	// Broker Relations V: 3% - 5*0.3% = 1.5%.
+	if got := BrokerFeeRate(5, 0, 0, 0); !almostEqual(got, 0.015) {
+		t.Errorf("broker V = %v, want 0.015", got)
+	}
+	// Advanced Broker Relations lowers the floor; with high standings rate cannot go below floor.
+	got := BrokerFeeRate(5, 5, 0, 0)
+	if got < 0 || got > 0.03 {
+		t.Errorf("broker fee out of range: %v", got)
+	}
+	// Standings reduce the rate further but never below 0.
+	if r := BrokerFeeRate(5, 5, 10, 10); r < 0 {
+		t.Errorf("broker fee went negative: %v", r)
+	}
+}

--- a/backend/internal/services/fee_service.go
+++ b/backend/internal/services/fee_service.go
@@ -68,6 +68,40 @@ func (s *FeeService) CalculateFees(
 	}, nil
 }
 
+// SalesTaxRate returns the sales-tax RATE (not absolute fee) for an Accounting level.
+// Base 5%, -10% per level (max -50% at Accounting V → 2.5%). Pure function, no min-ISK
+// floor — used for per-unit margin math in Multi-Hub Comparison (#43).
+func SalesTaxRate(accountingLevel int) float64 {
+	reduction := 0.10 * float64(accountingLevel)
+	if reduction > 0.50 {
+		reduction = 0.50
+	}
+	return 0.05 * (1 - reduction)
+}
+
+// BrokerFeeRate returns the broker-fee RATE for placing an order, given Broker Relations,
+// Advanced Broker Relations and faction/corp standings. Used for station-trading margins (#43).
+// EVE model: base 3%, -0.3% per Broker Relations level, minus standing reductions
+// (-0.03%/faction point, -0.02%/corp point); Advanced Broker Relations lowers the floor
+// (3% → 1% per level, min 0%). Result clamped to [floor, 0.03].
+func BrokerFeeRate(brokerRelations, advBrokerRelations int, factionStanding, corpStanding float64) float64 {
+	base := 0.03
+	rate := base - 0.003*float64(brokerRelations) - 0.0003*factionStanding - 0.0002*corpStanding
+
+	// Hard minimum broker fee is ~1%, lowered toward 0% by Advanced Broker Relations.
+	floor := 0.01 - 0.003*float64(advBrokerRelations)
+	if floor < 0 {
+		floor = 0
+	}
+	if rate < floor {
+		rate = floor
+	}
+	if rate > base {
+		rate = base
+	}
+	return rate
+}
+
 // CalculateSalesTax calculates sales tax based on Accounting skill
 // EVE Formula: Base 5% → Reduced by 10% per Accounting level → 2.5% at Accounting V
 // Minimum fee: 100 ISK

--- a/backend/internal/services/hubs.go
+++ b/backend/internal/services/hubs.go
@@ -1,0 +1,21 @@
+package services
+
+// Hub is one of the major EVE trade hubs used by Multi-Hub Comparison (Issue #43).
+// IDs verified against the SDE (v_trade_hubs / mapSolarSystems.regionID) 2026-05-28.
+type Hub struct {
+	Name       string // English hub name, e.g. "Jita"
+	SystemID   int    // solar system ID
+	RegionID   int    // region ID (ESI market orders are keyed by region)
+	RegionName string
+	Tier       string // "primary" | "secondary"
+}
+
+// MajorHubs is the fixed registry of the five major trade hubs.
+// Jita is the primary hub (the one #43 helps traders avoid); the rest are secondary.
+var MajorHubs = []Hub{
+	{Name: "Jita", SystemID: 30000142, RegionID: 10000002, RegionName: "The Forge", Tier: "primary"},
+	{Name: "Amarr", SystemID: 30002187, RegionID: 10000043, RegionName: "Domain", Tier: "secondary"},
+	{Name: "Dodixie", SystemID: 30002659, RegionID: 10000032, RegionName: "Sinq Laison", Tier: "secondary"},
+	{Name: "Rens", SystemID: 30002510, RegionID: 10000030, RegionName: "Heimatar", Tier: "secondary"},
+	{Name: "Hek", SystemID: 30002053, RegionID: 10000042, RegionName: "Metropolis", Tier: "secondary"},
+}

--- a/backend/internal/services/multi_hub_service.go
+++ b/backend/internal/services/multi_hub_service.go
@@ -1,0 +1,179 @@
+package services
+
+import (
+	"context"
+	"sort"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+)
+
+// Small dependency interfaces keep MultiHubComparisonService unit-testable.
+type hubOrderFetcher interface {
+	FetchMarketOrdersForType(ctx context.Context, regionID, typeID int) ([]esi.ESIMarketOrder, error)
+}
+
+type volumeProvider interface {
+	GetVolumeMetrics(ctx context.Context, typeID, regionID int) (*models.VolumeMetrics, error)
+}
+
+type competitionProvider interface {
+	Register(ctx context.Context, typeID, regionID int)
+	GetCompetition(ctx context.Context, typeID, regionID int) models.CompetitionInfo
+}
+
+type typeNamer interface {
+	GetTypeInfo(ctx context.Context, typeID int) (*database.TypeInfo, error)
+}
+
+// MultiHubComparisonService compares one item's station-trading profitability across the
+// major trade hubs, applying the character's fee skills (Issue #43). The ranking logic is
+// deliberately reusable: #107 (sell-from-assets) consumes the same per-hub net figures.
+type MultiHubComparisonService struct {
+	skills      SkillsServicer
+	market      hubOrderFetcher
+	volume      volumeProvider
+	competition competitionProvider
+	types       typeNamer
+	logger      *logger.Logger
+}
+
+// NewMultiHubComparisonService creates a new service.
+func NewMultiHubComparisonService(
+	skills SkillsServicer,
+	market hubOrderFetcher,
+	volume volumeProvider,
+	competition competitionProvider,
+	types typeNamer,
+	logger *logger.Logger,
+) *MultiHubComparisonService {
+	return &MultiHubComparisonService{
+		skills:      skills,
+		market:      market,
+		volume:      volume,
+		competition: competition,
+		types:       types,
+		logger:      logger,
+	}
+}
+
+// CompareHubs builds the per-hub comparison for an item, sorted by net margin descending.
+func (s *MultiHubComparisonService) CompareHubs(ctx context.Context, typeID, characterID int, accessToken string) (*models.HubComparisonResult, error) {
+	// Skills once (graceful: GetCharacterSkills returns defaults on ESI failure).
+	skills, err := s.skills.GetCharacterSkills(ctx, characterID, accessToken)
+	if err != nil || skills == nil {
+		skills = &TradingSkills{}
+	}
+	salesTaxRate := SalesTaxRate(skills.Accounting)
+	brokerFeeRate := BrokerFeeRate(skills.BrokerRelations, skills.AdvancedBrokerRelations, skills.FactionStanding, skills.CorpStanding)
+
+	itemName := ""
+	if info, err := s.types.GetTypeInfo(ctx, typeID); err == nil && info != nil {
+		itemName = info.Name
+	}
+
+	rows := make([]models.HubRow, 0, len(MajorHubs))
+	for _, hub := range MajorHubs {
+		s.competition.Register(ctx, typeID, hub.RegionID)
+		rows = append(rows, s.buildRow(ctx, typeID, hub, salesTaxRate, brokerFeeRate))
+	}
+
+	// Sort: rows with data first, then by net margin descending.
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].HasData != rows[j].HasData {
+			return rows[i].HasData
+		}
+		return rows[i].NetMarginPercent > rows[j].NetMarginPercent
+	})
+
+	bestHubRegionID := 0
+	for _, r := range rows {
+		if r.HasData {
+			bestHubRegionID = r.RegionID
+			break
+		}
+	}
+
+	return &models.HubComparisonResult{
+		TypeID:          typeID,
+		ItemName:        itemName,
+		Hubs:            rows,
+		BestHubRegionID: bestHubRegionID,
+		SkillsApplied: models.SkillsApplied{
+			Applied:         err == nil,
+			Accounting:      skills.Accounting,
+			BrokerRelations: skills.BrokerRelations,
+			SalesTaxRate:    salesTaxRate,
+			BrokerFeeRate:   brokerFeeRate,
+		},
+	}, nil
+}
+
+// buildRow computes one hub's comparison row.
+func (s *MultiHubComparisonService) buildRow(ctx context.Context, typeID int, hub Hub, salesTaxRate, brokerFeeRate float64) models.HubRow {
+	row := models.HubRow{
+		RegionID:    hub.RegionID,
+		RegionName:  hub.RegionName,
+		HubName:     hub.Name,
+		SystemID:    hub.SystemID,
+		Tier:        hub.Tier,
+		Competition: s.competition.GetCompetition(ctx, typeID, hub.RegionID),
+	}
+
+	orders, err := s.market.FetchMarketOrdersForType(ctx, hub.RegionID, typeID)
+	if err != nil {
+		s.logger.Warn("multi-hub: fetch orders failed", "error", err, "type", typeID, "region", hub.RegionID)
+		return row
+	}
+
+	bestBuy, bestSell, ok := bestPrices(orders)
+	if !ok {
+		return row
+	}
+
+	row.HasData = true
+	row.BuyPrice = bestBuy
+	row.SellPrice = bestSell
+	if bestBuy > 0 {
+		row.SpreadPercent = (bestSell - bestBuy) / bestBuy * 100
+	}
+
+	// Station-trading net per unit: buy at buy price (+broker), sell at sell price (-broker -tax).
+	buyCost := bestBuy * (1 + brokerFeeRate)
+	sellRevenue := bestSell * (1 - brokerFeeRate - salesTaxRate)
+	row.NetProfitPerUnit = sellRevenue - buyCost
+	if buyCost > 0 {
+		row.NetMarginPercent = row.NetProfitPerUnit / buyCost * 100
+	}
+
+	if vm, err := s.volume.GetVolumeMetrics(ctx, typeID, hub.RegionID); err == nil && vm != nil {
+		row.DailyVolume = vm.DailyVolumeAvg
+		row.LiquidityScore = vm.LiquidityScore
+	}
+
+	return row
+}
+
+// bestPrices returns the highest active buy price and lowest active sell price.
+func bestPrices(orders []esi.ESIMarketOrder) (bestBuy, bestSell float64, ok bool) {
+	haveBuy, haveSell := false, false
+	for _, o := range orders {
+		if o.VolumeRemain <= 0 {
+			continue
+		}
+		if o.IsBuyOrder {
+			if !haveBuy || o.Price > bestBuy {
+				bestBuy = o.Price
+				haveBuy = true
+			}
+		} else {
+			if !haveSell || o.Price < bestSell {
+				bestSell = o.Price
+				haveSell = true
+			}
+		}
+	}
+	return bestBuy, bestSell, haveBuy && haveSell
+}

--- a/backend/internal/services/multi_hub_service_test.go
+++ b/backend/internal/services/multi_hub_service_test.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+	applogger "github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+)
+
+type fakeSkills struct{ s *TradingSkills }
+
+func (f fakeSkills) GetCharacterSkills(_ context.Context, _ int, _ string) (*TradingSkills, error) {
+	return f.s, nil
+}
+
+type fakeMarket struct{ byRegion map[int][]esi.ESIMarketOrder }
+
+func (f fakeMarket) FetchMarketOrdersForType(_ context.Context, regionID, _ int) ([]esi.ESIMarketOrder, error) {
+	return f.byRegion[regionID], nil
+}
+
+type fakeVolume struct{}
+
+func (fakeVolume) GetVolumeMetrics(_ context.Context, _, _ int) (*models.VolumeMetrics, error) {
+	return &models.VolumeMetrics{DailyVolumeAvg: 1000, LiquidityScore: 50}, nil
+}
+
+type fakeCompetition struct{ registered int }
+
+func (f *fakeCompetition) Register(_ context.Context, _, _ int) { f.registered++ }
+func (f *fakeCompetition) GetCompetition(_ context.Context, _, _ int) models.CompetitionInfo {
+	return models.CompetitionInfo{ChangesPerHour: 1, Source: "baseline"}
+}
+
+type fakeTypes struct{}
+
+func (fakeTypes) GetTypeInfo(_ context.Context, _ int) (*database.TypeInfo, error) {
+	return &database.TypeInfo{TypeID: 34, Name: "Tritanium"}, nil
+}
+
+func sell(price float64) esi.ESIMarketOrder {
+	return esi.ESIMarketOrder{OrderID: int64(price * 10), Price: price, VolumeRemain: 100, IsBuyOrder: false}
+}
+func buy(price float64) esi.ESIMarketOrder {
+	return esi.ESIMarketOrder{OrderID: int64(price*10) + 1, Price: price, VolumeRemain: 100, IsBuyOrder: true}
+}
+
+func TestCompareHubs_RanksByNetMargin(t *testing.T) {
+	const jita, dodixie = 10000002, 10000032
+	market := fakeMarket{byRegion: map[int][]esi.ESIMarketOrder{
+		jita:    {buy(100), sell(102)}, // thin margin → loss after fees
+		dodixie: {buy(100), sell(110)}, // healthy margin
+		// Amarr/Rens/Hek: no orders → HasData=false
+	}}
+	svc := NewMultiHubComparisonService(
+		fakeSkills{&TradingSkills{Accounting: 5, BrokerRelations: 5}},
+		market, fakeVolume{}, &fakeCompetition{}, fakeTypes{}, applogger.New(),
+	)
+
+	res, err := svc.CompareHubs(context.Background(), 34, 123, "token")
+	if err != nil {
+		t.Fatalf("CompareHubs error: %v", err)
+	}
+	if res.ItemName != "Tritanium" {
+		t.Errorf("item name = %q", res.ItemName)
+	}
+	if len(res.Hubs) != len(MajorHubs) {
+		t.Fatalf("expected %d hub rows, got %d", len(MajorHubs), len(res.Hubs))
+	}
+	// Best hub must be Dodixie (higher net margin than thin Jita).
+	if res.BestHubRegionID != dodixie {
+		t.Errorf("best hub = %d, want %d (Dodixie)", res.BestHubRegionID, dodixie)
+	}
+	// First row is the recommended (highest-margin) hub with data.
+	if !res.Hubs[0].HasData || res.Hubs[0].RegionID != dodixie {
+		t.Errorf("first row = region %d hasData %v, want Dodixie with data", res.Hubs[0].RegionID, res.Hubs[0].HasData)
+	}
+	// Spread for Dodixie = (110-100)/100*100 = 10%.
+	if !almostEqual(res.Hubs[0].SpreadPercent, 10) {
+		t.Errorf("Dodixie spread = %v, want 10", res.Hubs[0].SpreadPercent)
+	}
+	// Dodixie net margin positive; the thin Jita row negative.
+	if res.Hubs[0].NetMarginPercent <= 0 {
+		t.Errorf("Dodixie net margin should be positive, got %v", res.Hubs[0].NetMarginPercent)
+	}
+	// Hubs without data sort last and are flagged.
+	last := res.Hubs[len(res.Hubs)-1]
+	if last.HasData {
+		t.Errorf("expected a no-data hub last, got region %d with data", last.RegionID)
+	}
+	// Skills applied reflected.
+	if !res.SkillsApplied.Applied || !almostEqual(res.SkillsApplied.SalesTaxRate, 0.025) {
+		t.Errorf("skills applied = %+v", res.SkillsApplied)
+	}
+}

--- a/backend/migrations/000002_competition_tracking.down.sql
+++ b/backend/migrations/000002_competition_tracking.down.sql
@@ -1,0 +1,4 @@
+-- Rollback: Competition tracking (Issue #43)
+DROP TABLE IF EXISTS competition_metric;
+DROP TABLE IF EXISTS competition_snapshot;
+DROP TABLE IF EXISTS competition_tracked;

--- a/backend/migrations/000002_competition_tracking.up.sql
+++ b/backend/migrations/000002_competition_tracking.up.sql
@@ -1,0 +1,47 @@
+-- Migration: Competition tracking for Multi-Hub Comparison (Issue #43)
+-- PostgreSQL schema. Powers the "order update frequency" competition indicator
+-- (lazy-tracked per (type_id, region_id); live churn from periodic snapshots,
+-- with a daily baseline from price_history.order_count as fallback).
+
+-- Lazily registered (type, hub-region) pairs the collector should track.
+CREATE TABLE IF NOT EXISTS competition_tracked (
+    type_id        INTEGER NOT NULL,
+    region_id      INTEGER NOT NULL,
+    last_requested TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (type_id, region_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_competition_tracked_last_requested
+    ON competition_tracked(last_requested);
+
+COMMENT ON TABLE competition_tracked IS 'Lazily registered (type,region) pairs the competition collector snapshots periodically';
+
+-- Rolling order snapshots; the collector diffs consecutive snapshots to derive churn.
+-- fingerprint is a compact map order_id -> price of the active sell orders at snapshot time.
+CREATE TABLE IF NOT EXISTS competition_snapshot (
+    id          BIGSERIAL PRIMARY KEY,
+    type_id     INTEGER NOT NULL,
+    region_id   INTEGER NOT NULL,
+    taken_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    fingerprint JSONB NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_competition_snapshot_lookup
+    ON competition_snapshot(type_id, region_id, taken_at DESC);
+
+COMMENT ON TABLE competition_snapshot IS 'Periodic order fingerprints; consecutive diffs yield order-change events for the churn metric';
+
+-- Derived competition metric per (type, region). source = 'live' (from snapshots)
+-- or 'baseline' (from price_history.order_count) until enough live data exists.
+CREATE TABLE IF NOT EXISTS competition_metric (
+    type_id          INTEGER NOT NULL,
+    region_id        INTEGER NOT NULL,
+    changes_per_hour DOUBLE PRECISION NOT NULL DEFAULT 0,
+    window_start     TIMESTAMPTZ,
+    window_end       TIMESTAMPTZ,
+    source           VARCHAR(16) NOT NULL DEFAULT 'baseline',
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (type_id, region_id)
+);
+
+COMMENT ON TABLE competition_metric IS 'Derived competition score per (type,region); source live=snapshot churn, baseline=daily order_count';

--- a/backend/pkg/esi/client.go
+++ b/backend/pkg/esi/client.go
@@ -111,6 +111,48 @@ func (c *Client) FetchMarketOrdersPage(ctx context.Context, regionID, page int) 
 	return esiOrders, totalPages, nil
 }
 
+// FetchMarketOrdersForType fetches all market orders (buy + sell) for a single type
+// in a region via the lightweight per-type ESI endpoint. Much cheaper than a full
+// region fetch — used by Multi-Hub Comparison (#43) and the competition collector.
+// Follows X-Pages pagination (capped to avoid runaway loops on pathological items).
+func (c *Client) FetchMarketOrdersForType(ctx context.Context, regionID, typeID int) ([]ESIMarketOrder, error) {
+	const maxPages = 20
+	var all []ESIMarketOrder
+	totalPages := 1
+	for page := 1; page <= totalPages && page <= maxPages; page++ {
+		endpoint := fmt.Sprintf("/v1/markets/%d/orders/?order_type=all&type_id=%d&page=%d", regionID, typeID, page)
+		resp, err := c.esi.Get(ctx, endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("ESI request failed: %w", err)
+		}
+		if resp.StatusCode == 304 {
+			resp.Body.Close()
+			break
+		}
+		if resp.StatusCode != 200 {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("unexpected ESI status %d: %s", resp.StatusCode, string(body))
+		}
+		if page == 1 {
+			if xPages := resp.Header.Get("X-Pages"); xPages != "" {
+				_, _ = fmt.Sscanf(xPages, "%d", &totalPages)
+			}
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response body: %w", err)
+		}
+		var orders []ESIMarketOrder
+		if err := json.Unmarshal(body, &orders); err != nil {
+			return nil, fmt.Errorf("failed to parse ESI response: %w", err)
+		}
+		all = append(all, orders...)
+	}
+	return all, nil
+}
+
 // ESIMarketHistory represents a single day's market history from ESI API
 type ESIMarketHistory struct {
 	Average    float64 `json:"average"`

--- a/deployments/init-db/01-init.sql
+++ b/deployments/init-db/01-init.sql
@@ -98,6 +98,37 @@ CREATE INDEX idx_profit_calculations_type ON profit_calculations(type_id);
 CREATE INDEX idx_profit_calculations_margin ON profit_calculations(profit_margin DESC);
 CREATE INDEX idx_profit_calculations_calculated ON profit_calculations(calculated_at);
 
+-- Competition tracking for Multi-Hub Comparison (#43)
+-- Mirrors backend/migrations/000002_competition_tracking.up.sql for the prod
+-- init-db apply path (HETZNER-DEPLOY Step 5). Idempotent.
+CREATE TABLE IF NOT EXISTS competition_tracked (
+    type_id        INT NOT NULL,
+    region_id      INT NOT NULL,
+    last_requested TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (type_id, region_id)
+);
+CREATE INDEX IF NOT EXISTS idx_competition_tracked_last_requested ON competition_tracked(last_requested);
+
+CREATE TABLE IF NOT EXISTS competition_snapshot (
+    id          BIGSERIAL PRIMARY KEY,
+    type_id     INT NOT NULL,
+    region_id   INT NOT NULL,
+    taken_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    fingerprint JSONB NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_competition_snapshot_lookup ON competition_snapshot(type_id, region_id, taken_at DESC);
+
+CREATE TABLE IF NOT EXISTS competition_metric (
+    type_id          INT NOT NULL,
+    region_id        INT NOT NULL,
+    changes_per_hour DOUBLE PRECISION NOT NULL DEFAULT 0,
+    window_start     TIMESTAMP WITH TIME ZONE,
+    window_end       TIMESTAMP WITH TIME ZONE,
+    source           VARCHAR(16) NOT NULL DEFAULT 'baseline',
+    updated_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (type_id, region_id)
+);
+
 -- Comments
 COMMENT ON TABLE users IS 'User accounts for EVE-O-Provit';
 COMMENT ON TABLE market_orders IS 'Cached market orders from ESI API';

--- a/docs/superpowers/specs/2026-05-28-multi-hub-comparison-design.md
+++ b/docs/superpowers/specs/2026-05-28-multi-hub-comparison-design.md
@@ -1,0 +1,94 @@
+# Multi-Hub Comparison (Issue #43) — Design
+
+- **Datum:** 2026-05-28
+- **Issue:** Sternrassler/eve-o-provit#43
+- **Status:** In Umsetzung
+
+## Use Case
+
+Ein kleiner Trader wählt ein Item und sieht für **denselben Artikel** einen Side-by-Side-Vergleich über die großen Handels-Hubs (Jita, Dodixie, Amarr, Rens, Hek): pro Hub Buy-Preis, Sell-Preis, Spread%, **skill-korrigierte Netto-Marge**, Liquidität/Volumen und ein **Konkurrenz-Indikator**. Eine Empfehlungs-Engine markiert den besten Hub. Ziel: Jita-Überfüllung meiden, profitablere Sekundär-Hubs finden — mit den Character-Skills (Fees, Cargo) korrekt eingerechnet.
+
+Abgrenzung: #43 ist **handels-getrieben** (generisch gewähltes Item, Station-Trading-Marge je Hub). #107 (Bestand verkaufen) ist bestands-getrieben und **wiederverwendet** die hier gebaute Hub-Ranking-Logik (siehe Design-Note in #43).
+
+## Scope
+
+Backend (Go) + Web-Frontend (Next.js) + Flutter-Client + volle Testpyramide (Unit/Integration/E2E je Frontend) + Deployment (Backend tag-basiert; Flutter APK + On-Device-Happy-Path).
+
+## Entscheidungen
+
+1. **Pro Hub anzeigen:** Buy-Preis, Sell-Preis, Spread%, **Netto-Marge nach Fees/Skills** (Round-Trip Station-Trading: Buy-Order kaufen → Sell-Order verkaufen, minus Sales-Tax + Broker-Fee).
+2. **Konkurrenz = A+C kombiniert:**
+   - **C (Sofort-Baseline):** ESI-Market-History `order_count`/Tag (vom `VolumeService` ohnehin geholt) → sofortiger Tages-Indikator, kein Cold-Start-Leerzustand.
+   - **A (Live-Upgrade):** Lazy-Tracking — beim ersten Vergleich werden `(type, 5 Hubs)` registriert; ein Scheduler snapshottet die Orders der getrackten Paare periodisch und akkumuliert Änderungs-Events/Stunde (neu/entfernt/umpreist). Sobald genug Snapshots da sind, ersetzt der Live-Churn die Baseline.
+   - Response-Feld `competition.source ∈ {baseline, live}` + `score`. C bleibt dauerhafter Fallback.
+3. **Hubs (fix, 5 Major-Hubs):** Jita/The Forge, Dodixie/Sinq Laison, Amarr/Domain, Rens/Heimatar, Hek/Metropolis — als Konstanten-Registry (Region-ID + Station-ID + primary/secondary-Flag).
+4. **Reusable Service:** `MultiHubComparisonService` komponiert die vorhandenen Services (Fee/Skills/Cargo/Volume/Market) — getrennt von HTTP-Handler/UI, damit #107 ihn wiederverwendet (siehe #43 Design-Note).
+5. **Skills:** Fees via `FeeService` (Accounting/Broker), Cargo via `cargo.GetShipCapacities` — auf **alle** Hub-Zeilen angewandt; ein „Skills Applied"-Panel zeigt die Effekte.
+
+## Architektur
+
+### Backend
+
+Neue/erweiterte Bausteine (alle unter `backend/`):
+
+- **Hub-Registry** `internal/services/hubs.go` — Konstanten der 5 Hubs (region_id, station_id, name, tier).
+- **Service** `internal/services/multi_hub_service.go` — `MultiHubComparisonService` mit
+  `CompareHubs(ctx, typeID, characterID, accessToken) (*MultiHubComparisonResult, error)`.
+  Komponiert: `SkillsService` (einmal, gecached), `FeeService.CalculateFees` (je Hub), `VolumeService.GetVolumeMetrics` (je Hub-Region), Market-Orders (je Hub-Region, best buy/best sell), `CompetitionService` (Score je Hub). Ranking nach Netto-Marge (Tie-Break: Netto-Tagesprofit via Volumen). Setzt `BestHub`.
+- **Competition** `internal/services/competition_service.go` + Collector:
+  - `competition_collector.go` — periodischer Job (Ticker, im `main.go` gestartet wie bestehende Background-Worker), iteriert getrackte `(type, hub)`-Paare, fetcht Orders, difft gegen letzten Snapshot, schreibt Churn-Metrik.
+  - Lazy-Registrierung: `CompareHubs` registriert die Paare (`upsert tracked`).
+  - Baseline aus Market-History `order_count` (C) wenn noch keine Live-Daten.
+- **Migration** `migrations/000002_competition_tracking.{up,down}.sql`:
+  - `competition_tracked(type_id, region_id, last_seen, PRIMARY KEY(type_id, region_id))`
+  - `competition_snapshot(type_id, region_id, taken_at, order_fingerprint JSONB)` (rolling, geprunt)
+  - `competition_metric(type_id, region_id, changes_per_hour, window_start, window_end, source, updated_at, PRIMARY KEY(type_id, region_id))`
+- **Repository** `internal/database/competition_repository.go` — Upserts/Reads für die drei Tabellen (pgx, wie `MarketRepository`).
+- **Handler** `internal/handlers/trading.go` → neue Methode `CompareHubs` (analog `CalculateRoutes`), Route `POST /api/v1/trading/hubs/compare` in `cmd/api/main.go` (protected, rate-limited).
+- **Models** `internal/models/hub_comparison.go` — `HubComparisonRequest{TypeID}`, `HubComparisonResult{ItemTypeID, ItemName, Hubs[], BestHubRegionID, SkillsApplied}`, `HubRow{RegionID, RegionName, StationName, Tier, BuyPrice, SellPrice, SpreadPercent, NetMarginPercent, NetProfitPerUnit, Volume *VolumeMetrics, Competition{Score, Source}}`.
+
+### Web (Next.js)
+
+- `frontend/src/app/multi-hub/page.tsx` — Placeholder ersetzen: Item-Suche (re-use `GET /api/v1/items/search`) → bei Auswahl `POST /hubs/compare` (React-Query `useMutation`, `credentials:"include"`).
+- Komponenten `frontend/src/components/trading/`: `HubComparisonTable.tsx`, `RecommendedHubBadge.tsx`, `SkillsAppliedPanel.tsx`, `CompetitionIndicator.tsx` (zeigt baseline/live).
+- `frontend/src/lib/api-client.ts` → `compareHubs(typeId)`, `searchItems(q)` (falls nicht vorhanden).
+- `frontend/src/types/trading.ts` → `HubComparisonResult`, `HubRow`, `CompetitionInfo`.
+
+### Flutter
+
+- `app/lib/api/hub_comparison_models.dart` — DTOs (null/float-robust `fromJson`).
+- `app/lib/features/trading/hub_comparison_screen.dart` — adaptiv via `isTwoPane(840)`: Item-Suchfeld + Ergebnis-Tabelle (1-Pane gestapelt / 2-Pane nebeneinander).
+- `app/lib/features/trading/hub_comparison_providers.dart` — `AsyncNotifier` (item → result).
+- `app/lib/api/trading_api.dart` → `compareHubs(typeId)`, `searchItems(q)`.
+- `app/lib/core/router.dart` → Route `/hub-comparison` + 4. NavigationDestination.
+
+## Datenfluss
+
+`Item-Suche (UI) → /items/search → Auswahl typeId → POST /hubs/compare → MultiHubComparisonService: Skills(1×) → für jeden Hub [Market best buy/sell, Fees, Volume, Competition] → Ranking → BestHub → Response → Tabelle + Empfehlung`.
+
+## Error-Handling
+
+- Auth-Pflicht (wie Trading); fehlender Skill-Scope → Fallback auf Base-Fees (kein Hard-Fail), `SkillsApplied=false`.
+- Hub ohne Orders/Volumen → Zeile mit Hinweis „keine Daten", nicht aus dem Vergleich kippen.
+- Keine geleakten Roh-Fehler (bestehende Konvention aus Handler-Tests).
+- Mobile-DTO null/float-robust (bekannte Lesson).
+
+## Tests (Pyramide)
+
+- **Backend Unit:** `multi_hub_service_test.go` (Ranking, Spread/Marge-Rechnung, Best-Hub-Wahl, baseline-vs-live-Auswahl) mit gemockten Servicern; `competition_service_test.go` (Churn-Diff aus zwei Snapshots).
+- **Backend Integration** (`//go:build integration`): `multi_hub_integration_test.go` — echte SDE + Markt-Migrationen, mehrere Hub-Regionen; Collector-Diff gegen DB.
+- **Web Unit (Vitest):** `HubComparisonTable.test.tsx`, `CompetitionIndicator.test.tsx`.
+- **Web E2E (Playwright, authed):** `tests/e2e/auth/multi-hub.spec.ts` — Login-Session, Item suchen, Vergleich anzeigen, Empfehlung sichtbar.
+- **Flutter Unit/Widget:** `test/hub_comparison_models_test.dart` (Parsing), `test/hub_comparison_screen_layout_test.dart` (1-Pane/2-Pane via View-Size).
+- **Flutter E2E:** Gruppe in `test/e2e/app_flow_test.dart` mit Provider-Override (fake result) — Tabelle + Empfehlung gerendert.
+
+## Deployment
+
+- **Backend:** SemVer-Bump in `CHANGELOG.md`, Migration `000002`, `make release VERSION=x.y.z` → Tag `v*` → CI (lint/test/blocking-govulncheck) → GHCR → `deploy-app.sh eveoprovit` → Smoke. Migration läuft beim Start (`migrate-up`/Startup-Apply).
+- **Flutter:** `flutter build apk --release --dart-define=API_BASE_URL=https://eveonline.sternrassler.de ...`, On-Device-Happy-Path auf dem Galaxy Tab gegen Prod (Item suchen → Hub-Vergleich → Empfehlung).
+
+## Out of Scope
+
+- #107 (Bestand verkaufen) — baut hierauf auf, separat.
+- Persistente Langzeit-Konkurrenz-Historie/Charts (#47).
+- Hub-Set konfigurierbar machen (vorerst fixe 5).

--- a/frontend/src/app/multi-hub/page.tsx
+++ b/frontend/src/app/multi-hub/page.tsx
@@ -1,114 +1,169 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Building2, TrendingUp, Users } from "lucide-react";
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { useAuth } from "@/lib/auth-context";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { HubComparisonTable } from "@/components/trading/HubComparisonTable";
+import { SkillsAppliedPanel } from "@/components/trading/SkillsAppliedPanel";
+import { searchItems, compareHubs } from "@/lib/api-client";
+import { ItemSearchResult } from "@/types/trading";
+import { Loader2, Search } from "lucide-react";
 
-export default function MultiHubPage() {
+const MIN_QUERY_LENGTH = 3;
+
+function MultiHubPageContent() {
+  const { isAuthenticated } = useAuth();
+  const [query, setQuery] = useState("");
+  const [selectedItem, setSelectedItem] = useState<ItemSearchResult | null>(
+    null
+  );
+
+  // Item search — runs once the query reaches the backend's 3-char minimum.
+  const { data: searchResults = [], isFetching: isSearching } = useQuery({
+    queryKey: ["itemSearch", query],
+    queryFn: () => searchItems(query),
+    enabled: query.trim().length >= MIN_QUERY_LENGTH,
+    staleTime: 60 * 1000,
+  });
+
+  // Multi-hub compare (authed POST), triggered when an item is picked.
+  const compareMutation = useMutation({
+    mutationFn: (typeId: number) => compareHubs(typeId),
+  });
+
+  const handleSelectItem = (item: ItemSearchResult) => {
+    setSelectedItem(item);
+    setQuery(item.name);
+    compareMutation.mutate(item.type_id);
+  };
+
+  const showSuggestions =
+    query.trim().length >= MIN_QUERY_LENGTH &&
+    selectedItem?.name !== query &&
+    searchResults.length > 0;
+
+  const apiError = compareMutation.isError
+    ? compareMutation.error instanceof Error
+      ? compareMutation.error.message
+      : "Unbekannter Fehler"
+    : undefined;
+
   return (
-    <div className="container mx-auto p-8">
+    <div className="container mx-auto px-4 py-8">
       <div className="mb-8">
-        <div className="flex items-center gap-3 mb-2">
-          <h1 className="text-3xl font-bold">Multi-Hub Comparison</h1>
-          <Badge variant="outline" className="text-blue-600">Phase 2</Badge>
-        </div>
+        <h1 className="mb-2 text-3xl font-bold">Multi-Hub Comparison</h1>
         <p className="text-muted-foreground">
-          Vergleiche Margen über verschiedene Trading Hubs hinweg
+          Vergleiche die Station-Trading-Margen eines Items über die großen
+          Handels-Hubs hinweg
         </p>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-3 mb-8">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Trade Hubs
-            </CardTitle>
-            <Building2 className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">4+</div>
-            <p className="text-xs text-muted-foreground">
-              Jita, Dodixie, Amarr, Rens
-            </p>
-          </CardContent>
-        </Card>
+      {!isAuthenticated && (
+        <Alert className="mb-6">
+          <AlertTitle>Login erforderlich</AlertTitle>
+          <AlertDescription>
+            Melde dich per EVE SSO an, um skill-bereinigte Hub-Vergleiche zu
+            laden.
+          </AlertDescription>
+        </Alert>
+      )}
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Competition Level
-            </CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">Low/Med/High</div>
-            <p className="text-xs text-muted-foreground">
-              Order update frequency tracking
-            </p>
-          </CardContent>
-        </Card>
+      {/* Item search */}
+      <div className="mb-8 max-w-xl">
+        <label
+          htmlFor="item-search"
+          className="mb-2 block text-sm font-medium"
+        >
+          Item suchen
+        </label>
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            id="item-search"
+            type="text"
+            placeholder="z.B. Tritanium (min. 3 Zeichen)"
+            className="pl-9"
+            value={query}
+            disabled={!isAuthenticated}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setSelectedItem(null);
+            }}
+            autoComplete="off"
+          />
+          {isSearching && (
+            <Loader2 className="absolute right-3 top-1/2 size-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+          )}
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Best Hub Recommendation
-            </CardTitle>
-            <TrendingUp className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">Auto</div>
-            <p className="text-xs text-muted-foreground">
-              Based on your capital
-            </p>
-          </CardContent>
-        </Card>
+          {showSuggestions && (
+            <ul
+              className="absolute z-10 mt-1 max-h-72 w-full overflow-auto rounded-md border bg-popover shadow-md"
+              role="listbox"
+              aria-label="Suchergebnisse"
+            >
+              {searchResults.map((item) => (
+                <li key={item.type_id} role="option" aria-selected="false">
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-muted"
+                    onClick={() => handleSelectItem(item)}
+                  >
+                    <span className="font-medium">{item.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {item.group_name}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
 
-      <Card className="border-dashed">
-        <CardHeader>
-          <CardTitle>Coming in Phase 2</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <h3 className="font-semibold flex items-center gap-2">
-              <span className="text-2xl">📊</span>
-              Side-by-Side Hub Comparison
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              Compare margins, volumes, and competition across all major trade hubs
-            </p>
-          </div>
+      {/* Compare state */}
+      {compareMutation.isPending && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          Lade Hub-Vergleich für {selectedItem?.name}...
+        </div>
+      )}
 
-          <div className="space-y-2">
-            <h3 className="font-semibold flex items-center gap-2">
-              <span className="text-2xl">🎯</span>
-              Smart Hub Recommendation
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              Get personalized recommendations based on your available capital
-            </p>
-          </div>
+      {apiError && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertTitle>Fehler</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-4">
+            <span>{apiError}</span>
+            {selectedItem && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => compareMutation.mutate(selectedItem.type_id)}
+              >
+                Erneut versuchen
+              </Button>
+            )}
+          </AlertDescription>
+        </Alert>
+      )}
 
-          <div className="space-y-2">
-            <h3 className="font-semibold flex items-center gap-2">
-              <span className="text-2xl">⚠️</span>
-              Competition Indicator
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              Avoid high-competition items (0.01 ISK wars) with real-time tracking
-            </p>
-          </div>
-
-          <div className="mt-6 p-4 bg-muted rounded-lg">
-            <p className="text-sm">
-              <strong>Target Release:</strong> March 2026 (Phase 2)
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Dependencies: Fee Calculator (#38), Volume Filter (#42)
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      {compareMutation.isSuccess && compareMutation.data && (
+        <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+          <HubComparisonTable result={compareMutation.data} />
+          <SkillsAppliedPanel skills={compareMutation.data.skills_applied} />
+        </div>
+      )}
     </div>
+  );
+}
+
+export default function MultiHubPage() {
+  return (
+    <ErrorBoundary>
+      <MultiHubPageContent />
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/components/trading/CompetitionIndicator.tsx
+++ b/frontend/src/components/trading/CompetitionIndicator.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { CompetitionInfo } from "@/types/trading";
+import { cn } from "@/lib/utils";
+import { Activity } from "lucide-react";
+
+interface CompetitionIndicatorProps {
+  competition: CompetitionInfo;
+}
+
+/**
+ * Shows the order-change frequency for a hub plus a small source badge
+ * distinguishing live tracking from a daily baseline estimate.
+ */
+export function CompetitionIndicator({ competition }: CompetitionIndicatorProps) {
+  const isLive = competition.source === "live";
+  const label = isLive ? "Live" : "Tages-Baseline";
+
+  return (
+    <div className="flex items-center gap-2">
+      <Activity className="size-3.5 text-muted-foreground" aria-hidden="true" />
+      <span className="text-sm font-medium">
+        {competition.changes_per_hour.toFixed(1)}/h
+      </span>
+      <span
+        className={cn(
+          "inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
+          isLive
+            ? "bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300"
+            : "bg-muted text-muted-foreground"
+        )}
+        title={isLive ? "Live-Order-Tracking" : "Geschätzt aus Tages-Baseline"}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/trading/HubComparisonTable.tsx
+++ b/frontend/src/components/trading/HubComparisonTable.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { HubComparisonResult, HubRow } from "@/types/trading";
+import {
+  cn,
+  formatISK,
+  getSpreadColor,
+  getProfitColor,
+} from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { RecommendedHubBadge } from "./RecommendedHubBadge";
+import { CompetitionIndicator } from "./CompetitionIndicator";
+
+interface HubComparisonTableProps {
+  result: HubComparisonResult;
+}
+
+/**
+ * Side-by-side comparison of an item's station-trading profitability across
+ * the major hubs. Rows arrive pre-sorted by net margin descending, with
+ * no-data hubs last. The recommended (best) hub is highlighted.
+ */
+export function HubComparisonTable({ result }: HubComparisonTableProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-xl">
+          Hub-Vergleich: {result.item_name}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm" aria-label="Hub-Vergleich">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th scope="col" className="px-4 py-3 font-medium">Hub</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">Kaufpreis</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">Verkaufspreis</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">Spread</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">Netto-Marge</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">Netto/Einheit</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">Tagesvolumen</th>
+                <th scope="col" className="px-4 py-3 font-medium">Konkurrenz</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.hubs.map((hub) => (
+                <HubRowItem
+                  key={hub.region_id}
+                  hub={hub}
+                  isRecommended={hub.region_id === result.best_hub_region_id}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function HubRowItem({
+  hub,
+  isRecommended,
+}: {
+  hub: HubRow;
+  isRecommended: boolean;
+}) {
+  if (!hub.has_data) {
+    return (
+      <tr
+        data-testid="hub-row"
+        data-region-id={hub.region_id}
+        className="border-b text-muted-foreground"
+      >
+        <td className="px-4 py-3">
+          <div className="font-medium">{hub.hub_name}</div>
+          <div className="text-xs">{hub.region_name}</div>
+        </td>
+        <td className="px-4 py-3 text-center italic" colSpan={7}>
+          Keine Daten verfügbar
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr
+      data-testid="hub-row"
+      data-region-id={hub.region_id}
+      className={cn(
+        "border-b transition-colors hover:bg-muted/40",
+        isRecommended && "bg-green-50 dark:bg-green-900/20"
+      )}
+    >
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{hub.hub_name}</span>
+          {isRecommended && <RecommendedHubBadge />}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {hub.region_name} · {hub.tier}
+        </div>
+      </td>
+      <td className="px-4 py-3 text-right font-medium">
+        {formatISK(hub.buy_price)}
+      </td>
+      <td className="px-4 py-3 text-right font-medium">
+        {formatISK(hub.sell_price)}
+      </td>
+      <td
+        className={cn(
+          "px-4 py-3 text-right font-medium",
+          getSpreadColor(hub.spread_percent)
+        )}
+      >
+        {hub.spread_percent.toFixed(1)}%
+      </td>
+      <td
+        className={cn(
+          "px-4 py-3 text-right font-bold",
+          getProfitColor(hub.net_margin_percent)
+        )}
+      >
+        {hub.net_margin_percent.toFixed(1)}%
+      </td>
+      <td className="px-4 py-3 text-right font-medium">
+        {formatISK(hub.net_profit_per_unit)}
+      </td>
+      <td className="px-4 py-3 text-right">
+        {hub.daily_volume.toLocaleString("de-DE")}
+      </td>
+      <td className="px-4 py-3">
+        <CompetitionIndicator competition={hub.competition} />
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/components/trading/RecommendedHubBadge.tsx
+++ b/frontend/src/components/trading/RecommendedHubBadge.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface RecommendedHubBadgeProps {
+  className?: string;
+}
+
+/**
+ * Small badge marking the recommended (best-margin) hub in the comparison.
+ */
+export function RecommendedHubBadge({ className }: RecommendedHubBadgeProps) {
+  return (
+    <Badge
+      className={cn(
+        "gap-1 border-transparent bg-green-600 text-white hover:bg-green-600/90",
+        className
+      )}
+    >
+      <Star className="size-3 fill-current" aria-hidden="true" />
+      Empfohlen
+    </Badge>
+  );
+}

--- a/frontend/src/components/trading/SkillsAppliedPanel.tsx
+++ b/frontend/src/components/trading/SkillsAppliedPanel.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { SkillsApplied } from "@/types/trading";
+import { GraduationCap } from "lucide-react";
+
+interface SkillsAppliedPanelProps {
+  skills: SkillsApplied;
+}
+
+function formatPercent(rate: number): string {
+  return `${(rate * 100).toFixed(2)}%`;
+}
+
+/**
+ * Panel summarising which trade-skill levels were applied to the margin
+ * calculation and the resulting effective fee rates.
+ */
+export function SkillsAppliedPanel({ skills }: SkillsAppliedPanelProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <GraduationCap className="size-4 text-muted-foreground" aria-hidden="true" />
+          Skills angewendet
+        </CardTitle>
+        <Badge variant={skills.applied ? "default" : "secondary"}>
+          {skills.applied ? "Aktiv" : "Standard"}
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+          <div>
+            <dt className="text-muted-foreground">Accounting</dt>
+            <dd className="font-medium">Level {skills.accounting}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Broker Relations</dt>
+            <dd className="font-medium">Level {skills.broker_relations}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Sales Tax</dt>
+            <dd className="font-medium">{formatPercent(skills.sales_tax_rate)}</dd>
+          </div>
+          <div>
+            <dt className="text-muted-foreground">Broker Fee</dt>
+            <dd className="font-medium">{formatPercent(skills.broker_fee_rate)}</dd>
+          </div>
+        </dl>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -4,7 +4,12 @@ import {
   CharacterShip,
   CharacterFittingResponse
 } from "@/types/character";
-import { Region, Ship } from "@/types/trading";
+import {
+  Region,
+  Ship,
+  ItemSearchResult,
+  HubComparisonResult,
+} from "@/types/trading";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:9001";
 
@@ -107,6 +112,58 @@ export async function fetchCharacterFitting(
 
   if (!response.ok) {
     throw new Error(`Failed to fetch character fitting: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+interface BackendItemSearchResponse {
+  items: ItemSearchResult[];
+  count?: number;
+}
+
+/**
+ * Search EVE items by name fragment (min 3 chars).
+ * @param q - search query
+ * @param limit - max results (default 20)
+ */
+export async function searchItems(
+  q: string,
+  limit = 20
+): Promise<ItemSearchResult[]> {
+  const params = new URLSearchParams({ q, limit: String(limit) });
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/items/search?${params.toString()}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to search items: ${response.statusText}`);
+  }
+
+  const data: BackendItemSearchResponse = await response.json();
+  return data.items || [];
+}
+
+/**
+ * Compare an item's station-trading profitability across the major hubs
+ * (requires authentication). Hubs are pre-sorted by net margin descending.
+ * @param typeId - EVE item type_id
+ */
+export async function compareHubs(
+  typeId: number
+): Promise<HubComparisonResult> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/trading/hubs/compare`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ type_id: typeId }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to compare hubs: ${response.statusText}`);
   }
 
   return response.json();

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -107,6 +107,46 @@ export interface ItemSearchResult {
   group_name: string;
 }
 
+// Multi-Hub Comparison (Issue #43)
+
+export interface CompetitionInfo {
+  changes_per_hour: number;
+  source: "live" | "baseline" | string;
+}
+
+export interface SkillsApplied {
+  applied: boolean;
+  accounting: number;
+  broker_relations: number;
+  sales_tax_rate: number;
+  broker_fee_rate: number;
+}
+
+export interface HubRow {
+  region_id: number;
+  region_name: string;
+  hub_name: string;
+  system_id: number;
+  tier: string;
+  has_data: boolean;
+  buy_price: number;
+  sell_price: number;
+  spread_percent: number;
+  net_margin_percent: number;
+  net_profit_per_unit: number;
+  daily_volume: number;
+  liquidity_score: number;
+  competition: CompetitionInfo;
+}
+
+export interface HubComparisonResult {
+  type_id: number;
+  item_name: string;
+  best_hub_region_id: number;
+  skills_applied: SkillsApplied;
+  hubs: HubRow[];
+}
+
 export interface InventorySellRequest {
   type_id: number;
   quantity: number;

--- a/frontend/tests/components/CompetitionIndicator.test.tsx
+++ b/frontend/tests/components/CompetitionIndicator.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CompetitionIndicator } from "@/components/trading/CompetitionIndicator";
+import { CompetitionInfo } from "@/types/trading";
+
+describe("CompetitionIndicator", () => {
+  it("shows the live label and rate for live-sourced data", () => {
+    const competition: CompetitionInfo = {
+      changes_per_hour: 42.5,
+      source: "live",
+    };
+
+    render(<CompetitionIndicator competition={competition} />);
+
+    expect(screen.getByText("Live")).toBeInTheDocument();
+    expect(screen.getByText("42.5/h")).toBeInTheDocument();
+    expect(screen.queryByText("Tages-Baseline")).not.toBeInTheDocument();
+  });
+
+  it("shows the baseline label for baseline-sourced data", () => {
+    const competition: CompetitionInfo = {
+      changes_per_hour: 3.2,
+      source: "baseline",
+    };
+
+    render(<CompetitionIndicator competition={competition} />);
+
+    expect(screen.getByText("Tages-Baseline")).toBeInTheDocument();
+    expect(screen.getByText("3.2/h")).toBeInTheDocument();
+    expect(screen.queryByText("Live")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/HubComparisonTable.test.tsx
+++ b/frontend/tests/components/HubComparisonTable.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { HubComparisonTable } from "@/components/trading/HubComparisonTable";
+import { HubComparisonResult, HubRow } from "@/types/trading";
+
+function makeHub(overrides: Partial<HubRow>): HubRow {
+  return {
+    region_id: 10000002,
+    region_name: "The Forge",
+    hub_name: "Jita",
+    system_id: 30000142,
+    tier: "primary",
+    has_data: true,
+    buy_price: 100,
+    sell_price: 110,
+    spread_percent: 10,
+    net_margin_percent: 3.4,
+    net_profit_per_unit: 4.1,
+    daily_volume: 125000,
+    liquidity_score: 72,
+    competition: { changes_per_hour: 42.5, source: "baseline" },
+    ...overrides,
+  };
+}
+
+const result: HubComparisonResult = {
+  type_id: 34,
+  item_name: "Tritanium",
+  best_hub_region_id: 10000032,
+  skills_applied: {
+    applied: true,
+    accounting: 5,
+    broker_relations: 5,
+    sales_tax_rate: 0.025,
+    broker_fee_rate: 0.015,
+  },
+  hubs: [
+    makeHub({
+      region_id: 10000032,
+      region_name: "Sinq Laison",
+      hub_name: "Dodixie",
+      net_margin_percent: 12.0,
+    }),
+    makeHub({
+      region_id: 10000002,
+      region_name: "The Forge",
+      hub_name: "Jita",
+      net_margin_percent: 3.4,
+    }),
+    makeHub({
+      region_id: 10000030,
+      region_name: "Heimatar",
+      hub_name: "Rens",
+      has_data: false,
+    }),
+  ],
+};
+
+describe("HubComparisonTable", () => {
+  it("renders a row for every hub including the item name", () => {
+    render(<HubComparisonTable result={result} />);
+
+    expect(screen.getByText(/Tritanium/)).toBeInTheDocument();
+    expect(screen.getByText("Dodixie")).toBeInTheDocument();
+    expect(screen.getByText("Jita")).toBeInTheDocument();
+    expect(screen.getByText("Rens")).toBeInTheDocument();
+    expect(screen.getAllByTestId("hub-row")).toHaveLength(3);
+  });
+
+  it("marks the recommended/best hub with the badge", () => {
+    render(<HubComparisonTable result={result} />);
+
+    const rows = screen.getAllByTestId("hub-row");
+    const bestRow = rows.find(
+      (r) => r.getAttribute("data-region-id") === "10000032"
+    );
+    const jitaRow = rows.find(
+      (r) => r.getAttribute("data-region-id") === "10000002"
+    );
+
+    expect(bestRow).toBeDefined();
+    expect(within(bestRow!).getByText("Empfohlen")).toBeInTheDocument();
+    expect(within(jitaRow!).queryByText("Empfohlen")).not.toBeInTheDocument();
+  });
+
+  it("renders a no-data placeholder for hubs without data", () => {
+    render(<HubComparisonTable result={result} />);
+
+    const rows = screen.getAllByTestId("hub-row");
+    const noDataRow = rows.find(
+      (r) => r.getAttribute("data-region-id") === "10000030"
+    );
+
+    expect(noDataRow).toBeDefined();
+    expect(
+      within(noDataRow!).getByText("Keine Daten verfügbar")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/e2e/auth/multi-hub.spec.ts
+++ b/frontend/tests/e2e/auth/multi-hub.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Multi-Hub Comparison workflow (Issue #43) — only operable when authenticated
+ * (the compare endpoint requires the session cookie; logged out, the search
+ * input is disabled by design). The auth project injects the captured session
+ * via storageState, so this spec runs against the real backend.
+ *
+ * Structure assertions only — live market values vary. The compare call hits a
+ * live market endpoint and can be slow, so timeouts are generous.
+ */
+test.describe('Authenticated multi-hub comparison', () => {
+  test('search an item, compare hubs, see table + recommended badge', async ({
+    page,
+  }) => {
+    // The compare endpoint runs a live multi-hub market lookup; give the whole
+    // workflow a wide envelope while per-step timeouts still catch a hang.
+    test.setTimeout(120_000);
+
+    await page.goto('/multi-hub');
+    await expect(page.locator('h1')).toContainText('Multi-Hub');
+
+    // Search a high-liquidity item that reliably exists across all hubs.
+    const search = page.getByLabel('Item suchen');
+    await expect(search).toBeEnabled({ timeout: 30000 });
+    await search.fill('Tritanium');
+
+    // Pick the matching suggestion from the listbox.
+    const suggestions = page.getByRole('listbox', { name: /Suchergebnisse/i });
+    await expect(suggestions).toBeVisible({ timeout: 30000 });
+    await suggestions
+      .getByRole('option', { name: /Tritanium/i })
+      .first()
+      .click();
+
+    // The compare table renders for the picked item.
+    const table = page.getByRole('table', { name: /Hub-Vergleich/i });
+    await expect(table).toBeVisible({ timeout: 60000 });
+    await expect(page.getByText(/Hub-Vergleich: Tritanium/i)).toBeVisible();
+
+    // The recommended-hub badge highlights the best hub.
+    await expect(page.getByText('Empfohlen').first()).toBeVisible();
+
+    // The skills-applied panel is shown alongside the table.
+    await expect(page.getByText('Skills angewendet')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #43.

## Was
Vergleicht für ein gewähltes Item die Station-Trading-Profitabilität über die 5 Major-Hubs (Jita, Amarr, Dodixie, Rens, Hek): Buy/Sell/Spread, skill-korrigierte Netto-Marge (Sales-Tax + Broker-Fee via Accounting/Broker Relations/Standings), Volumen und ein Konkurrenz-Indikator. Empfehlungs-Engine markiert den besten Hub. Backend, Web- und Flutter-Frontend, volle Testpyramide.

## Konkurrenz-Indikator (A+C)
- **C (Baseline):** sofort aus `price_history.order_count`/Tag — kein Cold-Start.
- **A (Live):** Hintergrund-Collector snapshottet lazy-getrackte `(type, region)`-Paare periodisch, leitet Order-Update-Frequenz (Changes/h) ab. `competition.source ∈ {live, baseline}`.

## Backend
- `POST /api/v1/trading/hubs/compare` → `MultiHubComparisonService` (reusable; #107 nutzt es wieder), Fee-Rate-Helper, `CompetitionRepository/Service/Collector`, `esi.FetchMarketOrdersForType`, Migration `000002` + Prod-`init-db`-Spiegelung.
- Hubs gegen SDE verifiziert (`v_trade_hubs`).

## Tests
- Backend: Unit (Churn, Fee-Rates, Ranking) + Integrationstest (Competition-Repo gegen echtes Postgres) — grün, gofmt/vet clean, govulncheck-Gate unverändert blockierend.
- Web: Vitest (38 pass) + Playwright authed E2E-Spec (`tests/e2e/auth/multi-hub.spec.ts`, gegen Live-Session zu verifizieren).
- Flutter: `flutter analyze` clean + `flutter test` (139 pass), inkl. Unit/Widget/E2E.

## Deploy-Hinweise
- Prod-Schema: `deployments/init-db/01-init.sql` um die Competition-Tabellen ergänzt (idempotent). **Manueller Schritt:** auf der bestehenden Prod-DB einmal via psql nachziehen (HETZNER-DEPLOY Step 5), da `init-db` nur bei Erst-Init läuft.
- Flutter: APK-Build + On-Device-Happy-Path auf dem Galaxy Tab gegen Prod ausstehend.

## Design
`docs/superpowers/specs/2026-05-28-multi-hub-comparison-design.md`