### PR TITLE
feat: ROI Calculator & Capital Allocation Optimizer (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ROI Calculator & Capital Allocation Optimizer (#44):** `POST /api/v1/trading/portfolio/optimize` — given region, ship, capital and a daily time budget, suggests how to allocate capital across items for maximum expected daily profit. Greedy allocator (most-efficient profit/ISK first) over the existing route-engine candidates, under per-item liquidity and capital caps; returns per-item allocation (capital, units, trips/day, daily profit, ROI%), totals and a Herfindahl-based diversification score. Sec-zone filter applied to candidate routes; skills applied to all figures.
+
 ## [0.9.4] - 2026-05-28
 
 ### Changed

--- a/app/lib/api/portfolio_models.dart
+++ b/app/lib/api/portfolio_models.dart
@@ -1,0 +1,180 @@
+/// Portfolio Optimizer DTOs — field names map exactly to the backend json
+/// tags for POST /api/v1/trading/portfolio/optimize.
+///
+/// CRITICAL: parsing is null/float-robust (mirrors hub_comparison_models.dart /
+/// trading_models.dart). Every numeric field tolerates absent/null values and
+/// accepts any [num] (int or double). A past production bug was caused by
+/// non-robust mobile DTO parsing.
+library;
+
+import 'hub_comparison_models.dart' show SkillsApplied;
+
+export 'hub_comparison_models.dart' show SkillsApplied;
+
+// ---------------------------------------------------------------------------
+// PortfolioRequest
+// ---------------------------------------------------------------------------
+
+/// Request body for POST /api/v1/trading/portfolio/optimize.
+///
+/// Mirrors the backend request struct exactly (snake_case json tags). The
+/// [secZones] list contains any of "high" | "low" | "null".
+class PortfolioRequest {
+  const PortfolioRequest({
+    required this.regionId,
+    required this.shipTypeId,
+    required this.capital,
+    required this.timeBudgetMin,
+    required this.liquidityCapPct,
+    required this.maxItemPct,
+    required this.secZones,
+  });
+
+  /// Backend: `region_id`
+  final int regionId;
+
+  /// Backend: `ship_type_id`
+  final int shipTypeId;
+
+  /// Backend: `capital` — total ISK available to allocate.
+  final double capital;
+
+  /// Backend: `time_budget_min` — available trading time per day, in minutes.
+  final int timeBudgetMin;
+
+  /// Backend: `liquidity_cap_pct` — max % of an item's daily volume to consume.
+  final double liquidityCapPct;
+
+  /// Backend: `max_item_pct` — max % of total capital allocated to one item.
+  final double maxItemPct;
+
+  /// Backend: `sec_zones` — security zones to include ("high"|"low"|"null").
+  final List<String> secZones;
+
+  Map<String, dynamic> toJson() => {
+        'region_id': regionId,
+        'ship_type_id': shipTypeId,
+        'capital': capital,
+        'time_budget_min': timeBudgetMin,
+        'liquidity_cap_pct': liquidityCapPct,
+        'max_item_pct': maxItemPct,
+        'sec_zones': secZones,
+      };
+}
+
+// ---------------------------------------------------------------------------
+// PortfolioItem
+// ---------------------------------------------------------------------------
+
+/// A single allocated item in the suggested portfolio.
+/// Backend: an element of the `items` array.
+class PortfolioItem {
+  const PortfolioItem({
+    required this.typeId,
+    required this.name,
+    required this.capitalUsed,
+    required this.units,
+    required this.tripsPerDay,
+    required this.dailyProfit,
+    required this.roiPercent,
+  });
+
+  /// Backend: `type_id`
+  final int typeId;
+
+  /// Backend: `name`
+  final String name;
+
+  /// Backend: `capital_used` — ISK allocated to this item.
+  final double capitalUsed;
+
+  /// Backend: `units` — number of units to trade.
+  final double units;
+
+  /// Backend: `trips_per_day` — round trips per day for this item.
+  final double tripsPerDay;
+
+  /// Backend: `daily_profit` — ISK profit per day from this item.
+  final double dailyProfit;
+
+  /// Backend: `roi_percent` — return on invested capital, in percent.
+  final double roiPercent;
+
+  factory PortfolioItem.fromJson(Map<String, dynamic> json) {
+    return PortfolioItem(
+      typeId: (json['type_id'] as num?)?.toInt() ?? 0,
+      name: json['name'] as String? ?? '',
+      capitalUsed: (json['capital_used'] as num?)?.toDouble() ?? 0,
+      units: (json['units'] as num?)?.toDouble() ?? 0,
+      tripsPerDay: (json['trips_per_day'] as num?)?.toDouble() ?? 0,
+      dailyProfit: (json['daily_profit'] as num?)?.toDouble() ?? 0,
+      roiPercent: (json['roi_percent'] as num?)?.toDouble() ?? 0,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PortfolioResult
+// ---------------------------------------------------------------------------
+
+/// Response from POST /api/v1/trading/portfolio/optimize.
+///
+/// [items] is pre-sorted by the backend. An empty [items] list is a valid,
+/// successful result meaning "no viable portfolio for this budget" — it is NOT
+/// an error.
+class PortfolioResult {
+  const PortfolioResult({
+    required this.items,
+    required this.totalCapitalUsed,
+    required this.totalDailyProfit,
+    required this.timeUsedMin,
+    required this.diversificationScore,
+    required this.skillsApplied,
+  });
+
+  /// Backend: `items` — pre-sorted allocation rows.
+  final List<PortfolioItem> items;
+
+  /// Backend: `total_capital_used`
+  final double totalCapitalUsed;
+
+  /// Backend: `total_daily_profit`
+  final double totalDailyProfit;
+
+  /// Backend: `time_used_min` — minutes of the time budget actually used.
+  final double timeUsedMin;
+
+  /// Backend: `diversification_score` — 0-100.
+  final double diversificationScore;
+
+  /// Backend: `skills_applied`
+  final SkillsApplied skillsApplied;
+
+  /// True when the optimizer found no viable allocation.
+  bool get isEmpty => items.isEmpty;
+
+  factory PortfolioResult.fromJson(Map<String, dynamic> json) {
+    final rawItems = json['items'] as List<dynamic>? ?? const [];
+    final skillsRaw = json['skills_applied'];
+    return PortfolioResult(
+      items: rawItems
+          .whereType<Map<String, dynamic>>()
+          .map(PortfolioItem.fromJson)
+          .toList(),
+      totalCapitalUsed: (json['total_capital_used'] as num?)?.toDouble() ?? 0,
+      totalDailyProfit: (json['total_daily_profit'] as num?)?.toDouble() ?? 0,
+      timeUsedMin: (json['time_used_min'] as num?)?.toDouble() ?? 0,
+      diversificationScore:
+          (json['diversification_score'] as num?)?.toDouble() ?? 0,
+      skillsApplied: skillsRaw is Map<String, dynamic>
+          ? SkillsApplied.fromJson(skillsRaw)
+          : const SkillsApplied(
+              applied: false,
+              accounting: 0,
+              brokerRelations: 0,
+              salesTaxRate: 0,
+              brokerFeeRate: 0,
+            ),
+    );
+  }
+}

--- a/app/lib/api/trading_api.dart
+++ b/app/lib/api/trading_api.dart
@@ -8,6 +8,7 @@ library;
 import 'package:dio/dio.dart';
 
 import 'hub_comparison_models.dart';
+import 'portfolio_models.dart';
 import 'trading_models.dart';
 
 class TradingApi {
@@ -37,6 +38,19 @@ class TradingApi {
       data: {'type_id': typeId},
     );
     return HubComparisonResponse.fromJson(response.data!);
+  }
+
+  // ── POST /api/v1/trading/portfolio/optimize ───────────────────────────────
+
+  /// Optimizes a capital allocation across items to maximize daily profit.
+  /// Returns a [PortfolioResult] with pre-sorted allocation rows; an empty
+  /// `items` list means no viable portfolio for the given budget.
+  Future<PortfolioResult> optimizePortfolio(PortfolioRequest request) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/api/v1/trading/portfolio/optimize',
+      data: request.toJson(),
+    );
+    return PortfolioResult.fromJson(response.data!);
   }
 
   // ── POST /api/v1/trading/routes/calculate ──────────────────────────────────

--- a/app/lib/core/router.dart
+++ b/app/lib/core/router.dart
@@ -21,6 +21,7 @@ import '../auth/auth_controller.dart';
 import '../auth/login_screen.dart';
 import '../features/character/character_screen.dart';
 import '../features/trading/hub_comparison_screen.dart';
+import '../features/trading/roi_calculator_screen.dart';
 import '../features/trading/trading_screen.dart';
 
 // ---------------------------------------------------------------------------
@@ -96,6 +97,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             builder: (context, state) => const HubComparisonScreen(),
           ),
           GoRoute(
+            path: '/roi-calculator',
+            builder: (context, state) => const RoiCalculatorScreen(),
+          ),
+          GoRoute(
             path: '/character',
             builder: (context, state) => const CharacterScreen(),
           ),
@@ -128,6 +133,10 @@ class _AppShell extends ConsumerWidget {
       label: 'Hub-Vergleich',
     ),
     NavigationDestination(
+      icon: Icon(Icons.auto_graph_rounded),
+      label: 'ROI',
+    ),
+    NavigationDestination(
       icon: Icon(Icons.person_outline_rounded),
       selectedIcon: Icon(Icons.person_rounded),
       label: 'Character',
@@ -140,7 +149,8 @@ class _AppShell extends ConsumerWidget {
 
   int get _selectedIndex {
     if (location.startsWith('/hub-comparison')) return 1;
-    if (location.startsWith('/character')) return 2;
+    if (location.startsWith('/roi-calculator')) return 2;
+    if (location.startsWith('/character')) return 3;
     return 0; // /trading is default; "Abmelden" is never a selected state
   }
 
@@ -157,8 +167,10 @@ class _AppShell extends ConsumerWidget {
             case 1:
               context.go('/hub-comparison');
             case 2:
-              context.go('/character');
+              context.go('/roi-calculator');
             case 3:
+              context.go('/character');
+            case 4:
               _confirmLogout(context, ref);
           }
         },

--- a/app/lib/features/trading/roi_calculator_screen.dart
+++ b/app/lib/features/trading/roi_calculator_screen.dart
@@ -1,0 +1,625 @@
+/// Adaptive ROI Calculator & Capital Allocation Optimizer screen.
+///
+/// The user picks a Region + Ship and enters their available Capital (ISK),
+/// trading Time per day (minutes), a Liquidity-Cap %, a Max % of capital per
+/// item and the security zones to include. The backend then suggests a capital
+/// allocation across items (a portfolio) that maximizes daily profit, plus a
+/// diversification score.
+///
+/// Layout (via [isTwoPane] / [kTwoPaneBreakpoint] = 840 dp):
+///   • <840 dp  → single-pane: input form above a scrollable result table.
+///   • ≥840 dp  → two-pane: input form on the left, result on the right.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/portfolio_models.dart';
+import '../../api/trading_models.dart';
+import '../../core/breakpoint.dart';
+import 'providers.dart';
+import 'roi_providers.dart';
+import 'ship_select.dart';
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// The ROI Calculator screen.
+class RoiCalculatorScreen extends ConsumerWidget {
+  const RoiCalculatorScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ROI-Rechner'),
+        centerTitle: false,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final twoPane = isTwoPane(constraints.maxWidth);
+          if (twoPane) {
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: const [
+                SizedBox(
+                  width: 340,
+                  child: SingleChildScrollView(
+                    padding: EdgeInsets.all(16),
+                    child: _InputForm(),
+                  ),
+                ),
+                VerticalDivider(width: 1),
+                Expanded(child: _ResultPane()),
+              ],
+            );
+          }
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: const [
+              Flexible(
+                child: SingleChildScrollView(
+                  padding: EdgeInsets.all(16),
+                  child: _InputForm(),
+                ),
+              ),
+              Divider(height: 1),
+              Expanded(child: _ResultPane()),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input form — region/ship pickers + numeric inputs + sec-zone toggles
+// ---------------------------------------------------------------------------
+
+class _InputForm extends ConsumerStatefulWidget {
+  const _InputForm();
+
+  @override
+  ConsumerState<_InputForm> createState() => _InputFormState();
+}
+
+class _InputFormState extends ConsumerState<_InputForm> {
+  // Numeric inputs.
+  final _capitalController = TextEditingController(text: '500000000');
+  double _timeBudgetMin = 120;
+  double _liquidityCapPct = 10;
+  double _maxItemPct = 30;
+
+  // Sec-zone toggles (default: high only — mirrors the trading filter default).
+  bool _highSec = true;
+  bool _lowSec = false;
+  bool _nullSec = false;
+
+  String? _error;
+
+  @override
+  void dispose() {
+    _capitalController.dispose();
+    super.dispose();
+  }
+
+  List<String> get _secZones => [
+        if (_highSec) 'high',
+        if (_lowSec) 'low',
+        if (_nullSec) 'null',
+      ];
+
+  Future<void> _optimize() async {
+    final region = ref.read(selectedRegionProvider);
+    final shipTypeId = ref.read(selectedShipTypeIdProvider);
+    final capital =
+        double.tryParse(_capitalController.text.replaceAll(RegExp(r'[^0-9.]'), ''));
+
+    if (region == null) {
+      setState(() => _error = 'Bitte eine Region auswählen.');
+      return;
+    }
+    if (shipTypeId == null) {
+      setState(() => _error = 'Bitte ein Schiff auswählen.');
+      return;
+    }
+    if (capital == null || capital <= 0) {
+      setState(() => _error = 'Bitte ein gültiges Kapital eingeben.');
+      return;
+    }
+    if (_secZones.isEmpty) {
+      setState(() => _error = 'Mindestens eine Sicherheitszone wählen.');
+      return;
+    }
+
+    setState(() => _error = null);
+
+    final request = PortfolioRequest(
+      regionId: region.id,
+      shipTypeId: shipTypeId,
+      capital: capital,
+      timeBudgetMin: _timeBudgetMin.round(),
+      liquidityCapPct: _liquidityCapPct,
+      maxItemPct: _maxItemPct,
+      secZones: _secZones,
+    );
+
+    await ref.read(roiOptimizeProvider.notifier).optimize(request);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final regionsAsync = ref.watch(regionsProvider);
+    final selectedRegion = ref.watch(selectedRegionProvider);
+    final busy = ref.watch(roiOptimizeProvider).isLoading;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // ── Region ─────────────────────────────────────────────────────────
+        regionsAsync.when(
+          loading: () => const LinearProgressIndicator(),
+          error: (err, _) => const Text('Regionen nicht verfügbar'),
+          data: (regions) => DropdownButtonFormField<Region>(
+            initialValue:
+                regions.contains(selectedRegion) ? selectedRegion : null,
+            isExpanded: true,
+            decoration: const InputDecoration(
+              labelText: 'Region',
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding:
+                  EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            ),
+            hint: const Text('Region wählen…'),
+            items: regions
+                .map(
+                  (r) => DropdownMenuItem(
+                    value: r,
+                    child: Text(r.name, overflow: TextOverflow.ellipsis),
+                  ),
+                )
+                .toList(),
+            onChanged: busy
+                ? null
+                : (r) =>
+                    ref.read(selectedRegionProvider.notifier).select(r),
+          ),
+        ),
+        const SizedBox(height: 12),
+
+        // ── Ship ───────────────────────────────────────────────────────────
+        ShipSelect(enabled: !busy),
+        const SizedBox(height: 12),
+
+        // ── Capital ────────────────────────────────────────────────────────
+        TextField(
+          controller: _capitalController,
+          enabled: !busy,
+          keyboardType: TextInputType.number,
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          decoration: const InputDecoration(
+            labelText: 'Kapital',
+            border: OutlineInputBorder(),
+            isDense: true,
+            suffixText: 'ISK',
+            contentPadding:
+                EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          ),
+        ),
+        const SizedBox(height: 16),
+
+        // ── Time budget ────────────────────────────────────────────────────
+        _SliderRow(
+          label: 'Zeit/Tag',
+          valueLabel: '${_timeBudgetMin.round()} min',
+        ),
+        Slider(
+          value: _timeBudgetMin,
+          min: 15,
+          max: 480,
+          divisions: 31,
+          label: '${_timeBudgetMin.round()} min',
+          onChanged:
+              busy ? null : (v) => setState(() => _timeBudgetMin = v),
+        ),
+
+        // ── Liquidity cap ──────────────────────────────────────────────────
+        _SliderRow(
+          label: 'Liquiditäts-Cap',
+          valueLabel: '${_liquidityCapPct.round()}%',
+        ),
+        Slider(
+          value: _liquidityCapPct,
+          min: 1,
+          max: 100,
+          divisions: 99,
+          label: '${_liquidityCapPct.round()}%',
+          onChanged:
+              busy ? null : (v) => setState(() => _liquidityCapPct = v),
+        ),
+
+        // ── Max % per item ─────────────────────────────────────────────────
+        _SliderRow(
+          label: 'Max. % / Item',
+          valueLabel: '${_maxItemPct.round()}%',
+        ),
+        Slider(
+          value: _maxItemPct,
+          min: 1,
+          max: 100,
+          divisions: 99,
+          label: '${_maxItemPct.round()}%',
+          onChanged: busy ? null : (v) => setState(() => _maxItemPct = v),
+        ),
+
+        const SizedBox(height: 8),
+
+        // ── Sec zones ──────────────────────────────────────────────────────
+        const Text(
+          'Sicherheitszonen',
+          style: TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+        ),
+        const SizedBox(height: 4),
+        _SecCheckbox(
+          label: 'High Sec (≥ 0.5)',
+          value: _highSec,
+          enabled: !busy,
+          onChanged: (v) => setState(() => _highSec = v),
+        ),
+        _SecCheckbox(
+          label: 'Low Sec (< 0.5)',
+          value: _lowSec,
+          enabled: !busy,
+          activeColor: const Color(0xFFFF9800),
+          onChanged: (v) => setState(() => _lowSec = v),
+        ),
+        _SecCheckbox(
+          label: 'Null Sec (≤ 0.0)',
+          value: _nullSec,
+          enabled: !busy,
+          activeColor: const Color(0xFFF44336),
+          onChanged: (v) => setState(() => _nullSec = v),
+        ),
+
+        if (_error != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            _error!,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ],
+
+        const SizedBox(height: 16),
+
+        // ── Optimize button ────────────────────────────────────────────────
+        FilledButton.icon(
+          onPressed: busy ? null : _optimize,
+          icon: busy
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.auto_graph_rounded),
+          label: const Text('Optimieren'),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result pane — async-aware
+// ---------------------------------------------------------------------------
+
+class _ResultPane extends ConsumerWidget {
+  const _ResultPane();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(roiOptimizeProvider);
+
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (err, _) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Optimierung fehlgeschlagen.\n$err',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ),
+      ),
+      data: (result) {
+        if (result == null) {
+          return const _IdleHint();
+        }
+        if (result.isEmpty) {
+          return const _EmptyResult();
+        }
+        return _PortfolioTable(result: result);
+      },
+    );
+  }
+}
+
+class _IdleHint extends StatelessWidget {
+  const _IdleHint();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.auto_graph_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Parameter wählen und optimieren',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(120),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyResult extends StatelessWidget {
+  const _EmptyResult();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          key: const Key('roi-empty-state'),
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sentiment_dissatisfied_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Kein sinnvolles Portfolio für dieses Budget',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(140),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Portfolio table + totals + diversification
+// ---------------------------------------------------------------------------
+
+class _PortfolioTable extends StatelessWidget {
+  const _PortfolioTable({required this.result});
+
+  final PortfolioResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final skills = result.skillsApplied;
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Empfohlenes Portfolio',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            skills.applied
+                ? 'Skill-bereinigt (Accounting ${skills.accounting}, '
+                    'Broker Relations ${skills.brokerRelations})'
+                : 'Ohne Skill-Bereinigung',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 16),
+
+          // ── Summary tiles ──────────────────────────────────────────────
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              _SummaryTile(
+                label: 'Tagesgewinn',
+                value: _fmtIsk(result.totalDailyProfit),
+                accent: Theme.of(context).colorScheme.primary,
+              ),
+              _SummaryTile(
+                label: 'Kapital genutzt',
+                value: _fmtIsk(result.totalCapitalUsed),
+              ),
+              _SummaryTile(
+                label: 'Zeit genutzt',
+                value: '${result.timeUsedMin.round()} min',
+              ),
+              _SummaryTile(
+                label: 'Diversifikation',
+                value: '${result.diversificationScore.round()}/100',
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+
+          // ── Allocation table ───────────────────────────────────────────
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              key: const Key('roi-allocation-table'),
+              columns: const [
+                DataColumn(label: Text('Item')),
+                DataColumn(label: Text('Kapital'), numeric: true),
+                DataColumn(label: Text('Units'), numeric: true),
+                DataColumn(label: Text('Fahrten/Tag'), numeric: true),
+                DataColumn(label: Text('Tagesgewinn'), numeric: true),
+                DataColumn(label: Text('ROI%'), numeric: true),
+              ],
+              rows: [
+                for (final item in result.items)
+                  DataRow(
+                    cells: [
+                      DataCell(Text(item.name)),
+                      DataCell(Text(_fmtIsk(item.capitalUsed))),
+                      DataCell(Text(_fmtUnits(item.units))),
+                      DataCell(Text(item.tripsPerDay.toStringAsFixed(1))),
+                      DataCell(Text(_fmtIsk(item.dailyProfit))),
+                      DataCell(Text('${item.roiPercent.toStringAsFixed(1)}%')),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Formatting helpers ───────────────────────────────────────────────────
+
+  static String _fmtIsk(double v) {
+    if (v >= 1e9) return '${(v / 1e9).toStringAsFixed(2)}B';
+    if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(2)}M';
+    if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+    return v.toStringAsFixed(2);
+  }
+
+  static String _fmtUnits(double v) {
+    if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(1)}M';
+    if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+    return v.toStringAsFixed(0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+class _SliderRow extends StatelessWidget {
+  const _SliderRow({required this.label, required this.valueLabel});
+  final String label;
+  final String valueLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            label,
+            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          valueLabel,
+          style: TextStyle(
+            fontSize: 13,
+            color: Theme.of(context).colorScheme.onSurface.withAlpha(153),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SecCheckbox extends StatelessWidget {
+  const _SecCheckbox({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+    this.enabled = true,
+    this.activeColor,
+  });
+
+  final String label;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final bool enabled;
+  final Color? activeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return CheckboxListTile(
+      value: value,
+      onChanged: enabled ? (v) => onChanged(v ?? false) : null,
+      title: Text(label, style: const TextStyle(fontSize: 13)),
+      controlAffinity: ListTileControlAffinity.leading,
+      dense: true,
+      contentPadding: EdgeInsets.zero,
+      activeColor: activeColor ?? Theme.of(context).colorScheme.primary,
+    );
+  }
+}
+
+class _SummaryTile extends StatelessWidget {
+  const _SummaryTile({
+    required this.label,
+    required this.value,
+    this.accent,
+  });
+
+  final String label;
+  final String value;
+  final Color? accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = accent ?? Theme.of(context).colorScheme.onSurface;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  color: color,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/trading/roi_providers.dart
+++ b/app/lib/features/trading/roi_providers.dart
@@ -1,0 +1,44 @@
+/// Riverpod providers for the ROI Calculator / Capital Allocation feature.
+///
+/// Provider graph (reuses [tradingApiProvider] from providers.dart):
+///   tradingApiProvider → roiOptimizeProvider (AsyncNotifier)
+///
+/// Region/ship selection reuses the existing trading-feature providers
+/// ([selectedRegionProvider], [selectedShipTypeIdProvider]).
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/portfolio_models.dart';
+import 'providers.dart' show tradingApiProvider;
+
+// ---------------------------------------------------------------------------
+// RoiOptimizeNotifier — AsyncNotifier<PortfolioResult?>
+// ---------------------------------------------------------------------------
+
+/// Owns the portfolio-optimization lifecycle.
+///
+/// [build] returns null — no optimization has been performed yet. Call
+/// [optimize] with a [PortfolioRequest] to trigger one; it sets
+/// [AsyncLoading] then guards the API call. An empty `items` list on the
+/// resulting [PortfolioResult] is a valid, successful "no viable portfolio"
+/// state — it is NOT treated as an error.
+class RoiOptimizeNotifier extends AsyncNotifier<PortfolioResult?> {
+  @override
+  Future<PortfolioResult?> build() async => null;
+
+  /// Runs a portfolio optimization for [request].
+  Future<void> optimize(PortfolioRequest request) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final api = ref.read(tradingApiProvider);
+      return api.optimizePortfolio(request);
+    });
+  }
+}
+
+/// Provider for [RoiOptimizeNotifier].
+final roiOptimizeProvider =
+    AsyncNotifierProvider<RoiOptimizeNotifier, PortfolioResult?>(
+  RoiOptimizeNotifier.new,
+);

--- a/app/test/e2e/app_flow_test.dart
+++ b/app/test/e2e/app_flow_test.dart
@@ -27,6 +27,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:eve_o_provit/features/trading/hub_comparison_screen.dart';
+import 'package:eve_o_provit/features/trading/roi_calculator_screen.dart';
 import 'package:eve_o_provit/features/trading/route_detail.dart';
 import 'package:eve_o_provit/features/trading/route_list.dart';
 import 'package:eve_o_provit/features/trading/trading_screen.dart';
@@ -334,6 +335,46 @@ void main() {
       expect(find.byType(HubComparisonScreen), findsOneWidget);
       expect(find.byType(VerticalDivider), findsNothing);
       expect(find.text('Dodixie'), findsOneWidget);
+    });
+  });
+
+  // ── 6c. ROI Calculator ────────────────────────────────────────────────────
+
+  group('ROI Calculator', () {
+    testWidgets(
+        'Navigating to ROI tab renders the allocation table from mocked data '
+        '(item names + totals)', (tester) async {
+      _setViewSize(tester, 1280, 800);
+
+      await _pumpApp(tester, authenticatedOverrides());
+
+      // Open the ROI bottom-nav destination.
+      await tester.tap(find.text('ROI').last);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoiCalculatorScreen), findsOneWidget);
+      // Allocation table renders with item names from fakePortfolioResponse.
+      expect(find.byKey(const Key('roi-allocation-table')), findsOneWidget);
+      expect(find.text('Tritanium'), findsOneWidget);
+      expect(find.text('Pyerite'), findsOneWidget);
+      // Diversification summary tile.
+      expect(find.text('Diversifikation'), findsOneWidget);
+      expect(find.text('72/100'), findsOneWidget);
+    });
+
+    testWidgets(
+        'ROI screen portrait (800×1280) is single-pane (no VerticalDivider)',
+        (tester) async {
+      _setViewSize(tester, 800, 1280);
+
+      await _pumpApp(tester, authenticatedOverrides());
+
+      await tester.tap(find.text('ROI').last);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RoiCalculatorScreen), findsOneWidget);
+      expect(find.byType(VerticalDivider), findsNothing);
+      expect(find.text('Tritanium'), findsOneWidget);
     });
   });
 

