### PR TITLE
fix(volume): populate market history + correct prod table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Market history / daily volume + competition baseline were always 0 in production. Two causes: (1) `FetchAndStoreMarketHistory` was never called, so `price_history` was never populated — `GetVolumeMetrics` now lazy-populates from ESI on a cold (type, region) and re-reads; (2) the prod `init-db` created the table as `market_history`, but the backend queries `price_history` — `init-db` corrected to `price_history` (matching migration 000001) and the dead empty `market_history` dropped. Multi-Hub: volume is fetched before the competition baseline so the baseline reads freshly-populated history.
+
 ## [0.9.2] - 2026-05-28
 
 ### Changed

--- a/backend/internal/services/multi_hub_service.go
+++ b/backend/internal/services/multi_hub_service.go
@@ -117,13 +117,21 @@ func (s *MultiHubComparisonService) CompareHubs(ctx context.Context, typeID, cha
 // buildRow computes one hub's comparison row.
 func (s *MultiHubComparisonService) buildRow(ctx context.Context, typeID int, hub Hub, salesTaxRate, brokerFeeRate float64) models.HubRow {
 	row := models.HubRow{
-		RegionID:    hub.RegionID,
-		RegionName:  hub.RegionName,
-		HubName:     hub.Name,
-		SystemID:    hub.SystemID,
-		Tier:        hub.Tier,
-		Competition: s.competition.GetCompetition(ctx, typeID, hub.RegionID),
+		RegionID:   hub.RegionID,
+		RegionName: hub.RegionName,
+		HubName:    hub.Name,
+		SystemID:   hub.SystemID,
+		Tier:       hub.Tier,
 	}
+
+	// Volume first: GetVolumeMetrics lazy-populates price_history, which the
+	// competition baseline then reads. Both are set even for hubs without current
+	// orders.
+	if vm, err := s.volume.GetVolumeMetrics(ctx, typeID, hub.RegionID); err == nil && vm != nil {
+		row.DailyVolume = vm.DailyVolumeAvg
+		row.LiquidityScore = vm.LiquidityScore
+	}
+	row.Competition = s.competition.GetCompetition(ctx, typeID, hub.RegionID)
 
 	orders, err := s.market.FetchMarketOrdersForType(ctx, hub.RegionID, typeID)
 	if err != nil {
@@ -149,11 +157,6 @@ func (s *MultiHubComparisonService) buildRow(ctx context.Context, typeID int, hu
 	row.NetProfitPerUnit = sellRevenue - buyCost
 	if buyCost > 0 {
 		row.NetMarginPercent = row.NetProfitPerUnit / buyCost * 100
-	}
-
-	if vm, err := s.volume.GetVolumeMetrics(ctx, typeID, hub.RegionID); err == nil && vm != nil {
-		row.DailyVolume = vm.DailyVolumeAvg
-		row.LiquidityScore = vm.LiquidityScore
 	}
 
 	return row

--- a/backend/internal/services/volume_service.go
+++ b/backend/internal/services/volume_service.go
@@ -102,6 +102,15 @@ func (vs *VolumeService) GetVolumeMetrics(ctx context.Context, typeID, regionID 
 		return nil, fmt.Errorf("failed to get volume history: %w", err)
 	}
 
+	// Lazy-populate: market history is never pre-synced, so on a cold (type, region)
+	// pull it from ESI once and re-read. Best-effort — items/regions with no ESI
+	// history fall through to zero metrics. Once stored, later calls hit the DB.
+	if len(history) == 0 {
+		if ferr := vs.FetchAndStoreMarketHistory(ctx, typeID, regionID); ferr == nil {
+			history, _ = vs.marketRepo.GetVolumeHistory(ctx, typeID, regionID, lookbackDays)
+		}
+	}
+
 	if len(history) == 0 {
 		// No historical data available - return zero metrics
 		return &models.VolumeMetrics{

--- a/backend/internal/services/volume_service_test.go
+++ b/backend/internal/services/volume_service_test.go
@@ -95,8 +95,11 @@ func TestGetVolumeMetrics_NoData(t *testing.T) {
 	typeID := 34
 	regionID := 10000002
 
-	// Mock: No historical data
+	// Mock: No historical data — GetVolumeMetrics then lazy-fetches from ESI, which
+	// also returns nothing, so metrics stay zero. (GetVolumeHistory is read twice:
+	// initial + post-fetch re-read.)
 	mockRepo.On("GetVolumeHistory", ctx, typeID, regionID, 30).Return([]database.PriceHistory{}, nil)
+	mockESI.On("FetchMarketHistory", ctx, regionID, typeID).Return([]esi.PriceHistoryEntry{}, nil)
 
 	metrics, err := vs.GetVolumeMetrics(ctx, typeID, regionID)
 
@@ -110,6 +113,39 @@ func TestGetVolumeMetrics_NoData(t *testing.T) {
 	assert.Equal(t, 0, metrics.DataDays)
 
 	mockRepo.AssertExpectations(t)
+	mockESI.AssertExpectations(t)
+}
+
+func TestGetVolumeMetrics_LazyPopulatesThenReads(t *testing.T) {
+	mockRepo := new(MockMarketRepository)
+	mockESI := new(MockESIClient)
+	vs := NewVolumeService(mockRepo, mockESI)
+
+	ctx := context.Background()
+	typeID := 34
+	regionID := 10000002
+	vol := int64(1000)
+	avg := 5.5
+	oc := 200
+
+	// First read: empty → triggers ESI fetch + store → second read returns data.
+	empty := []database.PriceHistory{}
+	populated := []database.PriceHistory{
+		{TypeID: typeID, RegionID: regionID, Date: time.Now(), Volume: &vol, Average: &avg, OrderCount: &oc},
+	}
+	mockRepo.On("GetVolumeHistory", ctx, typeID, regionID, 30).Return(empty, nil).Once()
+	mockESI.On("FetchMarketHistory", ctx, regionID, typeID).
+		Return([]esi.PriceHistoryEntry{{Date: time.Now(), Volume: &vol, Average: &avg, OrderCount: &oc}}, nil)
+	mockRepo.On("UpsertPriceHistory", ctx, mock.Anything).Return(nil)
+	mockRepo.On("GetVolumeHistory", ctx, typeID, regionID, 30).Return(populated, nil).Once()
+
+	metrics, err := vs.GetVolumeMetrics(ctx, typeID, regionID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1000.0, metrics.DailyVolumeAvg)
+	assert.Equal(t, 1, metrics.DataDays)
+	mockRepo.AssertExpectations(t)
+	mockESI.AssertExpectations(t)
 }
 
 func TestGetVolumeMetrics_WithData(t *testing.T) {

--- a/deployments/init-db/01-init.sql
+++ b/deployments/init-db/01-init.sql
@@ -39,21 +39,24 @@ CREATE INDEX idx_market_orders_type_region ON market_orders(type_id, region_id);
 CREATE INDEX idx_market_orders_is_buy ON market_orders(is_buy_order);
 CREATE INDEX idx_market_orders_cached ON market_orders(cached_at);
 
--- Market History (aggregated)
-CREATE TABLE IF NOT EXISTS market_history (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    type_id INT NOT NULL,
-    region_id INT NOT NULL,
+-- Price/Market History (aggregated). Table name MUST be price_history — that is
+-- what the backend (MarketRepository.UpsertPriceHistory/GetVolumeHistory) and the
+-- golang-migrate migration 000001 use. (A historical init-db named it market_history,
+-- which the code never queried → volume/baseline silently returned 0 in prod.)
+CREATE TABLE IF NOT EXISTS price_history (
+    id SERIAL PRIMARY KEY,
+    type_id INTEGER NOT NULL,
+    region_id INTEGER NOT NULL,
     date DATE NOT NULL,
-    average NUMERIC(20, 2),
-    highest NUMERIC(20, 2),
-    lowest NUMERIC(20, 2),
+    highest DECIMAL(19, 2),
+    lowest DECIMAL(19, 2),
+    average DECIMAL(19, 2),
     volume BIGINT,
-    order_count INT,
+    order_count INTEGER,
     UNIQUE(type_id, region_id, date)
 );
 
-CREATE INDEX idx_market_history_type_region_date ON market_history(type_id, region_id, date DESC);
+CREATE INDEX IF NOT EXISTS idx_price_history_lookup ON price_history(type_id, region_id, date DESC);
 
 -- User Watchlists
 CREATE TABLE IF NOT EXISTS watchlists (
@@ -132,7 +135,7 @@ CREATE TABLE IF NOT EXISTS competition_metric (
 -- Comments
 COMMENT ON TABLE users IS 'User accounts for EVE-O-Provit';
 COMMENT ON TABLE market_orders IS 'Cached market orders from ESI API';
-COMMENT ON TABLE market_history IS 'Historical market data for trend analysis';
+COMMENT ON TABLE price_history IS 'Aggregated historical market data (volume/order_count) from ESI';
 COMMENT ON TABLE watchlists IS 'User-defined item watchlists';
 COMMENT ON TABLE profit_calculations IS 'Cached profit margin calculations';
 


### PR DESCRIPTION
Daily volume (Tagesvolumen) + competition baseline showed 0 in prod for everything. Two root causes:

1. **`price_history` was never populated** — `FetchAndStoreMarketHistory` existed but had no caller. `GetVolumeMetrics` now lazy-populates from ESI on a cold (type, region) and re-reads (self-healing, bounded by the DB once stored).
2. **Schema-name drift** — prod `init-db/01-init.sql` created the table as `market_history`, but the backend + migration 000001 use `price_history`. So the code queried a table that didn't exist in prod. init-db corrected to `price_history`; the dead empty `market_history` dropped in prod.

Multi-Hub: volume is now fetched before the competition baseline so the baseline reads freshly-populated history. Prod DB already migrated (price_history created, market_history dropped); this ships the code that fills it. Tests added for both lazy-fetch paths.