### PR TITLE
fix(multi-hub): recommend only profitable hubs + full ISK precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Multi-Hub Comparison (#43): recommend a hub only when its net margin is **positive**. For thin-margin commodities where every hub loses money after fees, no hub is starred and the UI shows a "kein profitabler Hub" hint instead of recommending the least-bad loss. Web table now renders prices with full ISK precision (2 decimals + separators) instead of rounding sub-1000 values to whole ISK.
+
 ## [0.9.1] - 2026-05-28
 
 ### Added

--- a/app/lib/features/trading/hub_comparison_screen.dart
+++ b/app/lib/features/trading/hub_comparison_screen.dart
@@ -305,6 +305,23 @@ class _HubDataTable extends StatelessWidget {
             style: Theme.of(context).textTheme.bodySmall,
           ),
           const SizedBox(height: 16),
+          if (response.hubs.any((h) => h.hasData) &&
+              response.bestHubRegionId == 0)
+            Container(
+              key: const Key('no-profit-hint'),
+              margin: const EdgeInsets.only(bottom: 12),
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.amber.withAlpha(30),
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: Colors.amber.withAlpha(120)),
+              ),
+              child: const Text(
+                'Kein profitabler Hub für dieses Item — nach Steuer und Broker-Fee '
+                'ist die Station-Trading-Marge an allen Hubs negativ. Der beste '
+                '(am wenigsten verlustreiche) Hub steht oben.',
+              ),
+            ),
           SingleChildScrollView(
             scrollDirection: Axis.horizontal,
             child: DataTable(

--- a/app/test/hub_comparison_screen_layout_test.dart
+++ b/app/test/hub_comparison_screen_layout_test.dart
@@ -69,6 +69,37 @@ HubComparisonResponse _fakeResponse() => const HubComparisonResponse(
       ],
     );
 
+HubComparisonResponse _noProfitResponse() => const HubComparisonResponse(
+      typeId: 34,
+      itemName: 'Tritanium',
+      bestHubRegionId: 0, // every hub loses money → no recommendation
+      skillsApplied: SkillsApplied(
+        applied: true,
+        accounting: 3,
+        brokerRelations: 2,
+        salesTaxRate: 0.035,
+        brokerFeeRate: 0.024,
+      ),
+      hubs: [
+        HubRow(
+          regionId: 10000030,
+          regionName: 'Heimatar',
+          hubName: 'Rens',
+          systemId: 30002510,
+          tier: 'secondary',
+          hasData: true,
+          buyPrice: 3,
+          sellPrice: 3,
+          spreadPercent: 3.6,
+          netMarginPercent: -4.8,
+          netProfitPerUnit: 0,
+          dailyVolume: 0,
+          liquidityScore: 0,
+          competition: CompetitionInfo(changesPerHour: 0, source: 'baseline'),
+        ),
+      ],
+    );
+
 class _FakeApi extends TradingApi {
   _FakeApi() : super(Dio());
 
@@ -81,6 +112,11 @@ class _FakeApi extends TradingApi {
 class _StubNotifier extends HubComparisonNotifier {
   @override
   Future<HubComparisonResponse?> build() async => _fakeResponse();
+}
+
+class _NoProfitNotifier extends HubComparisonNotifier {
+  @override
+  Future<HubComparisonResponse?> build() async => _noProfitResponse();
 }
 
 Future<void> _pumpScreen(
@@ -137,5 +173,30 @@ void main() {
     expect(find.text('keine Daten'), findsOneWidget);
     // Recommended hub (Dodixie) is highlighted with a star icon.
     expect(find.byIcon(Icons.star_rounded), findsOneWidget);
+  });
+
+  testWidgets('No profitable hub: shows hint, no recommendation star',
+      (tester) async {
+    tester.view.physicalSize = const Size(1280, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tradingApiProvider.overrideWithValue(_FakeApi()),
+          hubComparisonProvider.overrideWith(_NoProfitNotifier.new),
+        ],
+        child: MaterialApp(
+          theme: buildTheme(Brightness.light),
+          home: const HubComparisonScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('no-profit-hint')), findsOneWidget);
+    expect(find.byIcon(Icons.star_rounded), findsNothing);
   });
 }

--- a/backend/internal/services/multi_hub_service.go
+++ b/backend/internal/services/multi_hub_service.go
@@ -88,9 +88,12 @@ func (s *MultiHubComparisonService) CompareHubs(ctx context.Context, typeID, cha
 		return rows[i].NetMarginPercent > rows[j].NetMarginPercent
 	})
 