--- a/app/test/e2e/support/fakes.dart
+++ b/app/test/e2e/support/fakes.dart
@@ -9,6 +9,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:eve_o_provit/api/hub_comparison_models.dart';
+import 'package:eve_o_provit/api/portfolio_models.dart';
 import 'package:eve_o_provit/api/trading_api.dart';
 import 'package:eve_o_provit/api/trading_models.dart';
 import 'package:eve_o_provit/auth/auth_controller.dart';
@@ -21,6 +22,7 @@ import 'package:eve_o_provit/features/character/providers.dart'
     show characterApiProvider;
 import 'package:eve_o_provit/features/trading/hub_comparison_providers.dart';
 import 'package:eve_o_provit/features/trading/providers.dart';
+import 'package:eve_o_provit/features/trading/roi_providers.dart';
 
 // ---------------------------------------------------------------------------
 // Canned data — shared by both TradingApi and CharacterApi fakes
@@ -175,6 +177,41 @@ HubComparisonResponse fakeHubResponse() => const HubComparisonResponse(
       ],
     );
 
+/// Canned [PortfolioResult] — a two-item allocation with totals.
+PortfolioResult fakePortfolioResponse() => const PortfolioResult(
+      items: [
+        PortfolioItem(
+          typeId: 34,
+          name: 'Tritanium',
+          capitalUsed: 1.5e8,
+          units: 120000,
+          tripsPerDay: 4,
+          dailyProfit: 2.5e7,
+          roiPercent: 16.7,
+        ),
+        PortfolioItem(
+          typeId: 35,
+          name: 'Pyerite',
+          capitalUsed: 1.2e8,
+          units: 60000,
+          tripsPerDay: 3,
+          dailyProfit: 1.8e7,
+          roiPercent: 15.0,
+        ),
+      ],
+      totalCapitalUsed: 4.8e8,
+      totalDailyProfit: 6.1e7,
+      timeUsedMin: 118,
+      diversificationScore: 72,
+      skillsApplied: SkillsApplied(
+        applied: true,
+        accounting: 5,
+        brokerRelations: 5,
+        salesTaxRate: 0.025,
+        brokerFeeRate: 0.015,
+      ),
+    );
+
 /// Canned character used in the authenticated auth state.
 const fakeCharacter = Character(
   id: 12345678,
@@ -262,6 +299,10 @@ class FakeTradingApi extends TradingApi {
   @override
   Future<HubComparisonResponse> compareHubs(int typeId) async =>
       fakeHubResponse();
+
+  @override
+  Future<PortfolioResult> optimizePortfolio(PortfolioRequest request) async =>
+      fakePortfolioResponse();
 
   @override
   Future<void> setWaypoint({
@@ -352,6 +393,22 @@ class FakeHubComparisonNotifier extends HubComparisonNotifier {
 }
 
 // ---------------------------------------------------------------------------
+// Fake RoiOptimizeNotifier — starts with canned data
+// ---------------------------------------------------------------------------
+
+/// A [RoiOptimizeNotifier] that initialises with [fakePortfolioResponse] so the
+/// allocation table is immediately visible without calling optimize().
+class FakeRoiOptimizeNotifier extends RoiOptimizeNotifier {
+  @override
+  Future<PortfolioResult?> build() async => fakePortfolioResponse();
+
+  @override
+  Future<void> optimize(PortfolioRequest request) async {
+    state = AsyncData(fakePortfolioResponse());
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Stub AuthControllers
 // ---------------------------------------------------------------------------
 
@@ -393,6 +450,7 @@ List<dynamic> authenticatedOverrides() => [
       tradingApiProvider.overrideWithValue(FakeTradingApi()),
       routesProvider.overrideWith(FakeRoutesNotifier.new),
       hubComparisonProvider.overrideWith(FakeHubComparisonNotifier.new),
+      roiOptimizeProvider.overrideWith(FakeRoiOptimizeNotifier.new),
       // Provide fake character API so ship selector / fitting card work offline.
       characterApiProvider.overrideWithValue(FakeCharacterApi()),
     ];

--- a/app/test/portfolio_models_test.dart
+++ b/app/test/portfolio_models_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/portfolio_models.dart';
+
+void main() {
+  // ── PortfolioRequest.toJson ────────────────────────────────────────────────
+
+  group('PortfolioRequest.toJson', () {
+    test('maps all fields to snake_case wire format', () {
+      const req = PortfolioRequest(
+        regionId: 10000002,
+        shipTypeId: 649,
+        capital: 500000000,
+        timeBudgetMin: 120,
+        liquidityCapPct: 10,
+        maxItemPct: 30,
+        secZones: ['high'],
+      );
+      expect(req.toJson(), {
+        'region_id': 10000002,
+        'ship_type_id': 649,
+        'capital': 500000000.0,
+        'time_budget_min': 120,
+        'liquidity_cap_pct': 10.0,
+        'max_item_pct': 30.0,
+        'sec_zones': ['high'],
+      });
+    });
+  });
+
+  // ── PortfolioResult.fromJson ───────────────────────────────────────────────
+
+  group('PortfolioResult.fromJson', () {
+    // Realistic sample: one full item, one item with missing/null numerics —
+    // exercises the null/float-robust parsing.
+    const Map<String, dynamic> sample = {
+      'items': [
+        {
+          'type_id': 34,
+          'name': 'Tritanium',
+          'capital_used': 1.5e8,
+          'units': 120000,
+          'trips_per_day': 4,
+          'daily_profit': 2.5e7,
+          'roi_percent': 16.7,
+        },
+        // Item with missing / null numeric fields.
+        {
+          'type_id': 35,
+          'name': 'Pyerite',
+          'capital_used': null,
+          // units absent entirely
+          'trips_per_day': 2,
+          'daily_profit': null,
+          // roi_percent absent
+        },
+      ],
+      'total_capital_used': 4.8e8,
+      'total_daily_profit': 6.1e7,
+      'time_used_min': 118,
+      'diversification_score': 72,
+      'skills_applied': {
+        'applied': true,
+        'accounting': 5,
+        'broker_relations': 5,
+        'sales_tax_rate': 0.025,
+        'broker_fee_rate': 0.015,
+      },
+    };
+
+    test('maps top-level scalar fields (int coerced to double)', () {
+      final r = PortfolioResult.fromJson(sample);
+      expect(r.totalCapitalUsed, 4.8e8);
+      expect(r.totalDailyProfit, 6.1e7);
+      expect(r.timeUsedMin, 118.0);
+      expect(r.diversificationScore, 72.0);
+      expect(r.items.length, 2);
+      expect(r.isEmpty, isFalse);
+    });
+
+    test('maps skills_applied object (reused SkillsApplied model)', () {
+      final s = PortfolioResult.fromJson(sample).skillsApplied;
+      expect(s.applied, isTrue);
+      expect(s.accounting, 5);
+      expect(s.brokerRelations, 5);
+      expect(s.salesTaxRate, 0.025);
+      expect(s.brokerFeeRate, 0.015);
+    });
+
+    test('skills_applied defaults when object absent', () {
+      final noSkills = Map<String, dynamic>.from(sample)
+        ..remove('skills_applied');
+      final s = PortfolioResult.fromJson(noSkills).skillsApplied;
+      expect(s.applied, isFalse);
+      expect(s.accounting, 0);
+      expect(s.salesTaxRate, 0);
+    });
+
+    group('full item', () {
+      late PortfolioItem item;
+      setUp(() => item = PortfolioResult.fromJson(sample).items[0]);
+
+      test('maps all fields', () {
+        expect(item.typeId, 34);
+        expect(item.name, 'Tritanium');
+        expect(item.capitalUsed, 1.5e8);
+        expect(item.units, 120000.0);
+        expect(item.tripsPerDay, 4.0);
+        expect(item.dailyProfit, 2.5e7);
+        expect(item.roiPercent, 16.7);
+      });
+    });
+
+    group('item with null / missing numerics', () {
+      late PortfolioItem item;
+      setUp(() => item = PortfolioResult.fromJson(sample).items[1]);
+
+      test('null/absent numeric fields default to 0', () {
+        expect(item.capitalUsed, 0);
+        expect(item.units, 0);
+        expect(item.dailyProfit, 0);
+        expect(item.roiPercent, 0);
+      });
+
+      test('present int field coerced to double', () {
+        expect(item.tripsPerDay, 2.0);
+      });
+    });
+
+    test('empty items list is a valid result (no viable portfolio)', () {
+      final r = PortfolioResult.fromJson(const {
+        'items': [],
+        'total_capital_used': 0,
+        'total_daily_profit': 0,
+        'time_used_min': 0,
+        'diversification_score': 0,
+      });
+      expect(r.items, isEmpty);
+      expect(r.isEmpty, isTrue);
+      expect(r.totalDailyProfit, 0);
+    });
+
+    test('items defaults to empty when key absent + scalars default to 0', () {
+      final r = PortfolioResult.fromJson(const {});
+      expect(r.items, isEmpty);
+      expect(r.isEmpty, isTrue);
+      expect(r.totalCapitalUsed, 0);
+      expect(r.diversificationScore, 0);
+      expect(r.skillsApplied.applied, isFalse);
+    });
+  });
+}

--- a/app/test/roi_calculator_screen_layout_test.dart
+++ b/app/test/roi_calculator_screen_layout_test.dart
@@ -1,0 +1,179 @@
+/// Widget tests for RoiCalculatorScreen adaptive layout.
+///
+/// 1. Small view (<840 dp) → single-pane: no VerticalDivider.
+/// 2. Large view (≥840 dp) → two-pane: at least one VerticalDivider.
+/// Plus: result table renders from a seeded portfolio, and an empty `items`
+/// result shows the "no viable portfolio" empty-state.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/portfolio_models.dart';
+import 'package:eve_o_provit/api/trading_api.dart';
+import 'package:eve_o_provit/api/trading_models.dart';
+import 'package:eve_o_provit/core/theme.dart';
+import 'package:eve_o_provit/features/character/character_api.dart';
+import 'package:eve_o_provit/features/character/character_models.dart';
+import 'package:eve_o_provit/features/character/providers.dart'
+    show characterApiProvider;
+import 'package:eve_o_provit/features/trading/providers.dart';
+import 'package:eve_o_provit/features/trading/roi_calculator_screen.dart';
+import 'package:eve_o_provit/features/trading/roi_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Canned data + fakes
+// ---------------------------------------------------------------------------
+
+PortfolioResult _fakeResult() => const PortfolioResult(
+      items: [
+        PortfolioItem(
+          typeId: 34,
+          name: 'Tritanium',
+          capitalUsed: 1.5e8,
+          units: 120000,
+          tripsPerDay: 4,
+          dailyProfit: 2.5e7,
+          roiPercent: 16.7,
+        ),
+        PortfolioItem(
+          typeId: 35,
+          name: 'Pyerite',
+          capitalUsed: 1.2e8,
+          units: 60000,
+          tripsPerDay: 3,
+          dailyProfit: 1.8e7,
+          roiPercent: 15.0,
+        ),
+      ],
+      totalCapitalUsed: 4.8e8,
+      totalDailyProfit: 6.1e7,
+      timeUsedMin: 118,
+      diversificationScore: 72,
+      skillsApplied: SkillsApplied(
+        applied: true,
+        accounting: 5,
+        brokerRelations: 5,
+        salesTaxRate: 0.025,
+        brokerFeeRate: 0.015,
+      ),
+    );
+
+PortfolioResult _emptyResult() => const PortfolioResult(
+      items: [],
+      totalCapitalUsed: 0,
+      totalDailyProfit: 0,
+      timeUsedMin: 0,
+      diversificationScore: 0,
+      skillsApplied: SkillsApplied(
+        applied: false,
+        accounting: 0,
+        brokerRelations: 0,
+        salesTaxRate: 0,
+        brokerFeeRate: 0,
+      ),
+    );
+
+class _FakeTradingApi extends TradingApi {
+  _FakeTradingApi() : super(Dio());
+
+  @override
+  Future<RegionsResponse> regions() async => RegionsResponse(
+        regions: [const Region(id: 10000002, name: 'The Forge')],
+        count: 1,
+      );
+
+  @override
+  Future<PortfolioResult> optimizePortfolio(PortfolioRequest request) async =>
+      _fakeResult();
+}
+
+class _FakeCharacterApi extends CharacterApi {
+  _FakeCharacterApi() : super(Dio());
+
+  @override
+  Future<CharacterShipsResponse> ships() async =>
+      const CharacterShipsResponse(ships: [], count: 0);
+}
+
+class _StubNotifier extends RoiOptimizeNotifier {
+  @override
+  Future<PortfolioResult?> build() async => _fakeResult();
+}
+
+class _EmptyNotifier extends RoiOptimizeNotifier {
+  @override
+  Future<PortfolioResult?> build() async => _emptyResult();
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  double width, {
+  double height = 1200,
+  RoiOptimizeNotifier Function() notifier = _StubNotifier.new,
+}) async {
+  tester.view.physicalSize = Size(width, height);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tradingApiProvider.overrideWithValue(_FakeTradingApi()),
+        characterApiProvider.overrideWithValue(_FakeCharacterApi()),
+        roiOptimizeProvider.overrideWith(notifier),
+      ],
+      child: MaterialApp(
+        theme: buildTheme(Brightness.light),
+        home: const RoiCalculatorScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('Single-pane (width 800): no VerticalDivider', (tester) async {
+    await _pumpScreen(tester, 800);
+
+    expect(find.byType(VerticalDivider), findsNothing);
+    // Input form + result both present.
+    expect(find.text('Region'), findsOneWidget);
+    expect(find.text('Empfohlenes Portfolio'), findsOneWidget);
+  });
+
+  testWidgets('Two-pane (width 1280): at least one VerticalDivider',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byType(VerticalDivider), findsAtLeastNWidgets(1));
+    expect(find.text('Region'), findsOneWidget);
+    expect(find.text('Empfohlenes Portfolio'), findsOneWidget);
+  });
+
+  testWidgets('Allocation table renders item names + totals', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byKey(const Key('roi-allocation-table')), findsOneWidget);
+    expect(find.text('Tritanium'), findsOneWidget);
+    expect(find.text('Pyerite'), findsOneWidget);
+    // Diversification summary tile.
+    expect(find.text('Diversifikation'), findsOneWidget);
+    expect(find.text('72/100'), findsOneWidget);
+  });
+
+  testWidgets('Empty items result shows the no-viable-portfolio empty-state',
+      (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _EmptyNotifier.new);
+
+    expect(find.byKey(const Key('roi-empty-state')), findsOneWidget);
+    expect(
+      find.text('Kein sinnvolles Portfolio für dieses Budget'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('roi-allocation-table')), findsNothing);
+  });
+}

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -35,6 +35,7 @@ type AppContainer struct {
 	FittingHandler     *handlers.FittingHandler
 	CalculationHandler *handlers.CalculationHandler
 	MultiHubHandler    *handlers.MultiHubHandler
+	PortfolioHandler   *handlers.PortfolioHandler
 
 	// Background workers
 	CompetitionCollector *services.CompetitionCollector
@@ -151,6 +152,10 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 	volumeService := services.NewVolumeService(c.MarketRepo, c.ESIClient)
 	multiHubService := services.NewMultiHubComparisonService(skillsService, c.ESIClient, volumeService, competitionService, c.SDERepo, c.AppLogger)
 	c.MultiHubHandler = handlers.NewMultiHubHandler(multiHubService)
+
+	// ROI Calculator / capital-allocation optimizer (#44) — reuses the route engine.
+	portfolioService := services.NewPortfolioService(routeService, skillsService, c.AppLogger)
+	c.PortfolioHandler = handlers.NewPortfolioHandler(portfolioService)
 
 	// Start the competition collector in the background (lazy-tracked pairs).
 	go c.CompetitionCollector.Start(ctx)

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -153,6 +153,7 @@ func setupApp(c *AppContainer) *fiber.App {
 
 	api.Post("/trading/routes/calculate", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.TradingHandler.CalculateRoutes)
 	api.Post("/trading/hubs/compare", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.MultiHubHandler.CompareHubs)
+	api.Post("/trading/portfolio/optimize", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.PortfolioHandler.Optimize)
 	api.Get("/items/search", c.TradingHandler.SearchItems)
 
 	api.Post("/calculations/cargo", c.CalculationHandler.CalculateCargo)

--- a/backend/internal/handlers/portfolio.go
+++ b/backend/internal/handlers/portfolio.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
+)
+
+// PortfolioHandler serves the ROI Calculator / capital-allocation endpoint (Issue #44).
+type PortfolioHandler struct {
+	service *services.PortfolioService
+}
+
+// NewPortfolioHandler creates a new portfolio handler.
+func NewPortfolioHandler(service *services.PortfolioService) *PortfolioHandler {
+	return &PortfolioHandler{service: service}
+}
+
+// Optimize handles POST /api/v1/trading/portfolio/optimize
+//
+// @Summary Optimize capital allocation across items for max daily profit
+// @Description Given region, ship, capital and time budget, suggests how to allocate
+// @Description capital across items (greedy, under liquidity + per-item caps).
+// @Tags Trading
+// @Accept json
+// @Produce json
+// @Param request body models.PortfolioRequest true "Optimization parameters"
+// @Success 200 {object} models.PortfolioResult
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/trading/portfolio/optimize [post]
+func (h *PortfolioHandler) Optimize(c *fiber.Ctx) error {
+	var req models.PortfolioRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+	if req.RegionID <= 0 || req.ShipTypeID <= 0 || req.Capital <= 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "region_id, ship_type_id and capital are required"})
+	}
+
+	characterID := c.Locals("character_id")
+	accessToken := c.Locals("access_token")
+	if characterID == nil || accessToken == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Authentication required"})
+	}
+	cid, ok := characterID.(int)
+	tok, ok2 := accessToken.(string)
+	if !ok || !ok2 {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid authentication context"})
+	}
+
+	result, err := h.service.Optimize(c.UserContext(), &req, cid, tok)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to optimize portfolio"})
+	}
+	return c.JSON(result)
+}

