### PR TITLE
ci(deploy): build + push frontend image (same-origin prod web UI)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,13 @@ permissions:
 
 env:
   IMAGE: ghcr.io/sternrassler/eve-o-provit-backend
+  FRONTEND_IMAGE: ghcr.io/sternrassler/eve-o-provit-frontend
   APP_NAME: eveoprovit
+  # Public NEXT_PUBLIC_* values, baked into the frontend bundle at build time.
+  # Served same-origin as the API, so callback + cookies + CORS all resolve to one host.
+  PUBLIC_API_URL: https://eveonline.sternrassler.de
+  PUBLIC_CALLBACK_URL: https://eveonline.sternrassler.de/callback
+  PUBLIC_EVE_CLIENT_ID: 4d0514c205af4e898b0569badd59a38e
 
 jobs:
   build-push:
@@ -54,8 +60,42 @@ jobs:
           cache-from: type=gha,scope=eve-o-provit-backend
           cache-to: type=gha,scope=eve-o-provit-backend,mode=max
 
+  build-push-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.FRONTEND_IMAGE }}
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=latest
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: frontend
+          file: frontend/Dockerfile
+          push: true
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ env.PUBLIC_API_URL }}
+            NEXT_PUBLIC_EVE_CALLBACK_URL=${{ env.PUBLIC_CALLBACK_URL }}
+            NEXT_PUBLIC_EVE_CLIENT_ID=${{ env.PUBLIC_EVE_CLIENT_ID }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=eve-o-provit-frontend
+          cache-to: type=gha,scope=eve-o-provit-frontend,mode=max
+
   deploy:
-    needs: build-push
+    needs: [build-push, build-push-frontend]
     runs-on: ubuntu-latest
     steps:
       - name: SSH deploy to backend host


### PR DESCRIPTION
Adds frontend image build to the release pipeline so the Next.js web app can be served same-origin at https://eveonline.sternrassler.de (paired with the hetzner Caddy/compose change). `NEXT_PUBLIC_*` are public values baked at build time. Part of deploying the prod web frontend (#43 follow-up).