+	// Only recommend a hub that is actually profitable. Rows are sorted by net
+	// margin descending, so the first profitable row is the best one; if even the
+	// top hub loses money (e.g. thin-margin commodities), recommend nothing.
 	bestHubRegionID := 0
 	for _, r := range rows {
-		if r.HasData {
+		if r.HasData && r.NetMarginPercent > 0 {
 			bestHubRegionID = r.RegionID
 			break
 		}

--- a/backend/internal/services/multi_hub_service_test.go
+++ b/backend/internal/services/multi_hub_service_test.go
@@ -96,3 +96,28 @@ func TestCompareHubs_RanksByNetMargin(t *testing.T) {
 		t.Errorf("skills applied = %+v", res.SkillsApplied)
 	}
 }
+
+func TestCompareHubs_NoProfitableHub_RecommendsNothing(t *testing.T) {
+	const jita = 10000002
+	// Thin commodity: buy ≈ sell, fees push every hub negative.
+	market := fakeMarket{byRegion: map[int][]esi.ESIMarketOrder{
+		jita:     {buy(100), sell(101)},
+		10000032: {buy(100), sell(100.5)},
+	}}
+	svc := NewMultiHubComparisonService(
+		fakeSkills{&TradingSkills{Accounting: 3, BrokerRelations: 2}},
+		market, fakeVolume{}, &fakeCompetition{}, fakeTypes{}, applogger.New(),
+	)
+	res, err := svc.CompareHubs(context.Background(), 34, 123, "token")
+	if err != nil {
+		t.Fatalf("CompareHubs error: %v", err)
+	}
+	// All hubs lose money → no recommendation.
+	if res.BestHubRegionID != 0 {
+		t.Errorf("best hub = %d, want 0 (no profitable hub)", res.BestHubRegionID)
+	}
+	// Sanity: the rows with data do have negative margins.
+	if res.Hubs[0].HasData && res.Hubs[0].NetMarginPercent > 0 {
+		t.Errorf("expected non-positive top margin, got %v", res.Hubs[0].NetMarginPercent)
+	}
+}

--- a/frontend/src/components/trading/HubComparisonTable.tsx
+++ b/frontend/src/components/trading/HubComparisonTable.tsx
@@ -3,7 +3,7 @@
 import { HubComparisonResult, HubRow } from "@/types/trading";
 import {
   cn,
-  formatISK,
+  formatISKWithSeparators,
   getSpreadColor,
   getProfitColor,
 } from "@/lib/utils";
@@ -21,6 +21,8 @@ interface HubComparisonTableProps {
  * no-data hubs last. The recommended (best) hub is highlighted.
  */
 export function HubComparisonTable({ result }: HubComparisonTableProps) {
+  const hasData = result.hubs.some((h) => h.has_data);
+  const noProfitableHub = hasData && !result.best_hub_region_id;
   return (
     <Card>
       <CardHeader>
@@ -29,6 +31,16 @@ export function HubComparisonTable({ result }: HubComparisonTableProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="p-0">
+        {noProfitableHub && (
+          <div
+            data-testid="no-profit-hint"
+            className="mx-4 mt-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
+          >
+            Kein profitabler Hub für dieses Item — nach Steuer und Broker-Fee ist die
+            Station-Trading-Marge an allen Hubs negativ. Der beste (am wenigsten
+            verlustreiche) Hub steht oben.
+          </div>
+        )}
         <div className="overflow-x-auto">
           <table className="w-full text-sm" aria-label="Hub-Vergleich">
             <thead>
@@ -103,10 +115,10 @@ function HubRowItem({
         </div>
       </td>
       <td className="px-4 py-3 text-right font-medium">
-        {formatISK(hub.buy_price)}
+        {formatISKWithSeparators(hub.buy_price)}
       </td>
       <td className="px-4 py-3 text-right font-medium">
-        {formatISK(hub.sell_price)}
+        {formatISKWithSeparators(hub.sell_price)}
       </td>
       <td
         className={cn(
@@ -125,7 +137,7 @@ function HubRowItem({
         {hub.net_margin_percent.toFixed(1)}%
       </td>
       <td className="px-4 py-3 text-right font-medium">
-        {formatISK(hub.net_profit_per_unit)}
+        {formatISKWithSeparators(hub.net_profit_per_unit)}
       </td>
       <td className="px-4 py-3 text-right">
         {hub.daily_volume.toLocaleString("de-DE")}

--- a/frontend/tests/components/HubComparisonTable.test.tsx
+++ b/frontend/tests/components/HubComparisonTable.test.tsx
@@ -96,4 +96,31 @@ describe("HubComparisonTable", () => {
       within(noDataRow!).getByText("Keine Daten verfügbar")
     ).toBeInTheDocument();
   });
+
+  it("shows the no-profitable-hub hint and no badge when best_hub_region_id is 0", () => {
+    const noProfit: HubComparisonResult = {
+      ...result,
+      best_hub_region_id: 0,
+      hubs: [
+        makeHub({ hub_name: "Rens", region_id: 10000030, net_margin_percent: -4.8 }),
+        makeHub({ hub_name: "Jita", region_id: 10000002, net_margin_percent: -32.5 }),
+      ],
+    };
+    render(<HubComparisonTable result={noProfit} />);
+
+    expect(screen.getByTestId("no-profit-hint")).toBeInTheDocument();
+    expect(screen.queryByText("Empfohlen")).not.toBeInTheDocument();
+  });
+
+  it("renders prices with full ISK precision (2 decimals), not compact", () => {
+    const lowValue: HubComparisonResult = {
+      ...result,
+      best_hub_region_id: 0,
+      hubs: [makeHub({ buy_price: 3.45, sell_price: 3.52, net_profit_per_unit: -0.18 })],
+    };
+    render(<HubComparisonTable result={lowValue} />);
+
+    expect(screen.getByText("3,45 ISK")).toBeInTheDocument();
+    expect(screen.getByText("3,52 ISK")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Follow-up to #43 from real prod use.

- **Recommendation only when profitable:** `best_hub_region_id` is set only if the top hub's net margin > 0. For thin-margin commodities (e.g. Tritanium) where every hub loses money after sales tax + broker fee, nothing is starred and the UI shows a "kein profitabler Hub" hint.
- **Full ISK precision (web):** prices show 2 decimals + separators instead of rounding sub-1000 values to whole ISK (was showing "3 ISK" / "-0 ISK").

Tests: backend no-profitable-hub case, web hint + precision, flutter hint. All suites green (backend, web 40, flutter 140).