--- a/backend/internal/models/portfolio.go
+++ b/backend/internal/models/portfolio.go
@@ -1,0 +1,33 @@
+package models
+
+// PortfolioRequest is the body for POST /api/v1/trading/portfolio/optimize.
+type PortfolioRequest struct {
+	RegionID        int      `json:"region_id"`
+	ShipTypeID      int      `json:"ship_type_id"`
+	Capital         float64  `json:"capital"`           // ISK budget
+	TimeBudgetMin   float64  `json:"time_budget_min"`   // available trading minutes/day
+	LiquidityCapPct float64  `json:"liquidity_cap_pct"` // 0..100, max share of daily volume per item
+	MaxItemPct      float64  `json:"max_item_pct"`      // 0..100, max share of capital per item
+	SecZones        []string `json:"sec_zones"`         // "high","low","null"
+} // @name PortfolioRequest
+
+// PortfolioItem is one allocated position in the suggested portfolio.
+type PortfolioItem struct {
+	TypeID      int     `json:"type_id"`
+	Name        string  `json:"name"`
+	CapitalUsed float64 `json:"capital_used"`
+	Units       int     `json:"units"`
+	TripsPerDay float64 `json:"trips_per_day"`
+	DailyProfit float64 `json:"daily_profit"`
+	ROIPercent  float64 `json:"roi_percent"` // daily_profit / capital_used * 100
+} // @name PortfolioItem
+
+// PortfolioResult is the response for POST /api/v1/trading/portfolio/optimize.
+type PortfolioResult struct {
+	Items                []PortfolioItem `json:"items"`
+	TotalCapitalUsed     float64         `json:"total_capital_used"`
+	TotalDailyProfit     float64         `json:"total_daily_profit"`
+	TimeUsedMin          float64         `json:"time_used_min"`
+	DiversificationScore int             `json:"diversification_score"` // 0..100
+	SkillsApplied        SkillsApplied   `json:"skills_applied"`
+} // @name PortfolioResult

--- a/backend/internal/services/portfolio_service.go
+++ b/backend/internal/services/portfolio_service.go
@@ -1,9 +1,133 @@
 package services
 
 import (
+	"context"
 	"math"
 	"sort"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
 )
+
+// PortfolioService orchestrates ROI/capital-allocation: it pulls candidate routes
+// from the route engine, applies the sec-zone filter, runs the greedy optimizer,
+// and maps the result to the API model with skills metadata (Issue #44).
+type PortfolioService struct {
+	routes    RouteCalculatorServicer
+	skills    SkillsServicer
+	optimizer *PortfolioOptimizer
+	logger    *logger.Logger
+}
+
+// NewPortfolioService creates a new portfolio service.
+func NewPortfolioService(routes RouteCalculatorServicer, skills SkillsServicer, logger *logger.Logger) *PortfolioService {
+	return &PortfolioService{routes: routes, skills: skills, optimizer: NewPortfolioOptimizer(), logger: logger}
+}
+
+// Optimize computes the suggested capital allocation for the request.
+func (s *PortfolioService) Optimize(ctx context.Context, req *models.PortfolioRequest, characterID int, accessToken string) (*models.PortfolioResult, error) {
+	// Route calc needs the character in context for skill-aware cargo/fees.
+	ctx = context.WithValue(ctx, contextKeyCharacterID, characterID)
+	ctx = context.WithValue(ctx, contextKeyAccessToken, accessToken)
+
+	resp, err := s.routes.CalculateWithFilters(ctx, &models.RouteCalculationRequest{
+		RegionID:             req.RegionID,
+		ShipTypeID:           req.ShipTypeID,
+		IncludeVolumeMetrics: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cands := make([]Candidate, 0, len(resp.Routes))
+	for i := range resp.Routes {
+		r := resp.Routes[i]
+		if !secZoneAllowed(r.MinRouteSecurityStatus, req.SecZones) {
+			continue
+		}
+		dailyVol := 0.0
+		if r.VolumeMetrics != nil {
+			dailyVol = r.VolumeMetrics.DailyVolumeAvg
+		}
+		cands = append(cands, Candidate{
+			TypeID:          r.ItemTypeID,
+			Name:            r.ItemName,
+			ProfitPerUnit:   r.ProfitPerUnit,
+			BuyPricePerUnit: r.BuyPrice,
+			UnitVolume:      r.ItemVolume,
+			DailyVolume:     dailyVol,
+			TripMinutes:     r.RoundTripSeconds / 60.0,
+		})
+	}
+
+	outcome := s.optimizer.Optimize(cands, OptimizeParams{
+		Capital:         req.Capital,
+		CargoCapacity:   resp.CargoCapacity,
+		TimeBudgetMin:   req.TimeBudgetMin,
+		LiquidityCapPct: req.LiquidityCapPct,
+		MaxItemPct:      req.MaxItemPct,
+	})
+
+	skills, serr := s.skills.GetCharacterSkills(ctx, characterID, accessToken)
+	if serr != nil || skills == nil {
+		skills = &TradingSkills{}
+	}
+
+	items := make([]models.PortfolioItem, 0, len(outcome.Items))
+	for _, it := range outcome.Items {
+		roi := 0.0
+		if it.CapitalUsed > 0 {
+			roi = it.DailyProfit / it.CapitalUsed * 100
+		}
+		items = append(items, models.PortfolioItem{
+			TypeID:      it.TypeID,
+			Name:        it.Name,
+			CapitalUsed: it.CapitalUsed,
+			Units:       it.Units,
+			TripsPerDay: it.TripsPerDay,
+			DailyProfit: it.DailyProfit,
+			ROIPercent:  roi,
+		})
+	}
+
+	return &models.PortfolioResult{
+		Items:                items,
+		TotalCapitalUsed:     outcome.TotalCapitalUsed,
+		TotalDailyProfit:     outcome.TotalDailyProfit,
+		TimeUsedMin:          outcome.TimeUsedMin,
+		DiversificationScore: outcome.DiversificationScore,
+		SkillsApplied: models.SkillsApplied{
+			Applied:         serr == nil,
+			Accounting:      skills.Accounting,
+			BrokerRelations: skills.BrokerRelations,
+			SalesTaxRate:    SalesTaxRate(skills.Accounting),
+			BrokerFeeRate:   BrokerFeeRate(skills.BrokerRelations, skills.AdvancedBrokerRelations, skills.FactionStanding, skills.CorpStanding),
+		},
+	}, nil
+}
+
+// secZoneAllowed reports whether a route's minimum security status falls within the
+// requested zones (empty = all allowed). high ≥0.5, low 0–0.5, null ≤0.0.
+func secZoneAllowed(minSec float64, zones []string) bool {
+	if len(zones) == 0 {
+		return true
+	}
+	var zone string
+	switch {
+	case minSec >= 0.5:
+		zone = "high"
+	case minSec > 0.0:
+		zone = "low"
+	default:
+		zone = "null"
+	}
+	for _, z := range zones {
+		if z == zone {
+			return true
+		}
+	}
+	return false
+}
 
 // Candidate is one tradeable item the optimizer may allocate to (derived from a
 // route-engine result, decoupled for testability).

--- a/backend/internal/services/portfolio_service.go
+++ b/backend/internal/services/portfolio_service.go
@@ -1,0 +1,151 @@
+package services
+
+import (
+	"math"
+	"sort"
+)
+
+// Candidate is one tradeable item the optimizer may allocate to (derived from a
+// route-engine result, decoupled for testability).
+type Candidate struct {
+	TypeID          int
+	Name            string
+	ProfitPerUnit   float64 // net profit per unit (skill-adjusted)
+	BuyPricePerUnit float64 // capital cost per unit
+	UnitVolume      float64 // m³ per unit
+	DailyVolume     float64 // market daily volume (for liquidity cap)
+	TripMinutes     float64 // round-trip minutes for this route
+}
+
+// OptimizeParams are the allocation constraints.
+type OptimizeParams struct {
+	Capital         float64
+	CargoCapacity   float64
+	TimeBudgetMin   float64
+	LiquidityCapPct float64 // 0..100
+	MaxItemPct      float64 // 0..100
+}
+
+// OutcomeItem is one allocated position (internal; mapped to models.PortfolioItem).
+type OutcomeItem struct {
+	TypeID      int
+	Name        string
+	CapitalUsed float64
+	Units       int
+	TripsPerDay float64
+	DailyProfit float64
+}
+
+// PortfolioOutcome is the optimizer result (internal).
+type PortfolioOutcome struct {
+	Items                []OutcomeItem
+	TotalCapitalUsed     float64
+	TotalDailyProfit     float64
+	TimeUsedMin          float64
+	DiversificationScore int
+}
+
+// PortfolioOptimizer allocates capital across candidate items.
+type PortfolioOptimizer struct{}
+
+// NewPortfolioOptimizer creates a new optimizer.
+func NewPortfolioOptimizer() *PortfolioOptimizer { return &PortfolioOptimizer{} }
+
+// Optimize greedily allocates capital + a shared time budget across candidates,
+// most-efficient (profit per ISK) first, under per-item liquidity and capital caps.
+func (o *PortfolioOptimizer) Optimize(cands []Candidate, p OptimizeParams) PortfolioOutcome {
+	perItemCapital := p.Capital * p.MaxItemPct / 100.0
+
+	type scored struct {
+		c            Candidate
+		unitsPerTrip int
+		maxUnits     int // min(liquidity cap, per-item capital cap)
+		efficiency   float64
+	}
+	var list []scored
+	for _, c := range cands {
+		if c.BuyPricePerUnit <= 0 || c.ProfitPerUnit <= 0 {
+			continue
+		}
+		upt := 1
+		if c.UnitVolume > 0 {
+			upt = int(p.CargoCapacity / c.UnitVolume)
+		}
+		if upt < 1 {
+			continue // doesn't fit cargo
+		}
+		maxUnits := int(c.DailyVolume * p.LiquidityCapPct / 100.0)
+		if capCap := int(perItemCapital / c.BuyPricePerUnit); capCap < maxUnits {
+			maxUnits = capCap
+		}
+		if maxUnits < 1 {
+			continue
+		}
+		list = append(list, scored{c: c, unitsPerTrip: upt, maxUnits: maxUnits, efficiency: c.ProfitPerUnit / c.BuyPricePerUnit})
+	}
+	sort.SliceStable(list, func(i, j int) bool { return list[i].efficiency > list[j].efficiency })
+
+	capitalLeft, timeLeft := p.Capital, p.TimeBudgetMin
+	var items []OutcomeItem
+	var totalCap, totalProfit, totalTime float64
+
+	for _, s := range list {
+		units := s.maxUnits
+		if affordable := int(capitalLeft / s.c.BuyPricePerUnit); affordable < units {
+			units = affordable
+		}
+		if units < 1 {
+			continue
+		}
+		trips := ceilDiv(units, s.unitsPerTrip)
+		if s.c.TripMinutes > 0 {
+			if affordTrips := int(timeLeft / s.c.TripMinutes); affordTrips < trips {
+				trips = affordTrips
+				if t := trips * s.unitsPerTrip; t < units {
+					units = t
+				}
+			}
+		}
+		if units < 1 || trips < 1 {
+			continue
+		}
+		capUsed := float64(units) * s.c.BuyPricePerUnit
+		profit := float64(units) * s.c.ProfitPerUnit
+		timeUsed := float64(trips) * s.c.TripMinutes
+		items = append(items, OutcomeItem{
+			TypeID: s.c.TypeID, Name: s.c.Name, CapitalUsed: capUsed,
+			Units: units, TripsPerDay: float64(trips), DailyProfit: profit,
+		})
+		capitalLeft -= capUsed
+		timeLeft -= timeUsed
+		totalCap += capUsed
+		totalProfit += profit
+		totalTime += timeUsed
+	}
+
+	return PortfolioOutcome{
+		Items: items, TotalCapitalUsed: totalCap, TotalDailyProfit: totalProfit,
+		TimeUsedMin: totalTime, DiversificationScore: diversificationScore(items, totalCap),
+	}
+}
+
+func ceilDiv(a, b int) int {
+	if b <= 0 {
+		return a
+	}
+	return (a + b - 1) / b
+}
+
+// diversificationScore is Herfindahl-based: (1 - Σ share²) × 100, rounded.
+// 0/1 items → 0 (no diversification).
+func diversificationScore(items []OutcomeItem, total float64) int {
+	if len(items) < 2 || total <= 0 {
+		return 0
+	}
+	var sumSq float64
+	for _, it := range items {
+		share := it.CapitalUsed / total
+		sumSq += share * share
+	}
+	return int(math.Round((1 - sumSq) * 100))
+}

--- a/backend/internal/services/portfolio_service_test.go
+++ b/backend/internal/services/portfolio_service_test.go
@@ -1,0 +1,82 @@
+package services
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func cand(id int, name string, profit, buy, vol, daily, tripMin float64) Candidate {
+	return Candidate{TypeID: id, Name: name, ProfitPerUnit: profit, BuyPricePerUnit: buy, UnitVolume: vol, DailyVolume: daily, TripMinutes: tripMin}
+}
+
+func TestOptimize_RespectsCapitalAndPerItemCap(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	cands := []Candidate{
+		cand(1, "A", 10, 100, 1, 1e9, 10),
+		cand(2, "B", 10, 100, 1, 1e9, 10),
+	}
+	res := opt.Optimize(cands, OptimizeParams{
+		Capital: 1000, CargoCapacity: 1e9, TimeBudgetMin: 1e9,
+		LiquidityCapPct: 100, MaxItemPct: 50,
+	})
+	if len(res.Items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(res.Items))
+	}
+	for _, it := range res.Items {
+		if it.CapitalUsed > 500.0001 {
+			t.Errorf("per-item cap (50%% of 1000=500) violated: %v", it.CapitalUsed)
+		}
+	}
+	if !approx(res.TotalCapitalUsed, 1000) {
+		t.Errorf("should use full capital, got %v", res.TotalCapitalUsed)
+	}
+}
+
+func TestOptimize_LiquidityCapLimitsUnits(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	cands := []Candidate{cand(1, "A", 5, 10, 1, 100, 1)}
+	res := opt.Optimize(cands, OptimizeParams{
+		Capital: 1e9, CargoCapacity: 1e9, TimeBudgetMin: 1e9,
+		LiquidityCapPct: 10, MaxItemPct: 100,
+	})
+	if res.Items[0].Units > 10 {
+		t.Errorf("liquidity cap (10%% of 100=10) violated: %d units", res.Items[0].Units)
+	}
+}
+
+func TestOptimize_TimeBudgetLimitsTrips(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	cands := []Candidate{cand(1, "A", 5, 10, 1, 1e9, 10)}
+	res := opt.Optimize(cands, OptimizeParams{
+		Capital: 1e9, CargoCapacity: 100, TimeBudgetMin: 25,
+		LiquidityCapPct: 100, MaxItemPct: 100,
+	})
+	if res.TimeUsedMin > 25.0001 {
+		t.Errorf("time budget exceeded: %v", res.TimeUsedMin)
+	}
+	if res.Items[0].TripsPerDay > 2 {
+		t.Errorf("trips should be capped at 2, got %v", res.Items[0].TripsPerDay)
+	}
+}
+
+func TestOptimize_DiversificationScore(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	one := opt.Optimize([]Candidate{cand(1, "A", 10, 100, 1, 1e9, 10)},
+		OptimizeParams{Capital: 1000, CargoCapacity: 1e9, TimeBudgetMin: 1e9, LiquidityCapPct: 100, MaxItemPct: 100})
+	two := opt.Optimize([]Candidate{cand(1, "A", 10, 100, 1, 1e9, 10), cand(2, "B", 10, 100, 1, 1e9, 10)},
+		OptimizeParams{Capital: 1000, CargoCapacity: 1e9, TimeBudgetMin: 1e9, LiquidityCapPct: 100, MaxItemPct: 50})
+	if !(two.DiversificationScore > one.DiversificationScore) {
+		t.Errorf("two-item portfolio should score higher: one=%d two=%d", one.DiversificationScore, two.DiversificationScore)
+	}
+}
+
+func TestOptimize_EmptyWhenCapitalTooSmall(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	res := opt.Optimize([]Candidate{cand(1, "A", 5, 1000, 1, 1e9, 1)},
+		OptimizeParams{Capital: 100, CargoCapacity: 1e9, TimeBudgetMin: 1e9, LiquidityCapPct: 100, MaxItemPct: 100})
+	if len(res.Items) != 0 {
+		t.Errorf("want empty portfolio when capital < one unit, got %d items", len(res.Items))
+	}
+}

--- a/docs/superpowers/plans/2026-05-28-roi-calculator.md
+++ b/docs/superpowers/plans/2026-05-28-roi-calculator.md
@@ -1,0 +1,416 @@
+# ROI Calculator & Capital Allocation Optimizer (#44) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Given a region, ship, capital and time budget, suggest how to allocate the capital across multiple items for maximum expected daily profit, with liquidity + diversification constraints.
+
+**Architecture:** A portfolio layer on the existing route engine. `RouteService.CalculateWithFilters` produces the profitable station→station routes (skill-adjusted net profit, cargo, trips, ISK/h, volume); a new greedy `PortfolioOptimizerService` allocates capital + a shared time budget across those candidates under per-item liquidity and capital caps. Surfaced via `POST /api/v1/trading/portfolio/optimize`, a web `/roi-calculator` page and a Flutter screen.
+
+**Tech Stack:** Go/Fiber backend (pgx, existing services), Next.js 16 + React Query + Tailwind, Flutter + Riverpod + dio. Spec: `docs/superpowers/specs/2026-05-28-roi-calculator-design.md`.
+
+---
+
+## File Structure
+
+**Backend (`backend/`)**
+- Create `internal/models/portfolio.go` — `PortfolioRequest`, `PortfolioResult`, `PortfolioItem`.
+- Create `internal/services/portfolio_service.go` — `PortfolioOptimizerService` (greedy allocator + diversification score). Pure logic over a candidate list (testable without the engine).
+- Create `internal/services/portfolio_service_test.go` — unit tests.
+- Create `internal/handlers/portfolio.go` — `MultiHubHandler`-style handler.
+- Modify `cmd/api/container.go` — build the service + handler.
+- Modify `cmd/api/main.go` — register `POST /api/v1/trading/portfolio/optimize`.
+
+**Web (`frontend/`)**
+- Modify `src/app/roi-calculator/page.tsx` — replace placeholder.
+- Create `src/components/trading/PortfolioInputForm.tsx`, `PortfolioResultTable.tsx`, `DiversificationScore.tsx`.
+- Modify `src/lib/api-client.ts` — `optimizePortfolio(req)`.
+- Modify `src/types/trading.ts` — `PortfolioRequest/Result/Item`.
+- Create `tests/components/PortfolioResultTable.test.tsx`, `tests/e2e/auth/roi-calculator.spec.ts`.
+
+**Flutter (`app/`)**
+- Create `lib/api/portfolio_models.dart`, `lib/features/trading/roi_calculator_screen.dart`, `lib/features/trading/roi_providers.dart`.
+- Modify `lib/api/trading_api.dart` (add `optimizePortfolio`), `lib/core/router.dart` (route + nav).
+- Create `test/portfolio_models_test.dart`, `test/roi_calculator_screen_layout_test.dart`; extend `test/e2e/app_flow_test.dart` + `test/e2e/support/fakes.dart`.
+
+---
+
+## Task 1: Backend models
+
+**Files:** Create `backend/internal/models/portfolio.go`
+
+- [ ] **Step 1: Write `portfolio.go`**
+
+```go
+package models
+
+// PortfolioRequest is the body for POST /api/v1/trading/portfolio/optimize.
+type PortfolioRequest struct {
+	RegionID        int      `json:"region_id"`
+	ShipTypeID      int      `json:"ship_type_id"`
+	Capital         float64  `json:"capital"`            // ISK budget
+	TimeBudgetMin   float64  `json:"time_budget_min"`    // available trading minutes/day
+	LiquidityCapPct float64  `json:"liquidity_cap_pct"`  // 0..100, max share of daily volume per item
+	MaxItemPct      float64  `json:"max_item_pct"`       // 0..100, max share of capital per item
+	SecZones        []string `json:"sec_zones"`          // "high","low","null"
+} // @name PortfolioRequest
+
+// PortfolioItem is one allocated position in the suggested portfolio.
+type PortfolioItem struct {
+	TypeID      int     `json:"type_id"`
+	Name        string  `json:"name"`
+	CapitalUsed float64 `json:"capital_used"`
+	Units       int     `json:"units"`
+	TripsPerDay float64 `json:"trips_per_day"`
+	DailyProfit float64 `json:"daily_profit"`
+	ROIPercent  float64 `json:"roi_percent"` // daily_profit / capital_used * 100
+} // @name PortfolioItem
+
+// PortfolioResult is the response.
+type PortfolioResult struct {
+	Items                []PortfolioItem `json:"items"`
+	TotalCapitalUsed     float64         `json:"total_capital_used"`
+	TotalDailyProfit     float64         `json:"total_daily_profit"`
+	TimeUsedMin          float64         `json:"time_used_min"`
+	DiversificationScore int             `json:"diversification_score"` // 0..100
+	SkillsApplied        SkillsApplied   `json:"skills_applied"`        // reuse from hub_comparison.go
+} // @name PortfolioResult
+```
+
+- [ ] **Step 2: Build** — `cd backend && go build ./...` → no errors. **Commit:** `git add backend/internal/models/portfolio.go && git commit -m "feat(portfolio): models for ROI calculator (#44)"`
+
+---
+
+## Task 2: PortfolioOptimizerService (greedy allocator) — TDD
+
+**Files:** Create `backend/internal/services/portfolio_service.go`, `backend/internal/services/portfolio_service_test.go`
+
+The optimizer works over a candidate slice (decoupled from the route engine for testability):
+
+```go
+// Candidate is one tradeable item the optimizer may allocate to.
+type Candidate struct {
+	TypeID         int
+	Name           string
+	ProfitPerUnit  float64 // net profit per unit (skill-adjusted, from route calc)
+	BuyPricePerUnit float64 // capital cost per unit
+	UnitVolume     float64 // m³ per unit
+	DailyVolume    float64 // market daily volume (for liquidity cap)
+	TripMinutes    float64 // round-trip minutes for this route
+}
+```
+
+- [ ] **Step 1: Write failing tests** in `portfolio_service_test.go`
+
+```go
+package services
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func cand(id int, name string, profit, buy, vol, daily, tripMin float64) Candidate {
+	return Candidate{TypeID: id, Name: name, ProfitPerUnit: profit, BuyPricePerUnit: buy, UnitVolume: vol, DailyVolume: daily, TripMinutes: tripMin}
+}
+
+func TestOptimize_RespectsCapitalAndPerItemCap(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	// Two equally efficient items; max 50% capital per item forces a split.
+	cands := []Candidate{
+		cand(1, "A", 10, 100, 1, 1e9, 10),
+		cand(2, "B", 10, 100, 1, 1e9, 10),
+	}
+	res := opt.Optimize(cands, OptimizeParams{
+		Capital: 1000, CargoCapacity: 1e9, TimeBudgetMin: 1e9,
+		LiquidityCapPct: 100, MaxItemPct: 50,
+	})
+	if len(res.Items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(res.Items))
+	}
+	for _, it := range res.Items {
+		if it.CapitalUsed > 500.0001 {
+			t.Errorf("per-item cap (50%% of 1000=500) violated: %v", it.CapitalUsed)
+		}
+	}
+	if !approx(res.TotalCapitalUsed, 1000) {
+		t.Errorf("should use full capital, got %v", res.TotalCapitalUsed)
+	}
+}
+
+func TestOptimize_LiquidityCapLimitsUnits(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	// Daily volume 100, cap 10% → at most 10 units/day regardless of capital.
+	cands := []Candidate{cand(1, "A", 5, 10, 1, 100, 1)}
+	res := opt.Optimize(cands, OptimizeParams{
+		Capital: 1e9, CargoCapacity: 1e9, TimeBudgetMin: 1e9,
+		LiquidityCapPct: 10, MaxItemPct: 100,
+	})
+	if res.Items[0].Units > 10 {
+		t.Errorf("liquidity cap (10%% of 100=10) violated: %d units", res.Items[0].Units)
+	}
+}
+
+func TestOptimize_TimeBudgetLimitsTrips(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	// 10-min trips, 25-min budget → at most 2 trips total.
+	cands := []Candidate{cand(1, "A", 5, 10, 1, 1e9, 10)}
+	res := opt.Optimize(cands, OptimizeParams{
+		Capital: 1e9, CargoCapacity: 100, TimeBudgetMin: 25,
+		LiquidityCapPct: 100, MaxItemPct: 100,
+	})
+	if res.TimeUsedMin > 25.0001 {
+		t.Errorf("time budget exceeded: %v", res.TimeUsedMin)
+	}
+	if res.Items[0].TripsPerDay > 2 {
+		t.Errorf("trips should be capped at 2, got %v", res.Items[0].TripsPerDay)
+	}
+}
+
+func TestOptimize_DiversificationScore(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	// One dominating item → low score; two equal → higher.
+	one := opt.Optimize([]Candidate{cand(1, "A", 10, 100, 1, 1e9, 10)},
+		OptimizeParams{Capital: 1000, CargoCapacity: 1e9, TimeBudgetMin: 1e9, LiquidityCapPct: 100, MaxItemPct: 100})
+	two := opt.Optimize([]Candidate{cand(1, "A", 10, 100, 1, 1e9, 10), cand(2, "B", 10, 100, 1, 1e9, 10)},
+		OptimizeParams{Capital: 1000, CargoCapacity: 1e9, TimeBudgetMin: 1e9, LiquidityCapPct: 100, MaxItemPct: 50})
+	if !(two.DiversificationScore > one.DiversificationScore) {
+		t.Errorf("two-item portfolio should score higher: one=%d two=%d", one.DiversificationScore, two.DiversificationScore)
+	}
+}
+
+func TestOptimize_EmptyWhenCapitalTooSmall(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	res := opt.Optimize([]Candidate{cand(1, "A", 5, 1000, 1, 1e9, 1)},
+		OptimizeParams{Capital: 100, CargoCapacity: 1e9, TimeBudgetMin: 1e9, LiquidityCapPct: 100, MaxItemPct: 100})
+	if len(res.Items) != 0 {
+		t.Errorf("want empty portfolio when capital < one unit, got %d items", len(res.Items))
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify fail** — `cd backend && go test ./internal/services/ -run TestOptimize` → FAIL (undefined `NewPortfolioOptimizer`).
+
+- [ ] **Step 3: Implement `portfolio_service.go`**
+
+```go
+package services
+
+import (
+	"math"
+	"sort"
+)
+
+type Candidate struct {
+	TypeID          int
+	Name            string
+	ProfitPerUnit   float64
+	BuyPricePerUnit float64
+	UnitVolume      float64
+	DailyVolume     float64
+	TripMinutes     float64
+}
+
+type OptimizeParams struct {
+	Capital         float64
+	CargoCapacity   float64
+	TimeBudgetMin   float64
+	LiquidityCapPct float64 // 0..100
+	MaxItemPct      float64 // 0..100
+}
+
+type OutcomeItem struct {
+	TypeID      int
+	Name        string
+	CapitalUsed float64
+	Units       int
+	TripsPerDay float64
+	DailyProfit float64
+}
+
+type PortfolioOutcome struct {
+	Items                []OutcomeItem
+	TotalCapitalUsed     float64
+	TotalDailyProfit     float64
+	TimeUsedMin          float64
+	DiversificationScore int
+}
+
+type PortfolioOptimizer struct{}
+
+func NewPortfolioOptimizer() *PortfolioOptimizer { return &PortfolioOptimizer{} }
+
+// Optimize greedily allocates capital + a shared time budget across candidates,
+// most-efficient (profit per ISK) first, under per-item liquidity and capital caps.
+func (o *PortfolioOptimizer) Optimize(cands []Candidate, p OptimizeParams) PortfolioOutcome {
+	perItemCapital := p.Capital * p.MaxItemPct / 100.0
+
+	type scored struct {
+		c            Candidate
+		unitsPerTrip int
+		maxUnits     int // min(liquidity cap, per-item capital cap)
+		efficiency   float64
+	}
+	var list []scored
+	for _, c := range cands {
+		if c.BuyPricePerUnit <= 0 || c.ProfitPerUnit <= 0 {
+			continue
+		}
+		upt := 1
+		if c.UnitVolume > 0 {
+			upt = int(p.CargoCapacity / c.UnitVolume)
+		}
+		if upt < 1 {
+			continue // doesn't fit cargo
+		}
+		maxUnits := int(c.DailyVolume * p.LiquidityCapPct / 100.0)
+		if capCap := int(perItemCapital / c.BuyPricePerUnit); capCap < maxUnits {
+			maxUnits = capCap
+		}
+		if maxUnits < 1 {
+			continue
+		}
+		list = append(list, scored{c: c, unitsPerTrip: upt, maxUnits: maxUnits, efficiency: c.ProfitPerUnit / c.BuyPricePerUnit})
+	}
+	sort.SliceStable(list, func(i, j int) bool { return list[i].efficiency > list[j].efficiency })
+
+	capitalLeft, timeLeft := p.Capital, p.TimeBudgetMin
+	var items []OutcomeItem
+	var totalCap, totalProfit, totalTime float64
+
+	for _, s := range list {
+		units := s.maxUnits
+		if affordable := int(capitalLeft / s.c.BuyPricePerUnit); affordable < units {
+			units = affordable
+		}
+		if units < 1 {
+			continue
+		}
+		trips := ceilDiv(units, s.unitsPerTrip)
+		if s.c.TripMinutes > 0 {
+			if affordTrips := int(timeLeft / s.c.TripMinutes); affordTrips < trips {
+				trips = affordTrips
+				if t := trips * s.unitsPerTrip; t < units {
+					units = t
+				}
+			}
+		}
+		if units < 1 || trips < 1 {
+			continue
+		}
+		capUsed := float64(units) * s.c.BuyPricePerUnit
+		profit := float64(units) * s.c.ProfitPerUnit
+		timeUsed := float64(trips) * s.c.TripMinutes
+		items = append(items, OutcomeItem{
+			TypeID: s.c.TypeID, Name: s.c.Name, CapitalUsed: capUsed,
+			Units: units, TripsPerDay: float64(trips), DailyProfit: profit,
+		})
+		capitalLeft -= capUsed
+		timeLeft -= timeUsed
+		totalCap += capUsed
+		totalProfit += profit
+		totalTime += timeUsed
+	}
+
+	return PortfolioOutcome{
+		Items: items, TotalCapitalUsed: totalCap, TotalDailyProfit: totalProfit,
+		TimeUsedMin: totalTime, DiversificationScore: diversificationScore(items, totalCap),
+	}
+}
+
+func ceilDiv(a, b int) int {
+	if b <= 0 {
+		return a
+	}
+	return (a + b - 1) / b
+}
+
+// diversificationScore is Herfindahl-based: (1 - Σ share²) × 100, rounded.
+// 0/1 items → 0 (no diversification).
+func diversificationScore(items []OutcomeItem, total float64) int {
+	if len(items) < 2 || total <= 0 {
+		return 0
+	}
+	var sumSq float64
+	for _, it := range items {
+		share := it.CapitalUsed / total
+		sumSq += share * share
+	}
+	return int(math.Round((1 - sumSq) * 100))
+}
+```
+
+- [ ] **Step 4: Run, verify pass** — `go test ./internal/services/ -run TestOptimize -v` → all PASS. Fix logic until green.
+
+- [ ] **Step 5: gofmt + commit** — `gofmt -w internal/services/portfolio_service*.go && git add backend/internal/services/portfolio_service*.go && git commit -m "feat(portfolio): greedy capital-allocation optimizer + tests (#44)"`
+
+---
+
+## Task 3: Handler + route + wiring
+
+**Files:** Create `backend/internal/handlers/portfolio.go`; Modify `backend/cmd/api/container.go`, `backend/cmd/api/main.go`
+
+- [ ] **Step 1: Implement `portfolio.go`** — mirror `internal/handlers/multi_hub.go`: parse `PortfolioRequest`, validate `RegionID>0 && ShipTypeID>0 && Capital>0`, extract `character_id`/`access_token` from `c.Locals` (type-assert `int`/`string`, 401 if missing), call a service method `Optimize(ctx, req, characterID, accessToken) (*models.PortfolioResult, error)`, return JSON; 500 on error (no raw error leak).
+
+- [ ] **Step 2: Wire the service** — create a thin `PortfolioService` in `portfolio_service.go` that: calls `routeService.CalculateWithFilters` to get candidate routes, maps each route → `Candidate` (ProfitPerUnit, BuyPricePerUnit, UnitVolume, DailyVolume from volume metrics, TripMinutes from route travel time), runs `PortfolioOptimizer.Optimize`, fetches skills once for `SkillsApplied`, maps `PortfolioOutcome` → `models.PortfolioResult` (incl. ROIPercent = dailyProfit/capitalUsed*100). Inject `RouteCalculatorServicer` + `SkillsServicer` via small interfaces (testable). In `container.go` build it with the existing `routeService` + `skillsService` and `NewPortfolioOptimizer()`; build `c.PortfolioHandler`.
+
+- [ ] **Step 3: Register route** in `main.go` after the hubs route:
+```go
+api.Post("/trading/portfolio/optimize", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.PortfolioHandler.Optimize)
+```
+
+- [ ] **Step 4: Build + vet** — `go build ./... && go vet ./internal/... ./cmd/...` → clean.
+
+- [ ] **Step 5: Commit** — `git add backend/ && git commit -m "feat(portfolio): handler + route + wiring (#44)"`
+
+---
+
+## Task 4: Backend gates
+
+- [ ] **Step 1:** `cd backend && gofmt -l internal/ cmd/` → empty; `go test -short ./internal/...` → PASS.
+- [ ] **Step 2:** Bump `CHANGELOG.md` `[Unreleased]` with an `### Added` entry describing the portfolio endpoint.
+- [ ] **Step 3: Commit** — `git add backend CHANGELOG.md && git commit -m "chore(portfolio): changelog + gates (#44)"`
+
+---
+
+## Task 5: Web frontend + tests
+
+**Files:** as in File Structure. Follow the #43 patterns exactly: `src/app/multi-hub/page.tsx` (page structure, useMutation, auth gate), `src/lib/api-client.ts` `compareHubs` (authed POST, `credentials:"include"`), `src/components/trading/HubComparisonTable.tsx` (table idiom), `tests/components/HubComparisonTable.test.tsx` + `tests/e2e/auth/multi-hub.spec.ts`.
+
+- [ ] **Step 1:** Add types to `src/types/trading.ts`: `PortfolioRequest`, `PortfolioItem`, `PortfolioResult` (snake_case → camel per existing convention; mirror the Go JSON tags).
+- [ ] **Step 2:** Add `optimizePortfolio(req: PortfolioRequest)` to `src/lib/api-client.ts` (POST `/api/v1/trading/portfolio/optimize`, `credentials:"include"`).
+- [ ] **Step 3:** `PortfolioResultTable.tsx` (columns: Item, Kapital, Units, Fahrten/Tag, Tagesgewinn, ROI%) + `DiversificationScore.tsx` (0–100 badge) + `PortfolioInputForm.tsx` (region, ship, capital, time, liquidity cap, max %/item, sec-zone checkboxes). Use `formatISKWithSeparators` for ISK.
+- [ ] **Step 4:** Replace `src/app/roi-calculator/page.tsx` placeholder: auth gate + ErrorBoundary + form → `useMutation(optimizePortfolio)` → results (table + totals + diversification). Loading/error/empty states ("kein sinnvolles Portfolio für dieses Budget").
+- [ ] **Step 5:** Vitest `tests/components/PortfolioResultTable.test.tsx` (renders allocations, totals, ROI%, empty-state) + Playwright `tests/e2e/auth/roi-calculator.spec.ts` (authed; fill form, submit, assert allocation table). Run `npm run test` + `npm run lint` → green.
+- [ ] **Step 6: Commit** — `git add frontend && git commit -m "feat(frontend): ROI calculator page + tests (#44)"`
+
+---
+
+## Task 6: Flutter + tests
+
+**Files:** as in File Structure. Follow the #43 `hub_comparison_*` patterns exactly.
+
+- [ ] **Step 1:** `lib/api/portfolio_models.dart` — DTOs with null/float-robust `fromJson` (mirror `hub_comparison_models.dart`).
+- [ ] **Step 2:** `lib/api/trading_api.dart` add `optimizePortfolio(PortfolioRequest)`; `lib/features/trading/roi_providers.dart` `AsyncNotifier<PortfolioResult?>`.
+- [ ] **Step 3:** `lib/features/trading/roi_calculator_screen.dart` adaptive via `isTwoPane(840)`: input form + result table (Item/Kapital/Units/Fahrten/Tagesgewinn/ROI%) + diversification + empty-state.
+- [ ] **Step 4:** `lib/core/router.dart` add `/roi-calculator` GoRoute + a NavigationDestination ("ROI").
+- [ ] **Step 5:** Tests — `test/portfolio_models_test.dart` (parse incl. empty items), `test/roi_calculator_screen_layout_test.dart` (1-/2-pane), group in `test/e2e/app_flow_test.dart` + `fakePortfolioResponse()` in `test/e2e/support/fakes.dart`. Run `flutter analyze` (clean) + `flutter test` (all pass).
+- [ ] **Step 6: Commit** — `git add app && git commit -m "feat(app): ROI calculator screen + tests (#44)"`
+
+---
+
+## Task 7: Ship
+
+- [ ] **Step 1:** PR `feat/roi-calculator` → CI green → merge.
+- [ ] **Step 2:** `make release VERSION=x.y.0` → release PR → merge → tag `vx.y.0` → deploy (backend + frontend images) → smoke success.
+- [ ] **Step 3:** Prod verify: `/version`, `/roi-calculator` 200, `POST /portfolio/optimize` 401 without auth (wired). Flutter APK rebuild + on-device happy path.
+- [ ] **Step 4:** Comment on #43-style summary on issue #44; close.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** ROI per item (Task 2 efficiency + ROIPercent map in Task 3) ✓; ROI ranking (sorted greedy + result order) ✓; portfolio builder/allocation (Task 2) ✓; daily profit projection (TotalDailyProfit) ✓; diversification score (Task 2) ✓; skills applied (Task 3 fetch) ✓; inputs incl. liquidity cap + sec zones + max%/item (Task 1 request + Task 2 caps) ✓; web + flutter (Tasks 5,6) ✓.
+- **Placeholders:** none — Task 2 Step 3 now contains the complete `Optimize` implementation (greedy, caps, `ceilDiv`, `diversificationScore`). Task 3 describes the handler/wiring by pointing at the concrete `multi_hub.go` analogue (same shape, fully specified), which is reuse-not-placeholder.
+- **Type consistency:** `Candidate`, `OptimizeParams`, `PortfolioOutcome`/`OutcomeItem` (internal) vs `models.Portfolio*` (API) are distinct by design; handler/service maps between them (Task 3 Step 2). `optimizePortfolio` name consistent web+flutter.

--- a/docs/superpowers/specs/2026-05-28-roi-calculator-design.md
+++ b/docs/superpowers/specs/2026-05-28-roi-calculator-design.md
@@ -1,0 +1,69 @@
+# ROI Calculator & Capital Allocation Optimizer (Issue #44) — Design
+
+- **Datum:** 2026-05-28
+- **Issue:** Sternrassler/eve-o-provit#44
+- **Status:** In Umsetzung
+
+## Use Case
+
+Ein Trader hat ein Budget (z.B. 500 Mio. ISK) und begrenzte Spielzeit. Frage: **Welche Items kaufe ich in welcher Stückzahl, um meinen Tagesgewinn zu maximieren?** #44 ist eine **Portfolio-/Kapital-Allokations-Schicht** auf der bestehenden Routen-Engine — nicht *wo* handle ich ein Item (#43), sondern *was und wie viel* mit meinem Kapital.
+
+Modell-Scope (wie das bestehende Trading): **eine Region, Station→Station-Arbitrage** (an Station A aus Sell-Orders kaufen, haulen, an Station B in Buy-Orders verkaufen), Cargo- und reisezeit-begrenzt, skill-bereinigt.
+
+## Eingaben
+
+- **Region** (`region_id`)
+- **Schiff** (`ship_type_id` → effektives Cargo via Skills, Warp/Align für Reisezeit)
+- **Kapital** (verfügbares ISK-Budget)
+- **Verfügbare Zeit** (`time_budget_min` — hartes Fahrten/Tag-Budget)
+- **Liquiditäts-Cap** (`liquidity_cap_pct` — max. Anteil am Tages-Volumen, den man realistisch handelt)
+- **Sec-Zonen-Filter** (High/Low/Null)
+- **Max. % Kapital pro Item** (`max_item_pct` — Diversifikations-Constraint)
+- **Skills** — automatisch aus dem Login (Accounting/Broker → Fees, Industrial/Hauler → Cargo, Navigation → Fahrten/Tag)
+
+## Zielfunktion
+
+**Maximiere erwarteten Gesamt-Tagesgewinn** unter den Constraints: Kapital-Budget, Zeit-Budget (Fahrten/Tag), Cargo/Fahrt, Liquiditäts-Cap pro Item, Max-% Kapital pro Item. Zeit geht als hartes Constraint ein (langsame Routen → weniger Fahrten/Tag), Kapital ist die Allokations-Achse. „Profit je Zeit" ist das implizite Effizienzmaß für die Auswahl.
+
+## Architektur
+
+### Backend
+- **Kandidaten-Generierung (Wiederverwendung):** `RouteService.CalculateWithFilters(region, ship, sec-zones, volume)` liefert die profitablen Station→Station-Routen der Region mit Netto-Gewinn, Cargo, Fahrten, ISK/h und Volumen-Metriken (skill-bereinigt). Kein neuer Markt-/Trading-Code.
+- **`PortfolioOptimizerService`** `internal/services/portfolio_service.go` — greedy 2-Ressourcen-Allokation (Kapital + Zeit):
+  1. Pro Kandidat realistische Kapazität: `tripsPerDay = min(reisezeit-erlaubte Fahrten, Zeit-Budget)`; `maxUnitsPerDay = liquidity_cap_pct × daily_volume`; `cargo/Fahrt`; `perItemCapital = max_item_pct × capital`.
+  2. **Effizienz** = erwarteter Tagesgewinn pro eingesetztem ISK (unter obigen Caps).
+  3. **Greedy:** nach Effizienz sortiert Kapital + geteiltes Zeit-Budget auffüllen, bis Kapital oder Zeit erschöpft; Per-Item-Kapital-Cap erzwingt Streuung.
+  4. Ergebnis je Item `{type_id, name, capital_used, units, trips_per_day, daily_profit, roi_pct}`; Totals `{total_capital_used, total_daily_profit, diversification_score, time_used_min}`.
+  - **Diversifikations-Score:** aus Kapital-Konzentration, Herfindahl-artig — `score = round((1 − Σ(anteil_i²)) × 100)` (0 = alles in 1 Item, 100 = maximal gestreut).
+- **Models** `internal/models/portfolio.go` — `PortfolioRequest`, `PortfolioResult`, `PortfolioItem`.
+- **Handler** `internal/handlers/portfolio.go` → `POST /api/v1/trading/portfolio/optimize` (protected, rate-limited), Route in `cmd/api/main.go`.
+- **Testbarkeit:** Optimizer bekommt die Kandidaten + Constraints als reine Eingaben (Interface für die Routen-Quelle), damit die Greedy-Logik ohne echte Engine unit-testbar ist.
+
+### Web (`frontend/src/app/roi-calculator/page.tsx`)
+Placeholder ersetzen. Eingabe-Formular (Region, Schiff, Kapital, Zeit, Liquiditäts-Cap, Max-%/Item, Sec-Zonen — re-use `RegionSelect`/`ShipSelect`/Filter-Muster) → `useMutation` auf `/portfolio/optimize`. Ergebnis: **ROI-Ranking-Tabelle** + **Allokations-Tabelle** (Item, Kapital, Units, Tagesgewinn, Fahrten/Tag, ROI%) + **Gesamt-Tagesgewinn** + **Diversifikations-Score** + Skills-Applied-Panel. Komponenten unter `components/trading/`.
+
+### Flutter (`app/lib/features/trading/roi_calculator_screen.dart`)
+Adaptiver Screen via `isTwoPane(840)`: Eingaben links/oben, Ergebnis-Tabelle rechts/unten. DTOs in `api/portfolio_models.dart` (null/float-robust), Provider `roi_providers.dart` (`AsyncNotifier`), `trading_api.optimizePortfolio(...)`, Route `/roi-calculator` + Nav-Destination.
+
+## Datenfluss
+
+`Eingaben (UI) → POST /portfolio/optimize → RouteService.CalculateWithFilters (Kandidaten) → PortfolioOptimizerService (greedy Allokation unter Kapital+Zeit+Liquidität+Per-Item-Cap) → Result → Ranking + Allokation + Totals`.
+
+## Error-Handling
+- Auth-pflichtig; fehlende Skills → Base-Werte (kein Hard-Fail), `skills_applied=false`.
+- Keine Kandidaten / Kapital zu klein für günstigstes Item → leeres Portfolio mit Hinweis „kein sinnvolles Portfolio für dieses Budget".
+- Keine geleakten Roh-Fehler (Handler-Konvention). Mobile-DTO null/float-robust.
+
+## Tests (Pyramide)
+- **Backend Unit:** `portfolio_service_test.go` — greedy respektiert Kapital-/Zeit-/Liquiditäts-/Per-Item-Cap; Diversifikations-Score (1 Item → ~0, gleichverteilt → hoch); leeres Budget → leeres Portfolio.
+- **Web:** Vitest (Allokations-/Ranking-Tabelle, Diversifikations-Score-Anzeige) + Playwright authed E2E (`tests/e2e/auth/roi-calculator.spec.ts`).
+- **Flutter:** Unit (Parsing) + Widget (adaptiv 1-/2-Pane) + E2E-Gruppe in `test/e2e/app_flow_test.dart` (Provider-Override).
+
+## Deployment
+Backend tag-basiert (v0.x → GHCR → deploy-app.sh) + Frontend-Image (same-origin, bereits in der Pipeline). Migrationen werden beim Boot angewandt (keine neue nötig — #44 ist read-only/berechnend). Flutter: APK-Build + On-Device-Happy-Path.
+
+## Out of Scope (YAGNI)
+- Exakter ILP-Solver (greedy reicht, erklärbar).
+- Multi-Region / Inter-Hub-Hauling (#45).
+- Persistente Portfolios/Watchlist (#48).
+- Eigener Markt-Fetch (Routen-Engine wird wiederverwendet).

--- a/frontend/src/app/roi-calculator/page.tsx
+++ b/frontend/src/app/roi-calculator/page.tsx
@@ -1,114 +1,152 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Calculator, PieChart, Wallet } from "lucide-react";
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useAuth } from "@/lib/auth-context";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  PortfolioInputForm,
+  PortfolioFormState,
+} from "@/components/trading/PortfolioInputForm";
+import { PortfolioResultTable } from "@/components/trading/PortfolioResultTable";
+import { DiversificationScore } from "@/components/trading/DiversificationScore";
+import { SkillsAppliedPanel } from "@/components/trading/SkillsAppliedPanel";
+import { optimizePortfolio } from "@/lib/api-client";
+import { PortfolioRequest } from "@/types/trading";
+import { Loader2 } from "lucide-react";
 
-export default function ROICalculatorPage() {
+const DEFAULT_REGION = "10000002"; // The Forge
+const DEFAULT_SHIP = "649";
+
+const defaultForm: PortfolioFormState = {
+  region: DEFAULT_REGION,
+  ship: DEFAULT_SHIP,
+  capital: 500_000_000,
+  timeBudgetMin: 120,
+  liquidityCapPct: 10,
+  maxItemPct: 30,
+  allowHighSec: true,
+  allowLowSec: false,
+  allowNullSec: false,
+};
+
+function buildRequest(form: PortfolioFormState): PortfolioRequest {
+  const secZones: string[] = [];
+  if (form.allowHighSec) secZones.push("high");
+  if (form.allowLowSec) secZones.push("low");
+  if (form.allowNullSec) secZones.push("null");
+
+  return {
+    region_id: parseInt(form.region, 10),
+    ship_type_id: parseInt(form.ship, 10),
+    capital: form.capital,
+    time_budget_min: form.timeBudgetMin,
+    liquidity_cap_pct: form.liquidityCapPct,
+    max_item_pct: form.maxItemPct,
+    sec_zones: secZones,
+  };
+}
+
+function ROICalculatorContent() {
+  const { isAuthenticated } = useAuth();
+  const [form, setForm] = useState<PortfolioFormState>(defaultForm);
+
+  const optimizeMutation = useMutation({
+    mutationFn: (req: PortfolioRequest) => optimizePortfolio(req),
+  });
+
+  const handleSubmit = () => {
+    optimizeMutation.mutate(buildRequest(form));
+  };
+
+  const apiError = optimizeMutation.isError
+    ? optimizeMutation.error instanceof Error
+      ? optimizeMutation.error.message
+      : "Unbekannter Fehler"
+    : undefined;
+
   return (
-    <div className="container mx-auto p-8">
+    <div className="container mx-auto px-4 py-8">
       <div className="mb-8">
-        <div className="flex items-center gap-3 mb-2">
-          <h1 className="text-3xl font-bold">ROI Calculator & Capital Optimizer</h1>
-          <Badge variant="outline" className="text-blue-600">Phase 2</Badge>
-        </div>
+        <h1 className="mb-2 text-3xl font-bold">
+          ROI Calculator & Capital Optimizer
+        </h1>
         <p className="text-muted-foreground">
-          Optimiere deine Kapital-Allokation für maximalen Return on Investment
+          Verteile dein Kapital optimal über mehrere Items für maximalen
+          Tagesgewinn
         </p>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-3 mb-8">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              ROI Ranking
-            </CardTitle>
-            <Calculator className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">Daily Profit / Capital</div>
-            <p className="text-xs text-muted-foreground">
-              Sort by efficiency
-            </p>
-          </CardContent>
-        </Card>
+      {!isAuthenticated && (
+        <Alert className="mb-6">
+          <AlertTitle>Login erforderlich</AlertTitle>
+          <AlertDescription>
+            Melde dich per EVE SSO an, um eine skill-bereinigte
+            Kapital-Allokation zu berechnen.
+          </AlertDescription>
+        </Alert>
+      )}
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Portfolio Builder
-            </CardTitle>
-            <PieChart className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">Auto-Allocate</div>
-            <p className="text-xs text-muted-foreground">
-              &ldquo;Invest 500M optimally&rdquo;
-            </p>
-          </CardContent>
-        </Card>
+      <div className="grid gap-6 lg:grid-cols-[340px_1fr]">
+        {/* Input form */}
+        <PortfolioInputForm
+          state={form}
+          onChange={setForm}
+          onSubmit={handleSubmit}
+          disabled={!isAuthenticated || optimizeMutation.isPending}
+          loading={optimizeMutation.isPending}
+          authenticated={isAuthenticated}
+        />
 
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">
-              Risk Diversification
-            </CardTitle>
-            <Wallet className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">Score</div>
-            <p className="text-xs text-muted-foreground">
-              Balance your portfolio
-            </p>
-          </CardContent>
-        </Card>
+        {/* Results */}
+        <div className="space-y-6">
+          {optimizeMutation.isPending && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Berechne optimale Kapital-Allokation...
+            </div>
+          )}
+
+          {apiError && (
+            <Alert variant="destructive">
+              <AlertTitle>Fehler</AlertTitle>
+              <AlertDescription className="flex items-center justify-between gap-4">
+                <span>{apiError}</span>
+                <Button variant="outline" size="sm" onClick={handleSubmit}>
+                  Erneut versuchen
+                </Button>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {optimizeMutation.isSuccess && optimizeMutation.data && (
+            <div className="space-y-6">
+              <PortfolioResultTable result={optimizeMutation.data} />
+              <div className="grid gap-6 md:grid-cols-2">
+                <DiversificationScore
+                  score={optimizeMutation.data.diversification_score}
+                />
+                <SkillsAppliedPanel
+                  skills={optimizeMutation.data.skills_applied}
+                />
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Genutzte Zeit: {optimizeMutation.data.time_used_min} Min/Tag
+              </p>
+            </div>
+          )}
+        </div>
       </div>
-
-      <Card className="border-dashed">
-        <CardHeader>
-          <CardTitle>Coming in Phase 2</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <h3 className="font-semibold flex items-center gap-2">
-              <span className="text-2xl">📈</span>
-              Smart Capital Allocation
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              Enter your available capital and get optimal item mix for maximum daily profit
-            </p>
-          </div>
-
-          <div className="space-y-2">
-            <h3 className="font-semibold flex items-center gap-2">
-              <span className="text-2xl">🎲</span>
-              Risk Management
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              Diversification score prevents over-concentration in single items
-            </p>
-          </div>
-
-          <div className="space-y-2">
-            <h3 className="font-semibold flex items-center gap-2">
-              <span className="text-2xl">💰</span>
-              Expected Profit Projection
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              See projected daily/weekly/monthly profits based on historical data
-            </p>
-          </div>
-
-          <div className="mt-6 p-4 bg-muted rounded-lg">
-            <p className="text-sm">
-              <strong>Target Release:</strong> March 2026 (Phase 2)
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Dependencies: Volume Filter (#42), Fee Calculator (#38)
-            </p>
-          </div>
-        </CardContent>
-      </Card>
     </div>
+  );
+}
+
+export default function ROICalculatorPage() {
+  return (
+    <ErrorBoundary>
+      <ROICalculatorContent />
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/components/trading/DiversificationScore.tsx
+++ b/frontend/src/components/trading/DiversificationScore.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { PieChart } from "lucide-react";
+
+interface DiversificationScoreProps {
+  score: number; // 0-100
+}
+
+function getScoreColor(score: number): string {
+  if (score >= 67) return "text-green-600 dark:text-green-400";
+  if (score >= 34) return "text-yellow-600 dark:text-yellow-400";
+  return "text-red-600 dark:text-red-400";
+}
+
+function getScoreLabel(score: number): string {
+  if (score >= 67) return "Gut diversifiziert";
+  if (score >= 34) return "Mäßig diversifiziert";
+  return "Stark konzentriert";
+}
+
+/**
+ * Diversification score badge (0-100) summarising how well the suggested
+ * portfolio spreads capital across items. Higher = better diversified.
+ */
+export function DiversificationScore({ score }: DiversificationScoreProps) {
+  const clamped = Math.max(0, Math.min(100, score));
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <PieChart
+            className="size-4 text-muted-foreground"
+            aria-hidden="true"
+          />
+          Diversifikation
+        </CardTitle>
+        <Badge variant="secondary">{getScoreLabel(clamped)}</Badge>
+      </CardHeader>
+      <CardContent>
+        <div
+          className={cn("text-3xl font-bold", getScoreColor(clamped))}
+          data-testid="diversification-score"
+        >
+          {clamped}
+          <span className="ml-1 text-base font-normal text-muted-foreground">
+            / 100
+          </span>
+        </div>
+        <div
+          className="mt-3 h-2 w-full overflow-hidden rounded-full bg-muted"
+          role="progressbar"
+          aria-valuenow={clamped}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className={cn(
+              "h-full rounded-full transition-all",
+              clamped >= 67
+                ? "bg-green-600 dark:bg-green-500"
+                : clamped >= 34
+                  ? "bg-yellow-600 dark:bg-yellow-500"
+                  : "bg-red-600 dark:bg-red-500"
+            )}
+            style={{ width: `${clamped}%` }}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/trading/PortfolioInputForm.tsx
+++ b/frontend/src/components/trading/PortfolioInputForm.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { RegionSelect } from "./RegionSelect";
+import { ShipSelect } from "./ShipSelect";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Loader2 } from "lucide-react";
+
+export interface PortfolioFormState {
+  region: string;
+  ship: string;
+  capital: number;
+  timeBudgetMin: number;
+  liquidityCapPct: number;
+  maxItemPct: number;
+  allowHighSec: boolean;
+  allowLowSec: boolean;
+  allowNullSec: boolean;
+}
+
+interface PortfolioInputFormProps {
+  state: PortfolioFormState;
+  onChange: (state: PortfolioFormState) => void;
+  onSubmit: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  authenticated?: boolean;
+}
+
+/**
+ * Input form for the ROI Calculator / capital-allocation optimizer: region +
+ * ship selectors, capital / time / liquidity / max-per-item numeric inputs and
+ * security-zone checkboxes.
+ */
+export function PortfolioInputForm({
+  state,
+  onChange,
+  onSubmit,
+  disabled,
+  loading,
+  authenticated = false,
+}: PortfolioInputFormProps) {
+  const update = <K extends keyof PortfolioFormState>(
+    key: K,
+    value: PortfolioFormState[K]
+  ) => onChange({ ...state, [key]: value });
+
+  const noSecZone =
+    !state.allowHighSec && !state.allowLowSec && !state.allowNullSec;
+
+  return (
+    <form
+      className="space-y-4 rounded-lg border p-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <RegionSelect
+        value={state.region}
+        onChange={(v) => update("region", v)}
+        disabled={disabled}
+      />
+      <ShipSelect
+        value={state.ship}
+        onChange={(v) => update("ship", v)}
+        disabled={disabled}
+        authenticated={authenticated}
+      />
+
+      <div className="space-y-2">
+        <Label htmlFor="capital">Kapital (ISK)</Label>
+        <Input
+          id="capital"
+          type="number"
+          min={0}
+          value={state.capital}
+          disabled={disabled}
+          onChange={(e) => update("capital", Number(e.target.value))}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="time-budget">Zeit-Budget (Min/Tag)</Label>
+        <Input
+          id="time-budget"
+          type="number"
+          min={0}
+          value={state.timeBudgetMin}
+          disabled={disabled}
+          onChange={(e) => update("timeBudgetMin", Number(e.target.value))}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="liquidity-cap">Liquiditäts-Cap (%)</Label>
+        <Input
+          id="liquidity-cap"
+          type="number"
+          min={0}
+          max={100}
+          value={state.liquidityCapPct}
+          disabled={disabled}
+          onChange={(e) => update("liquidityCapPct", Number(e.target.value))}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="max-item">Max % Kapital pro Item</Label>
+        <Input
+          id="max-item"
+          type="number"
+          min={0}
+          max={100}
+          value={state.maxItemPct}
+          disabled={disabled}
+          onChange={(e) => update("maxItemPct", Number(e.target.value))}
+        />
+      </div>
+
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Sicherheitszonen</legend>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="sec-high"
+            checked={state.allowHighSec}
+            disabled={disabled}
+            onCheckedChange={(c) => update("allowHighSec", c === true)}
+          />
+          <Label htmlFor="sec-high" className="font-normal">
+            High-Sec
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="sec-low"
+            checked={state.allowLowSec}
+            disabled={disabled}
+            onCheckedChange={(c) => update("allowLowSec", c === true)}
+          />
+          <Label htmlFor="sec-low" className="font-normal">
+            Low-Sec
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="sec-null"
+            checked={state.allowNullSec}
+            disabled={disabled}
+            onCheckedChange={(c) => update("allowNullSec", c === true)}
+          />
+          <Label htmlFor="sec-null" className="font-normal">
+            Null-Sec
+          </Label>
+        </div>
+      </fieldset>
+
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={disabled || loading || noSecZone}
+      >
+        {loading && <Loader2 className="mr-2 size-4 animate-spin" />}
+        {loading ? "Optimiere..." : "Portfolio optimieren"}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/components/trading/PortfolioResultTable.tsx
+++ b/frontend/src/components/trading/PortfolioResultTable.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { PortfolioResult, PortfolioItem } from "@/types/trading";
+import { cn, formatISKWithSeparators, getProfitColor } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface PortfolioResultTableProps {
+  result: PortfolioResult;
+}
+
+/**
+ * Suggested capital allocation across items (the portfolio), maximising daily
+ * profit. Rows arrive pre-sorted by efficiency (most efficient first). An empty
+ * item list means no viable portfolio for the given budget.
+ */
+export function PortfolioResultTable({ result }: PortfolioResultTableProps) {
+  if (result.items.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Portfolio</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div
+            data-testid="portfolio-empty"
+            className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
+          >
+            Kein sinnvolles Portfolio für dieses Budget
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-xl">Kapital-Allokation</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm" aria-label="Kapital-Allokation">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th scope="col" className="px-4 py-3 font-medium">
+                  Item
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  Kapital
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  Units
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  Fahrten/Tag
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  Tagesgewinn
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  ROI%
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.items.map((item) => (
+                <PortfolioRowItem key={item.type_id} item={item} />
+              ))}
+            </tbody>
+            <tfoot>
+              <tr
+                data-testid="portfolio-totals"
+                className="border-t-2 font-semibold"
+              >
+                <td className="px-4 py-3">Gesamt</td>
+                <td className="px-4 py-3 text-right">
+                  {formatISKWithSeparators(result.total_capital_used)}
+                </td>
+                <td className="px-4 py-3" colSpan={2} />
+                <td className="px-4 py-3 text-right text-green-600 dark:text-green-400">
+                  {formatISKWithSeparators(result.total_daily_profit)}
+                </td>
+                <td className="px-4 py-3" />
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PortfolioRowItem({ item }: { item: PortfolioItem }) {
+  return (
+    <tr
+      data-testid="portfolio-row"
+      data-type-id={item.type_id}
+      className="border-b transition-colors hover:bg-muted/40"
+    >
+      <td className="px-4 py-3 font-medium">{item.name}</td>
+      <td className="px-4 py-3 text-right">
+        {formatISKWithSeparators(item.capital_used)}
+      </td>
+      <td className="px-4 py-3 text-right">
+        {item.units.toLocaleString("de-DE")}
+      </td>
+      <td className="px-4 py-3 text-right">{item.trips_per_day}</td>
+      <td className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
+        {formatISKWithSeparators(item.daily_profit)}
+      </td>
+      <td
+        className={cn(
+          "px-4 py-3 text-right font-bold",
+          getProfitColor(item.roi_percent)
+        )}
+      >
+        {item.roi_percent.toFixed(1)}%
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -9,6 +9,8 @@ import {
   Ship,
   ItemSearchResult,
   HubComparisonResult,
+  PortfolioRequest,
+  PortfolioResult,
 } from "@/types/trading";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:9001";
@@ -164,6 +166,32 @@ export async function compareHubs(
 
   if (!response.ok) {
     throw new Error(`Failed to compare hubs: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Optimize capital allocation across items for maximum daily profit
+ * (requires authentication). Returns a portfolio with items pre-sorted by
+ * efficiency (most efficient first) plus a diversification score.
+ * @param req - portfolio optimization parameters
+ */
+export async function optimizePortfolio(
+  req: PortfolioRequest
+): Promise<PortfolioResult> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/trading/portfolio/optimize`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(req),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to optimize portfolio: ${response.statusText}`);
   }
 
   return response.json();

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -147,6 +147,37 @@ export interface HubComparisonResult {
   hubs: HubRow[];
 }
 
+// ROI Calculator & Capital Allocation Optimizer (Issue #44)
+
+export interface PortfolioRequest {
+  region_id: number;
+  ship_type_id: number;
+  capital: number;
+  time_budget_min: number;
+  liquidity_cap_pct: number;
+  max_item_pct: number;
+  sec_zones: string[]; // e.g. ["high", "low", "null"]
+}
+
+export interface PortfolioItem {
+  type_id: number;
+  name: string;
+  capital_used: number;
+  units: number;
+  trips_per_day: number;
+  daily_profit: number;
+  roi_percent: number;
+}
+
+export interface PortfolioResult {
+  items: PortfolioItem[];
+  total_capital_used: number;
+  total_daily_profit: number;
+  time_used_min: number;
+  diversification_score: number;
+  skills_applied: SkillsApplied;
+}
+
 export interface InventorySellRequest {
   type_id: number;
   quantity: number;

--- a/frontend/tests/components/PortfolioResultTable.test.tsx
+++ b/frontend/tests/components/PortfolioResultTable.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { PortfolioResultTable } from "@/components/trading/PortfolioResultTable";
+import { PortfolioItem, PortfolioResult } from "@/types/trading";
+
+function makeItem(overrides: Partial<PortfolioItem>): PortfolioItem {
+  return {
+    type_id: 34,
+    name: "Tritanium",
+    capital_used: 1.5e8,
+    units: 120000,
+    trips_per_day: 4,
+    daily_profit: 2.5e7,
+    roi_percent: 16.7,
+    ...overrides,
+  };
+}
+
+const result: PortfolioResult = {
+  items: [
+    makeItem({ type_id: 34, name: "Tritanium", roi_percent: 16.7 }),
+    makeItem({
+      type_id: 35,
+      name: "Pyerite",
+      capital_used: 3.3e8,
+      units: 90000,
+      trips_per_day: 2,
+      daily_profit: 3.6e7,
+      roi_percent: 10.9,
+    }),
+  ],
+  total_capital_used: 4.8e8,
+  total_daily_profit: 6.1e7,
+  time_used_min: 118,
+  diversification_score: 72,
+  skills_applied: {
+    applied: true,
+    accounting: 5,
+    broker_relations: 5,
+    sales_tax_rate: 0.025,
+    broker_fee_rate: 0.015,
+  },
+};
+
+describe("PortfolioResultTable", () => {
+  it("renders one allocation row per item with name and ROI%", () => {
+    render(<PortfolioResultTable result={result} />);
+
+    const rows = screen.getAllByTestId("portfolio-row");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("Tritanium")).toBeInTheDocument();
+    expect(screen.getByText("Pyerite")).toBeInTheDocument();
+    expect(screen.getByText("16.7%")).toBeInTheDocument();
+    expect(screen.getByText("10.9%")).toBeInTheDocument();
+  });
+
+  it("renders units and trips per day for each item", () => {
+    render(<PortfolioResultTable result={result} />);
+
+    const tritRow = screen
+      .getAllByTestId("portfolio-row")
+      .find((r) => r.getAttribute("data-type-id") === "34");
+    expect(tritRow).toBeDefined();
+    expect(within(tritRow!).getByText("120.000")).toBeInTheDocument();
+    expect(within(tritRow!).getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders totals with full ISK precision", () => {
+    render(<PortfolioResultTable result={result} />);
+
+    const totals = screen.getByTestId("portfolio-totals");
+    expect(within(totals).getByText("480.000.000,00 ISK")).toBeInTheDocument();
+    expect(within(totals).getByText("61.000.000,00 ISK")).toBeInTheDocument();
+  });
+
+  it("renders the empty-state when no viable portfolio exists", () => {
+    const empty: PortfolioResult = {
+      ...result,
+      items: [],
+      total_capital_used: 0,
+      total_daily_profit: 0,
+    };
+    render(<PortfolioResultTable result={empty} />);
+
+    expect(screen.getByTestId("portfolio-empty")).toBeInTheDocument();
+    expect(
+      screen.getByText("Kein sinnvolles Portfolio für dieses Budget")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("portfolio-row")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/e2e/auth/roi-calculator.spec.ts
+++ b/frontend/tests/e2e/auth/roi-calculator.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * ROI Calculator / Capital Allocation Optimizer workflow (Issue #44) — only
+ * operable when authenticated (the optimize endpoint requires the session
+ * cookie). The auth project injects the captured session via storageState, so
+ * this spec runs against the real backend.
+ *
+ * Structure assertions only — live market values vary. The optimize call runs a
+ * live portfolio optimization and can be slow, so timeouts are generous.
+ */
+test.describe('Authenticated ROI calculator', () => {
+  test('fill the form, optimize, see allocation table + diversification score', async ({
+    page,
+  }) => {
+    // The optimize endpoint runs a live multi-item market lookup; give the whole
+    // workflow a wide envelope while per-step timeouts still catch a hang.
+    test.setTimeout(120_000);
+
+    await page.goto('/roi-calculator');
+    await expect(page.locator('h1')).toContainText('ROI Calculator');
+
+    // Submit button is enabled once authenticated (region/ship default-filled,
+    // High-Sec checked by default).
+    const submit = page.getByRole('button', { name: /Portfolio optimieren/i });
+    await expect(submit).toBeEnabled({ timeout: 30000 });
+
+    // Adjust capital to a healthy budget and submit.
+    const capital = page.getByLabel('Kapital (ISK)');
+    await capital.fill('500000000');
+    await submit.click();
+
+    // Either an allocation table appears, or the empty-state hint (no viable
+    // portfolio for the budget) — both are valid backend outcomes.
+    const table = page.getByRole('table', { name: /Kapital-Allokation/i });
+    const empty = page.getByTestId('portfolio-empty');
+    await expect(table.or(empty)).toBeVisible({ timeout: 90000 });
+
+    if (await table.isVisible()) {
+      // Allocation rows render, plus the diversification score and skills panel.
+      await expect(page.getByTestId('portfolio-row').first()).toBeVisible();
+      await expect(page.getByTestId('diversification-score')).toBeVisible();
+      await expect(page.getByText('Skills angewendet')).toBeVisible();
+    }
+  });
+});


### PR DESCRIPTION
Closes #44.

## Was
`POST /api/v1/trading/portfolio/optimize` — Eingabe Region, Schiff, Kapital, verfügbare Zeit (+ Liquiditäts-Cap, Max-%/Item, Sec-Zonen) → Vorschlag, wie das Kapital über mehrere Items verteilt wird, um den **Tagesgewinn** zu maximieren. Plus Web `/roi-calculator` + Flutter-Screen.

## Modell
- **Portfolio-Schicht auf der bestehenden Routen-Engine** (Region, Station→Station): Kandidaten aus `RouteService.CalculateWithFilters`, Sec-Zonen-Filter, dann **greedy Allokation** (effizienteste profit/ISK zuerst) unter Kapital- + Zeit-Budget + Liquiditäts-Cap + Per-Item-Kapital-Cap.
- **Diversifikations-Score** Herfindahl-artig (`(1−Σ Anteil²)×100`).
- Skills auf alle Zahlen angewandt (Fees/Cargo/Navigation).

## Tests
- Backend: 5 Optimizer-Unit-Tests (Kapital-/Zeit-/Liquiditäts-/Per-Item-Cap, Score, leeres Budget); gofmt/vet/build/tests grün, govulncheck-Gate unverändert.
- Web: Vitest 44 grün (4 neu) + Playwright authed E2E-Spec.
- Flutter: analyze clean + 155 Tests (Unit/Widget/E2E).

Spec/Plan: `docs/superpowers/specs/2026-05-28-roi-calculator-design.md`, `docs/superpowers/plans/2026-05-28-roi-calculator.md`.