### PR TITLE
feat: neighborhood hauling routes (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Neighborhood Hauling Routes (#45):** `POST /api/v1/trading/hauling/routes` — from the character's current region + adjacent regions (1 hop, derived from the stargate graph), finds profitable station→station arbitrage (buy cheap, haul, sell dear; direct/taker, no order placing). Per route an optimal cargo load (greedy by profit/m³ under cargo m³ + capital + liquidity), travel time + jumps + security risk (safe/caution/danger), ranked by ISK/h. New `SDERepository.GetNeighborRegions`; reuses the region order fetch, navigation, fitting cargo and skills.
+
 ## [0.10.1] - 2026-05-29
 
 ## [0.10.0] - 2026-05-28

--- a/app/lib/api/hauling_models.dart
+++ b/app/lib/api/hauling_models.dart
@@ -1,0 +1,258 @@
+/// Neighborhood Hauling Routes DTOs — field names map exactly to the backend
+/// json tags for POST /api/v1/trading/hauling/routes.
+///
+/// CRITICAL: parsing is null/float-robust (mirrors hub_comparison_models.dart /
+/// portfolio_models.dart). Every numeric field tolerates absent/null values and
+/// accepts any [num] (int or double). A past production bug was caused by
+/// non-robust mobile DTO parsing.
+library;
+
+import 'hub_comparison_models.dart' show SkillsApplied;
+
+export 'hub_comparison_models.dart' show SkillsApplied;
+
+// ---------------------------------------------------------------------------
+// HaulingRequest
+// ---------------------------------------------------------------------------
+
+/// Request body for POST /api/v1/trading/hauling/routes.
+///
+/// Mirrors the backend request struct exactly (snake_case json tags).
+/// [originRegionId] of 0 ⇒ the backend uses the character's current region.
+class HaulingRequest {
+  const HaulingRequest({
+    required this.originRegionId,
+    required this.shipTypeId,
+    required this.capital,
+    required this.avoidLowSec,
+    required this.maxRoutes,
+  });
+
+  /// Backend: `origin_region_id` — 0 means "use the character's current region".
+  final int originRegionId;
+
+  /// Backend: `ship_type_id`
+  final int shipTypeId;
+
+  /// Backend: `capital` — total ISK available for hauling.
+  final double capital;
+
+  /// Backend: `avoid_low_sec` — when true, low-sec hops are excluded.
+  final bool avoidLowSec;
+
+  /// Backend: `max_routes` — cap on the number of routes returned.
+  final int maxRoutes;
+
+  Map<String, dynamic> toJson() => {
+        'origin_region_id': originRegionId,
+        'ship_type_id': shipTypeId,
+        'capital': capital,
+        'avoid_low_sec': avoidLowSec,
+        'max_routes': maxRoutes,
+      };
+}
+
+// ---------------------------------------------------------------------------
+// HaulingItem
+// ---------------------------------------------------------------------------
+
+/// A single item in a hauling route's optimal cargo load.
+/// Backend: an element of a route's `items` array.
+class HaulingItem {
+  const HaulingItem({
+    required this.typeId,
+    required this.name,
+    required this.quantity,
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.unitVolume,
+    required this.profit,
+    required this.profitPerM3,
+  });
+
+  /// Backend: `type_id`
+  final int typeId;
+
+  /// Backend: `name`
+  final String name;
+
+  /// Backend: `quantity` — units to haul.
+  final int quantity;
+
+  /// Backend: `buy_price` — per-unit buy price at the origin station.
+  final double buyPrice;
+
+  /// Backend: `sell_price` — per-unit sell price at the destination station.
+  final double sellPrice;
+
+  /// Backend: `unit_volume` — m³ per unit.
+  final double unitVolume;
+
+  /// Backend: `profit` — total net profit for this item across [quantity].
+  final double profit;
+
+  /// Backend: `profit_per_m3` — net profit per m³ of cargo.
+  final double profitPerM3;
+
+  factory HaulingItem.fromJson(Map<String, dynamic> json) {
+    return HaulingItem(
+      typeId: (json['type_id'] as num?)?.toInt() ?? 0,
+      name: json['name'] as String? ?? '',
+      quantity: (json['quantity'] as num?)?.toInt() ?? 0,
+      buyPrice: (json['buy_price'] as num?)?.toDouble() ?? 0,
+      sellPrice: (json['sell_price'] as num?)?.toDouble() ?? 0,
+      unitVolume: (json['unit_volume'] as num?)?.toDouble() ?? 0,
+      profit: (json['profit'] as num?)?.toDouble() ?? 0,
+      profitPerM3: (json['profit_per_m3'] as num?)?.toDouble() ?? 0,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HaulingRoute
+// ---------------------------------------------------------------------------
+
+/// A single profitable station→station hauling route with an optimal load.
+/// Backend: an element of the `routes` array.
+class HaulingRoute {
+  const HaulingRoute({
+    required this.buySystemName,
+    required this.buyStationName,
+    required this.buyStationId,
+    required this.sellSystemName,
+    required this.sellStationName,
+    required this.sellStationId,
+    required this.jumps,
+    required this.travelTimeMin,
+    required this.securityRisk,
+    required this.totalProfit,
+    required this.totalCapital,
+    required this.totalVolume,
+    required this.iskPerHour,
+    required this.items,
+  });
+
+  /// Backend: `buy_system_name`
+  final String buySystemName;
+
+  /// Backend: `buy_station_name`
+  final String buyStationName;
+
+  /// Backend: `buy_station_id` — station/structure id used as buy waypoint.
+  final int buyStationId;
+
+  /// Backend: `sell_system_name`
+  final String sellSystemName;
+
+  /// Backend: `sell_station_name`
+  final String sellStationName;
+
+  /// Backend: `sell_station_id` — station/structure id used as sell waypoint.
+  final int sellStationId;
+
+  /// Backend: `jumps` — number of jumps from buy to sell station.
+  final int jumps;
+
+  /// Backend: `travel_time_min` — estimated travel time in minutes.
+  final double travelTimeMin;
+
+  /// Backend: `security_risk` — "safe" | "caution" | "danger".
+  final String securityRisk;
+
+  /// Backend: `total_profit` — net ISK profit for the full optimal load.
+  final double totalProfit;
+
+  /// Backend: `total_capital` — ISK required to buy the optimal load.
+  final double totalCapital;
+
+  /// Backend: `total_volume` — m³ of the optimal load.
+  final double totalVolume;
+
+  /// Backend: `isk_per_hour` — the route's headline efficiency metric.
+  final double iskPerHour;
+
+  /// Backend: `items` — the optimal cargo load.
+  final List<HaulingItem> items;
+
+  factory HaulingRoute.fromJson(Map<String, dynamic> json) {
+    final rawItems = json['items'] as List<dynamic>? ?? const [];
+    return HaulingRoute(
+      buySystemName: json['buy_system_name'] as String? ?? '',
+      buyStationName: json['buy_station_name'] as String? ?? '',
+      buyStationId: (json['buy_station_id'] as num?)?.toInt() ?? 0,
+      sellSystemName: json['sell_system_name'] as String? ?? '',
+      sellStationName: json['sell_station_name'] as String? ?? '',
+      sellStationId: (json['sell_station_id'] as num?)?.toInt() ?? 0,
+      jumps: (json['jumps'] as num?)?.toInt() ?? 0,
+      travelTimeMin: (json['travel_time_min'] as num?)?.toDouble() ?? 0,
+      securityRisk: json['security_risk'] as String? ?? 'safe',
+      totalProfit: (json['total_profit'] as num?)?.toDouble() ?? 0,
+      totalCapital: (json['total_capital'] as num?)?.toDouble() ?? 0,
+      totalVolume: (json['total_volume'] as num?)?.toDouble() ?? 0,
+      iskPerHour: (json['isk_per_hour'] as num?)?.toDouble() ?? 0,
+      items: rawItems
+          .whereType<Map<String, dynamic>>()
+          .map(HaulingItem.fromJson)
+          .toList(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HaulingResponse
+// ---------------------------------------------------------------------------
+
+/// Response from POST /api/v1/trading/hauling/routes.
+///
+/// [routes] is pre-sorted by the backend (isk_per_hour desc). An empty
+/// [routes] list is a valid, successful result meaning "no profitable routes
+/// in the neighborhood" — it is NOT an error.
+class HaulingResponse {
+  const HaulingResponse({
+    required this.originRegionId,
+    required this.regionsScanned,
+    required this.routes,
+    required this.skillsApplied,
+  });
+
+  /// Backend: `origin_region_id` — the region actually used as origin.
+  final int originRegionId;
+
+  /// Backend: `regions_scanned` — region ids included in the scan.
+  final List<int> regionsScanned;
+
+  /// Backend: `routes` — pre-sorted by isk_per_hour desc.
+  final List<HaulingRoute> routes;
+
+  /// Backend: `skills_applied`
+  final SkillsApplied skillsApplied;
+
+  /// True when no profitable routes were found.
+  bool get isEmpty => routes.isEmpty;
+
+  factory HaulingResponse.fromJson(Map<String, dynamic> json) {
+    final rawRoutes = json['routes'] as List<dynamic>? ?? const [];
+    final rawRegions = json['regions_scanned'] as List<dynamic>? ?? const [];
+    final skillsRaw = json['skills_applied'];
+    return HaulingResponse(
+      originRegionId: (json['origin_region_id'] as num?)?.toInt() ?? 0,
+      regionsScanned: rawRegions
+          .whereType<num>()
+          .map((n) => n.toInt())
+          .toList(),
+      routes: rawRoutes
+          .whereType<Map<String, dynamic>>()
+          .map(HaulingRoute.fromJson)
+          .toList(),
+      skillsApplied: skillsRaw is Map<String, dynamic>
+          ? SkillsApplied.fromJson(skillsRaw)
+          : const SkillsApplied(
+              applied: false,
+              accounting: 0,
+              brokerRelations: 0,
+              salesTaxRate: 0,
+              brokerFeeRate: 0,
+            ),
+    );
+  }
+}

--- a/app/lib/api/trading_api.dart
+++ b/app/lib/api/trading_api.dart
@@ -7,6 +7,7 @@ library;
 
 import 'package:dio/dio.dart';
 
+import 'hauling_models.dart';
 import 'hub_comparison_models.dart';
 import 'portfolio_models.dart';
 import 'trading_models.dart';
@@ -51,6 +52,20 @@ class TradingApi {
       data: request.toJson(),
     );
     return PortfolioResult.fromJson(response.data!);
+  }
+
+  // ── POST /api/v1/trading/hauling/routes ────────────────────────────────────
+
+  /// Finds profitable station→station hauling routes in the character's
+  /// current region plus adjacent regions. Returns a [HaulingResponse] with
+  /// routes pre-sorted by isk_per_hour desc; an empty `routes` list means no
+  /// profitable routes were found in the neighborhood.
+  Future<HaulingResponse> findHaulingRoutes(HaulingRequest request) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/api/v1/trading/hauling/routes',
+      data: request.toJson(),
+    );
+    return HaulingResponse.fromJson(response.data!);
   }
 
   // ── POST /api/v1/trading/routes/calculate ──────────────────────────────────

--- a/app/lib/core/router.dart
+++ b/app/lib/core/router.dart
@@ -20,6 +20,7 @@ import 'package:go_router/go_router.dart';
 import '../auth/auth_controller.dart';
 import '../auth/login_screen.dart';
 import '../features/character/character_screen.dart';
+import '../features/trading/hauling_screen.dart';
 import '../features/trading/hub_comparison_screen.dart';
 import '../features/trading/roi_calculator_screen.dart';
 import '../features/trading/trading_screen.dart';
@@ -101,6 +102,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             builder: (context, state) => const RoiCalculatorScreen(),
           ),
           GoRoute(
+            path: '/hauling',
+            builder: (context, state) => const HaulingScreen(),
+          ),
+          GoRoute(
             path: '/character',
             builder: (context, state) => const CharacterScreen(),
           ),
@@ -137,6 +142,10 @@ class _AppShell extends ConsumerWidget {
       label: 'ROI',
     ),
     NavigationDestination(
+      icon: Icon(Icons.local_shipping_rounded),
+      label: 'Hauling',
+    ),
+    NavigationDestination(
       icon: Icon(Icons.person_outline_rounded),
       selectedIcon: Icon(Icons.person_rounded),
       label: 'Character',
@@ -150,7 +159,8 @@ class _AppShell extends ConsumerWidget {
   int get _selectedIndex {
     if (location.startsWith('/hub-comparison')) return 1;
     if (location.startsWith('/roi-calculator')) return 2;
-    if (location.startsWith('/character')) return 3;
+    if (location.startsWith('/hauling')) return 3;
+    if (location.startsWith('/character')) return 4;
     return 0; // /trading is default; "Abmelden" is never a selected state
   }
 
@@ -169,8 +179,10 @@ class _AppShell extends ConsumerWidget {
             case 2:
               context.go('/roi-calculator');
             case 3:
-              context.go('/character');
+              context.go('/hauling');
             case 4:
+              context.go('/character');
+            case 5:
               _confirmLogout(context, ref);
           }
         },

--- a/app/lib/features/trading/hauling_providers.dart
+++ b/app/lib/features/trading/hauling_providers.dart
@@ -1,0 +1,43 @@
+/// Riverpod providers for the Neighborhood Hauling Routes feature.
+///
+/// Provider graph (reuses [tradingApiProvider] from providers.dart):
+///   tradingApiProvider → haulingRoutesProvider (AsyncNotifier)
+///
+/// Ship selection reuses the existing trading-feature provider
+/// ([selectedShipTypeIdProvider]).
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/hauling_models.dart';
+import 'providers.dart' show tradingApiProvider;
+
+// ---------------------------------------------------------------------------
+// HaulingRoutesNotifier — AsyncNotifier<HaulingResponse?>
+// ---------------------------------------------------------------------------
+
+/// Owns the hauling-route-search lifecycle.
+///
+/// [build] returns null — no search has been performed yet. Call [find] with a
+/// [HaulingRequest] to trigger one; it sets [AsyncLoading] then guards the API
+/// call. An empty `routes` list on the resulting [HaulingResponse] is a valid,
+/// successful "no profitable routes" state — it is NOT treated as an error.
+class HaulingRoutesNotifier extends AsyncNotifier<HaulingResponse?> {
+  @override
+  Future<HaulingResponse?> build() async => null;
+
+  /// Runs a hauling-route search for [request].
+  Future<void> find(HaulingRequest request) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final api = ref.read(tradingApiProvider);
+      return api.findHaulingRoutes(request);
+    });
+  }
+}
+
+/// Provider for [HaulingRoutesNotifier].
+final haulingRoutesProvider =
+    AsyncNotifierProvider<HaulingRoutesNotifier, HaulingResponse?>(
+  HaulingRoutesNotifier.new,
+);

--- a/app/lib/features/trading/hauling_screen.dart
+++ b/app/lib/features/trading/hauling_screen.dart
@@ -1,0 +1,742 @@
+/// Adaptive Neighborhood Hauling Routes screen.
+///
+/// The user picks a Ship + enters their available Capital (ISK) + toggles
+/// "avoid low-sec". The backend then scans the character's current region plus
+/// adjacent regions and returns profitable station→station hauling routes
+/// (buy cheap at one station, sell dear at another), each with an optimal cargo
+/// load and an isk/hour metric. Routes are pre-sorted by isk/hour desc. The
+/// user can push a route to the in-game autopilot.
+///
+/// Layout (via [isTwoPane] / [kTwoPaneBreakpoint] = 840 dp):
+///   • <840 dp  → single-pane: input form above a scrollable route list;
+///                tapping a route pushes a detail page.
+///   • ≥840 dp  → two-pane: input form on the left, route list on the right;
+///                tapping a route shows its detail in a dialog.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/hauling_models.dart';
+import '../../core/breakpoint.dart';
+import 'hauling_providers.dart';
+import 'providers.dart';
+import 'ship_select.dart';
+
+// ---------------------------------------------------------------------------
+// Security-risk → colour mapping (safe=green, caution=amber, danger=red)
+// ---------------------------------------------------------------------------
+
+const Color _kSafeColor = Color(0xFF66BB6A);
+const Color _kCautionColor = Color(0xFFFF9800);
+const Color _kDangerColor = Color(0xFFF44336);
+
+/// Maps a backend `security_risk` value to its chip colour.
+Color securityRiskColor(String risk) {
+  switch (risk) {
+    case 'danger':
+      return _kDangerColor;
+    case 'caution':
+      return _kCautionColor;
+    case 'safe':
+    default:
+      return _kSafeColor;
+  }
+}
+
+/// Maps a backend `security_risk` value to a German chip label.
+String securityRiskLabel(String risk) {
+  switch (risk) {
+    case 'danger':
+      return 'Gefahr';
+    case 'caution':
+      return 'Vorsicht';
+    case 'safe':
+    default:
+      return 'Sicher';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// The hauling-routes screen.
+class HaulingScreen extends ConsumerWidget {
+  const HaulingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Hauling-Routen'),
+        centerTitle: false,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final twoPane = isTwoPane(constraints.maxWidth);
+          if (twoPane) {
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: const [
+                SizedBox(
+                  width: 340,
+                  child: SingleChildScrollView(
+                    padding: EdgeInsets.all(16),
+                    child: _InputForm(),
+                  ),
+                ),
+                VerticalDivider(width: 1),
+                Expanded(child: _ResultPane(twoPane: true)),
+              ],
+            );
+          }
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: const [
+              Flexible(
+                child: SingleChildScrollView(
+                  padding: EdgeInsets.all(16),
+                  child: _InputForm(),
+                ),
+              ),
+              Divider(height: 1),
+              Expanded(child: _ResultPane(twoPane: false)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input form — ship picker + capital + avoid-low-sec switch
+// ---------------------------------------------------------------------------
+
+class _InputForm extends ConsumerStatefulWidget {
+  const _InputForm();
+
+  @override
+  ConsumerState<_InputForm> createState() => _InputFormState();
+}
+
+class _InputFormState extends ConsumerState<_InputForm> {
+  final _capitalController = TextEditingController(text: '500000000');
+  bool _avoidLowSec = true;
+  String? _error;
+
+  @override
+  void dispose() {
+    _capitalController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _search() async {
+    final shipTypeId = ref.read(selectedShipTypeIdProvider);
+    final capital = double.tryParse(
+        _capitalController.text.replaceAll(RegExp(r'[^0-9.]'), ''));
+
+    if (shipTypeId == null) {
+      setState(() => _error = 'Bitte ein Schiff auswählen.');
+      return;
+    }
+    if (capital == null || capital <= 0) {
+      setState(() => _error = 'Bitte ein gültiges Kapital eingeben.');
+      return;
+    }
+
+    setState(() => _error = null);
+
+    // origin_region_id: 0 ⇒ backend uses the character's current region.
+    final request = HaulingRequest(
+      originRegionId: 0,
+      shipTypeId: shipTypeId,
+      capital: capital,
+      avoidLowSec: _avoidLowSec,
+      maxRoutes: 15,
+    );
+
+    await ref.read(haulingRoutesProvider.notifier).find(request);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final busy = ref.watch(haulingRoutesProvider).isLoading;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // ── Ship ───────────────────────────────────────────────────────────
+        ShipSelect(enabled: !busy),
+        const SizedBox(height: 12),
+
+        // ── Capital ────────────────────────────────────────────────────────
+        TextField(
+          controller: _capitalController,
+          enabled: !busy,
+          keyboardType: TextInputType.number,
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          decoration: const InputDecoration(
+            labelText: 'Kapital',
+            border: OutlineInputBorder(),
+            isDense: true,
+            suffixText: 'ISK',
+            contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          ),
+        ),
+        const SizedBox(height: 8),
+
+        // ── Avoid low-sec ──────────────────────────────────────────────────
+        SwitchListTile(
+          key: const Key('hauling-avoid-lowsec'),
+          value: _avoidLowSec,
+          onChanged: busy ? null : (v) => setState(() => _avoidLowSec = v),
+          title: const Text(
+            'Low-Sec vermeiden',
+            style: TextStyle(fontSize: 14),
+          ),
+          contentPadding: EdgeInsets.zero,
+          dense: true,
+        ),
+
+        if (_error != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            _error!,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ],
+
+        const SizedBox(height: 16),
+
+        // ── Search button ──────────────────────────────────────────────────
+        FilledButton.icon(
+          onPressed: busy ? null : _search,
+          icon: busy
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.local_shipping_rounded),
+          label: const Text('Routen suchen'),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result pane — async-aware
+// ---------------------------------------------------------------------------
+
+class _ResultPane extends ConsumerWidget {
+  const _ResultPane({required this.twoPane});
+
+  final bool twoPane;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(haulingRoutesProvider);
+
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (err, _) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Routensuche fehlgeschlagen.\n$err',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ),
+      ),
+      data: (resp) {
+        if (resp == null) {
+          return const _IdleHint();
+        }
+        if (resp.isEmpty) {
+          return const _EmptyResult();
+        }
+        return _RouteList(response: resp, twoPane: twoPane);
+      },
+    );
+  }
+}
+
+class _IdleHint extends StatelessWidget {
+  const _IdleHint();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.local_shipping_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Schiff + Kapital wählen und Routen suchen',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(120),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyResult extends StatelessWidget {
+  const _EmptyResult();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          key: const Key('hauling-empty-state'),
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sentiment_dissatisfied_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Keine profitablen Routen im Umkreis',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(140),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route list
+// ---------------------------------------------------------------------------
+
+class _RouteList extends StatelessWidget {
+  const _RouteList({required this.response, required this.twoPane});
+
+  final HaulingResponse response;
+  final bool twoPane;
+
+  @override
+  Widget build(BuildContext context) {
+    final skills = response.skillsApplied;
+    return ListView(
+      key: const Key('hauling-route-list'),
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          'Gefundene Routen',
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          skills.applied
+              ? 'Skill-bereinigt (Accounting ${skills.accounting}, '
+                  'Broker Relations ${skills.brokerRelations})'
+              : 'Ohne Skill-Bereinigung',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 12),
+        for (final route in response.routes)
+          _RouteCard(route: route, twoPane: twoPane),
+      ],
+    );
+  }
+}
+
+class _RouteCard extends StatelessWidget {
+  const _RouteCard({required this.route, required this.twoPane});
+
+  final HaulingRoute route;
+  final bool twoPane;
+
+  void _openDetail(BuildContext context) {
+    if (twoPane) {
+      showDialog<void>(
+        context: context,
+        builder: (_) => Dialog(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560, maxHeight: 720),
+            child: HaulingRouteDetail(route: route),
+          ),
+        ),
+      );
+    } else {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => Scaffold(
+            appBar: AppBar(
+              title: Text('${route.buySystemName} → ${route.sellSystemName}'),
+            ),
+            body: HaulingRouteDetail(route: route),
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.primary;
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: InkWell(
+        key: Key('hauling-route-${route.buyStationId}-${route.sellStationId}'),
+        onTap: () => _openDetail(context),
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // ── Route header: buy → sell + sec-risk chip ─────────────────
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '${route.buySystemName} → ${route.sellSystemName}',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  _SecurityRiskChip(risk: route.securityRisk),
+                ],
+              ),
+              const SizedBox(height: 8),
+
+              // ── ISK/h — large accent ─────────────────────────────────────
+              Text(
+                '${_fmtIsk(route.iskPerHour)} ISK/h',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      color: accent,
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 8),
+
+              // ── Meta row: jumps, travel time, total profit ───────────────
+              Wrap(
+                spacing: 16,
+                runSpacing: 4,
+                children: [
+                  _Meta(
+                    icon: Icons.alt_route_rounded,
+                    label: '${route.jumps} Sprünge',
+                  ),
+                  _Meta(
+                    icon: Icons.schedule_rounded,
+                    label: '${route.travelTimeMin.toStringAsFixed(1)} min',
+                  ),
+                  _Meta(
+                    icon: Icons.payments_rounded,
+                    label: '${_fmtIsk(route.totalProfit)} ISK',
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Meta extends StatelessWidget {
+  const _Meta({required this.icon, required this.label});
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final muted = Theme.of(context).colorScheme.onSurface.withAlpha(153);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: muted),
+        const SizedBox(width: 4),
+        Text(label, style: TextStyle(color: muted)),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Security-risk chip (safe=green / caution=amber / danger=red)
+// ---------------------------------------------------------------------------
+
+class _SecurityRiskChip extends StatelessWidget {
+  const _SecurityRiskChip({required this.risk});
+
+  final String risk;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = securityRiskColor(risk);
+    return Container(
+      key: Key('hauling-risk-chip-$risk'),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withAlpha(40),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withAlpha(150)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.shield_rounded, size: 14, color: color),
+          const SizedBox(width: 4),
+          Text(
+            securityRiskLabel(risk),
+            style: TextStyle(
+              color: color,
+              fontWeight: FontWeight.w600,
+              fontSize: 12,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route detail — cargo item table + "Route an EVE übertragen" button
+// ---------------------------------------------------------------------------
+
+/// Full detail view for a [HaulingRoute]: a cargo item table plus a button that
+/// pushes the route to the in-game autopilot (buy station then sell station).
+class HaulingRouteDetail extends ConsumerWidget {
+  const HaulingRouteDetail({super.key, required this.route});
+
+  final HaulingRoute route;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accent = Theme.of(context).colorScheme.primary;
+    final muted = Theme.of(context).colorScheme.onSurface.withAlpha(153);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ── Header ─────────────────────────────────────────────────────
+          Text(
+            'Hauling-Route',
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: muted,
+                  letterSpacing: 1.1,
+                ),
+          ),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '${route.buySystemName} → ${route.sellSystemName}',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _SecurityRiskChip(risk: route.securityRisk),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '${route.buyStationName}\n→ ${route.sellStationName}',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: muted),
+          ),
+          const SizedBox(height: 12),
+
+          Text(
+            '${_fmtIsk(route.iskPerHour)} ISK/h',
+            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  color: accent,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 8),
+
+          // ── Summary row ──────────────────────────────────────────────────
+          Wrap(
+            spacing: 16,
+            runSpacing: 4,
+            children: [
+              _Meta(
+                icon: Icons.alt_route_rounded,
+                label: '${route.jumps} Sprünge',
+              ),
+              _Meta(
+                icon: Icons.schedule_rounded,
+                label: '${route.travelTimeMin.toStringAsFixed(1)} min',
+              ),
+              _Meta(
+                icon: Icons.payments_rounded,
+                label: 'Gewinn ${_fmtIsk(route.totalProfit)}',
+              ),
+              _Meta(
+                icon: Icons.account_balance_wallet_rounded,
+                label: 'Kapital ${_fmtIsk(route.totalCapital)}',
+              ),
+              _Meta(
+                icon: Icons.inventory_2_rounded,
+                label: '${_fmtVolume(route.totalVolume)} m³',
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+
+          // ── Cargo item table ─────────────────────────────────────────────
+          Text(
+            'Ladung',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              key: const Key('hauling-cargo-table'),
+              columns: const [
+                DataColumn(label: Text('Item')),
+                DataColumn(label: Text('Menge'), numeric: true),
+                DataColumn(label: Text('Kauf'), numeric: true),
+                DataColumn(label: Text('Verkauf'), numeric: true),
+                DataColumn(label: Text('Volumen'), numeric: true),
+                DataColumn(label: Text('Gewinn'), numeric: true),
+                DataColumn(label: Text('Gewinn/m³'), numeric: true),
+              ],
+              rows: [
+                for (final item in route.items)
+                  DataRow(
+                    cells: [
+                      DataCell(Text(item.name)),
+                      DataCell(Text(_fmtUnits(item.quantity.toDouble()))),
+                      DataCell(Text(_fmtIsk(item.buyPrice))),
+                      DataCell(Text(_fmtIsk(item.sellPrice))),
+                      DataCell(Text(
+                          '${_fmtVolume(item.unitVolume * item.quantity)} m³')),
+                      DataCell(Text(_fmtIsk(item.profit))),
+                      DataCell(Text(_fmtIsk(item.profitPerM3))),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+
+          // ── Action button ────────────────────────────────────────────────
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              key: const Key('hauling-waypoint-button'),
+              onPressed: () => _setWaypoint(context, ref),
+              icon: const Icon(Icons.navigation_rounded),
+              label: const Text('Route an EVE übertragen'),
+              style: FilledButton.styleFrom(
+                backgroundColor: accent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                textStyle: const TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 16,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _setWaypoint(BuildContext context, WidgetRef ref) async {
+    final api = ref.read(tradingApiProvider);
+    try {
+      // Clear existing route; set buy station first, then append sell station.
+      await api.setWaypoint(
+        destinationId: route.buyStationId,
+        clearOtherWaypoints: true,
+        addToBeginning: false,
+      );
+      await api.setWaypoint(
+        destinationId: route.sellStationId,
+        clearOtherWaypoints: false,
+        addToBeginning: false,
+      );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Route gesetzt: ${route.buySystemName} → ${route.sellSystemName}',
+            ),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Fehler beim Setzen der Route: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers (mirrors roi/hub screens)
+// ---------------------------------------------------------------------------
+
+String _fmtIsk(double v) {
+  if (v >= 1e9) return '${(v / 1e9).toStringAsFixed(2)}B';
+  if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(2)}M';
+  if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+  return v.toStringAsFixed(2);
+}
+
+String _fmtVolume(double v) {
+  if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(1)}M';
+  if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+  return v.toStringAsFixed(0);
+}
+
+String _fmtUnits(double v) {
+  if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(1)}M';
+  if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+  return v.toStringAsFixed(0);
+}

--- a/app/test/hauling_models_test.dart
+++ b/app/test/hauling_models_test.dart
@@ -1,0 +1,119 @@
+/// Unit tests for HaulingResponse.fromJson — exercises the null/float-robust
+/// parsing required for the mobile DTO layer.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/hauling_models.dart';
+
+void main() {
+  group('HaulingResponse.fromJson', () {
+    const Map<String, dynamic> sample = {
+      'origin_region_id': 10000002,
+      'regions_scanned': [10000002, 10000016],
+      'routes': [
+        {
+          'buy_system_name': 'Osmon',
+          'buy_station_name': 'Osmon V - Moon 5 - Some Station',
+          'buy_station_id': 60000001,
+          'sell_system_name': 'Jita',
+          'sell_station_name': 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
+          'sell_station_id': 60003760,
+          'jumps': 7,
+          'travel_time_min': 12.5,
+          'security_risk': 'safe',
+          'total_profit': 1.2e8,
+          'total_capital': 3.4e8,
+          'total_volume': 2400,
+          'isk_per_hour': 4.8e8,
+          'items': [
+            {
+              'type_id': 34,
+              'name': 'Meta-4 Module A',
+              'quantity': 50,
+              'buy_price': 1.0e6,
+              'sell_price': 1.9e6,
+              'unit_volume': 10,
+              'profit': 4.5e7,
+              'profit_per_m3': 90000,
+            },
+          ],
+        },
+      ],
+      'skills_applied': {
+        'applied': true,
+        'accounting': 5,
+        'broker_relations': 5,
+        'sales_tax_rate': 0.025,
+        'broker_fee_rate': 0.015,
+      },
+    };
+
+    test('parses all fields including nested route + item', () {
+      final resp = HaulingResponse.fromJson(sample);
+
+      expect(resp.originRegionId, 10000002);
+      expect(resp.regionsScanned, [10000002, 10000016]);
+      expect(resp.isEmpty, isFalse);
+      expect(resp.routes, hasLength(1));
+      expect(resp.skillsApplied.applied, isTrue);
+      expect(resp.skillsApplied.accounting, 5);
+
+      final route = resp.routes.first;
+      expect(route.buySystemName, 'Osmon');
+      expect(route.sellSystemName, 'Jita');
+      expect(route.buyStationId, 60000001);
+      expect(route.sellStationId, 60003760);
+      expect(route.jumps, 7);
+      expect(route.travelTimeMin, 12.5);
+      expect(route.securityRisk, 'safe');
+      expect(route.totalProfit, 1.2e8);
+      expect(route.totalCapital, 3.4e8);
+      expect(route.totalVolume, 2400);
+      expect(route.iskPerHour, 4.8e8);
+
+      final item = route.items.single;
+      expect(item.typeId, 34);
+      expect(item.name, 'Meta-4 Module A');
+      expect(item.quantity, 50);
+      expect(item.buyPrice, 1.0e6);
+      expect(item.sellPrice, 1.9e6);
+      expect(item.unitVolume, 10);
+      expect(item.profit, 4.5e7);
+      expect(item.profitPerM3, 90000);
+    });
+
+    test('tolerates missing / null fields (defaults, not exceptions)', () {
+      final resp = HaulingResponse.fromJson(const {
+        'routes': [
+          {
+            'buy_system_name': 'A',
+            'sell_system_name': 'B',
+            // everything numeric absent
+          },
+        ],
+      });
+
+      expect(resp.originRegionId, 0);
+      expect(resp.regionsScanned, isEmpty);
+      expect(resp.skillsApplied.applied, isFalse);
+
+      final route = resp.routes.single;
+      expect(route.jumps, 0);
+      expect(route.travelTimeMin, 0);
+      expect(route.securityRisk, 'safe'); // defaulted
+      expect(route.iskPerHour, 0);
+      expect(route.items, isEmpty);
+    });
+
+    test('empty routes list is a valid "no routes" result', () {
+      final resp = HaulingResponse.fromJson(const {
+        'origin_region_id': 10000002,
+        'regions_scanned': [10000002],
+        'routes': [],
+      });
+      expect(resp.isEmpty, isTrue);
+      expect(resp.routes, isEmpty);
+    });
+  });
+}

--- a/app/test/hauling_screen_layout_test.dart
+++ b/app/test/hauling_screen_layout_test.dart
@@ -1,0 +1,235 @@
+/// Widget tests for HaulingScreen adaptive layout + route list + detail.
+///
+/// 1. Small view (<840 dp) → single-pane: no VerticalDivider.
+/// 2. Large view (≥840 dp) → two-pane: at least one VerticalDivider.
+/// Plus: route list renders from a seeded response, the security-risk chip uses
+/// the right colour, the cargo detail table renders on tap, and an empty
+/// `routes` result shows the "no profitable routes" empty-state.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/hauling_models.dart';
+import 'package:eve_o_provit/api/trading_api.dart';
+import 'package:eve_o_provit/core/theme.dart';
+import 'package:eve_o_provit/features/character/character_api.dart';
+import 'package:eve_o_provit/features/character/character_models.dart';
+import 'package:eve_o_provit/features/character/providers.dart'
+    show characterApiProvider;
+import 'package:eve_o_provit/features/trading/hauling_providers.dart';
+import 'package:eve_o_provit/features/trading/hauling_screen.dart';
+import 'package:eve_o_provit/features/trading/providers.dart';
+
+// ---------------------------------------------------------------------------
+// Canned data + fakes
+// ---------------------------------------------------------------------------
+
+HaulingResponse _fakeResponse() => const HaulingResponse(
+      originRegionId: 10000002,
+      regionsScanned: [10000002, 10000016],
+      routes: [
+        HaulingRoute(
+          buySystemName: 'Osmon',
+          buyStationName: 'Osmon V - Moon 5 - Station',
+          buyStationId: 60000001,
+          sellSystemName: 'Jita',
+          sellStationName: 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
+          sellStationId: 60003760,
+          jumps: 7,
+          travelTimeMin: 12.5,
+          securityRisk: 'safe',
+          totalProfit: 1.2e8,
+          totalCapital: 3.4e8,
+          totalVolume: 2400,
+          iskPerHour: 4.8e8,
+          items: [
+            HaulingItem(
+              typeId: 34,
+              name: 'Meta-4 Module A',
+              quantity: 50,
+              buyPrice: 1.0e6,
+              sellPrice: 1.9e6,
+              unitVolume: 10,
+              profit: 4.5e7,
+              profitPerM3: 90000,
+            ),
+          ],
+        ),
+        HaulingRoute(
+          buySystemName: 'Hek',
+          buyStationName: 'Hek VIII - Moon 12 - Boundless Creation',
+          buyStationId: 60000002,
+          sellSystemName: 'Rens',
+          sellStationName: 'Rens VI - Moon 8 - Brutor Tribe Treasury',
+          sellStationId: 60004588,
+          jumps: 3,
+          travelTimeMin: 5.0,
+          securityRisk: 'danger',
+          totalProfit: 6.0e7,
+          totalCapital: 1.0e8,
+          totalVolume: 1200,
+          iskPerHour: 2.0e8,
+          items: [
+            HaulingItem(
+              typeId: 35,
+              name: 'Meta-4 Module B',
+              quantity: 20,
+              buyPrice: 5.0e5,
+              sellPrice: 1.1e6,
+              unitVolume: 5,
+              profit: 1.2e7,
+              profitPerM3: 120000,
+            ),
+          ],
+        ),
+      ],
+      skillsApplied: SkillsApplied(
+        applied: true,
+        accounting: 5,
+        brokerRelations: 5,
+        salesTaxRate: 0.025,
+        brokerFeeRate: 0.015,
+      ),
+    );
+
+HaulingResponse _emptyResponse() => const HaulingResponse(
+      originRegionId: 10000002,
+      regionsScanned: [10000002],
+      routes: [],
+      skillsApplied: SkillsApplied(
+        applied: false,
+        accounting: 0,
+        brokerRelations: 0,
+        salesTaxRate: 0,
+        brokerFeeRate: 0,
+      ),
+    );
+
+class _FakeTradingApi extends TradingApi {
+  _FakeTradingApi() : super(Dio());
+
+  @override
+  Future<HaulingResponse> findHaulingRoutes(HaulingRequest request) async =>
+      _fakeResponse();
+}
+
+class _FakeCharacterApi extends CharacterApi {
+  _FakeCharacterApi() : super(Dio());
+
+  @override
+  Future<CharacterShipsResponse> ships() async =>
+      const CharacterShipsResponse(ships: [], count: 0);
+}
+
+class _StubNotifier extends HaulingRoutesNotifier {
+  @override
+  Future<HaulingResponse?> build() async => _fakeResponse();
+}
+
+class _EmptyNotifier extends HaulingRoutesNotifier {
+  @override
+  Future<HaulingResponse?> build() async => _emptyResponse();
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  double width, {
+  double height = 1400,
+  HaulingRoutesNotifier Function() notifier = _StubNotifier.new,
+}) async {
+  tester.view.physicalSize = Size(width, height);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tradingApiProvider.overrideWithValue(_FakeTradingApi()),
+        characterApiProvider.overrideWithValue(_FakeCharacterApi()),
+        haulingRoutesProvider.overrideWith(notifier),
+      ],
+      child: MaterialApp(
+        theme: buildTheme(Brightness.light),
+        home: const HaulingScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('Single-pane (width 800): no VerticalDivider', (tester) async {
+    await _pumpScreen(tester, 800);
+
+    expect(find.byType(VerticalDivider), findsNothing);
+    expect(find.text('Kapital'), findsOneWidget);
+    expect(find.text('Gefundene Routen'), findsOneWidget);
+  });
+
+  testWidgets('Two-pane (width 1280): at least one VerticalDivider',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byType(VerticalDivider), findsAtLeastNWidgets(1));
+    expect(find.text('Kapital'), findsOneWidget);
+    expect(find.text('Gefundene Routen'), findsOneWidget);
+  });
+
+  testWidgets('Route list renders buy → sell headers', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byKey(const Key('hauling-route-list')), findsOneWidget);
+    expect(find.text('Osmon → Jita'), findsOneWidget);
+    expect(find.text('Hek → Rens'), findsOneWidget);
+  });
+
+  testWidgets('Security risk chips use the correct colour', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    final safeChip = tester.widget<Container>(
+      find.byKey(const Key('hauling-risk-chip-safe')).first,
+    );
+    final safeDeco = safeChip.decoration as BoxDecoration;
+    expect(safeDeco.color, securityRiskColor('safe').withAlpha(40));
+    expect(securityRiskColor('safe'), const Color(0xFF66BB6A)); // green
+
+    final dangerChip = tester.widget<Container>(
+      find.byKey(const Key('hauling-risk-chip-danger')).first,
+    );
+    final dangerDeco = dangerChip.decoration as BoxDecoration;
+    expect(dangerDeco.color, securityRiskColor('danger').withAlpha(40));
+    expect(securityRiskColor('danger'), const Color(0xFFF44336)); // red
+
+    // caution maps to amber (no caution row in fixture, assert mapping directly)
+    expect(securityRiskColor('caution'), const Color(0xFFFF9800));
+  });
+
+  testWidgets('Tapping a route opens the cargo detail table', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    await tester.tap(
+      find.byKey(const Key('hauling-route-60000001-60003760')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('hauling-cargo-table')), findsOneWidget);
+    expect(find.text('Meta-4 Module A'), findsOneWidget);
+    // Cargo column headers.
+    expect(find.text('Gewinn/m³'), findsOneWidget);
+    // Waypoint action button present.
+    expect(find.byKey(const Key('hauling-waypoint-button')), findsOneWidget);
+    expect(find.text('Route an EVE übertragen'), findsOneWidget);
+  });
+
+  testWidgets('Empty routes result shows the empty-state', (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _EmptyNotifier.new);
+
+    expect(find.byKey(const Key('hauling-empty-state')), findsOneWidget);
+    expect(find.text('Keine profitablen Routen im Umkreis'), findsOneWidget);
+    expect(find.byKey(const Key('hauling-route-list')), findsNothing);
+  });
+}

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -36,6 +36,7 @@ type AppContainer struct {
 	CalculationHandler *handlers.CalculationHandler
 	MultiHubHandler    *handlers.MultiHubHandler
 	PortfolioHandler   *handlers.PortfolioHandler
+	HaulingHandler     *handlers.HaulingHandler
 
 	// Background workers
 	CompetitionCollector *services.CompetitionCollector
@@ -156,6 +157,11 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 	// ROI Calculator / capital-allocation optimizer (#44) — reuses the route engine.
 	portfolioService := services.NewPortfolioService(routeService, skillsService, c.AppLogger)
 	c.PortfolioHandler = handlers.NewPortfolioHandler(portfolioService)
+
+	// Neighborhood hauling routes (#45) — reuses order fetch + navigation + cargo + skills.
+	haulingRouteFinder := services.NewRouteFinder(c.ESIClient, c.MarketRepo, c.SDERepo, c.DB.SDE, c.Redis)
+	haulingService := services.NewHaulingService(c.SDERepo, haulingRouteFinder, fittingService, skillsService, characterHelper, c.DB.SDE, c.AppLogger)
+	c.HaulingHandler = handlers.NewHaulingHandler(haulingService)
 
 	// Start the competition collector in the background (lazy-tracked pairs).
 	go c.CompetitionCollector.Start(ctx)

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -154,6 +154,7 @@ func setupApp(c *AppContainer) *fiber.App {
 	api.Post("/trading/routes/calculate", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.TradingHandler.CalculateRoutes)
 	api.Post("/trading/hubs/compare", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.MultiHubHandler.CompareHubs)
 	api.Post("/trading/portfolio/optimize", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.PortfolioHandler.Optimize)
+	api.Post("/trading/hauling/routes", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.HaulingHandler.FindRoutes)
 	api.Get("/items/search", c.TradingHandler.SearchItems)
 
 	api.Post("/calculations/cargo", c.CalculationHandler.CalculateCargo)

--- a/backend/internal/database/sde.go
+++ b/backend/internal/database/sde.go
@@ -226,6 +226,33 @@ func (r *SDERepository) GetRegionIDForSystem(ctx context.Context, systemID int64
 	return regionID, nil
 }
 
+// GetNeighborRegions returns region IDs adjacent to regionID — regions whose system
+// is connected by a stargate to a system in regionID. Excludes regionID itself.
+func (r *SDERepository) GetNeighborRegions(ctx context.Context, regionID int) ([]int, error) {
+	const query = `
+		SELECT DISTINCT s2.regionID
+		FROM v_stargate_graph g
+		JOIN mapSolarSystems s1 ON g.from_system_id = s1._key
+		JOIN mapSolarSystems s2 ON g.to_system_id   = s2._key
+		WHERE s1.regionID = ? AND s2.regionID <> ?
+		ORDER BY s2.regionID
+	`
+	rows, err := r.db.QueryContext(ctx, query, regionID, regionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query neighbor regions for %d: %w", regionID, err)
+	}
+	defer rows.Close()
+	var out []int
+	for rows.Next() {
+		var rid int
+		if err := rows.Scan(&rid); err != nil {
+			return nil, fmt.Errorf("failed to scan neighbor region: %w", err)
+		}
+		out = append(out, rid)
+	}
+	return out, rows.Err()
+}
+
 // SearchItems searches for published items by name with group information
 func (r *SDERepository) SearchItems(ctx context.Context, searchTerm string, limit int) ([]struct {
 	TypeID    int

--- a/backend/internal/database/sde_neighbor_test.go
+++ b/backend/internal/database/sde_neighbor_test.go
@@ -1,0 +1,43 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestGetNeighborRegions builds a minimal in-memory graph: region 10 has systems 1,2;
+// region 20 has system 3; region 30 has system 4. Gates: 1↔3 (cross to 20),
+// 1↔2 (same region 10), 2↔4 (cross to 30). Neighbors of 10 must be {20, 30}.
+func TestGetNeighborRegions(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	stmts := []string{
+		`CREATE TABLE mapSolarSystems (_key INTEGER PRIMARY KEY, regionID INTEGER NOT NULL)`,
+		`CREATE TABLE v_stargate_graph (from_system_id INTEGER, to_system_id INTEGER)`,
+		`INSERT INTO mapSolarSystems (_key, regionID) VALUES (1,10),(2,10),(3,20),(4,30)`,
+		// bidirectional edges (the real view emits both directions too)
+		`INSERT INTO v_stargate_graph (from_system_id, to_system_id) VALUES
+			(1,3),(3,1), (1,2),(2,1), (2,4),(4,2)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.Exec(s); err != nil {
+			t.Fatalf("setup %q: %v", s, err)
+		}
+	}
+
+	repo := NewSDERepository(db)
+	got, err := repo.GetNeighborRegions(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetNeighborRegions: %v", err)
+	}
+	if len(got) != 2 || got[0] != 20 || got[1] != 30 {
+		t.Errorf("neighbors of region 10 = %v, want [20 30]", got)
+	}
+}

--- a/backend/internal/handlers/hauling.go
+++ b/backend/internal/handlers/hauling.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
+)
+
+// HaulingHandler serves the neighborhood hauling-routes endpoint (Issue #45).
+type HaulingHandler struct {
+	service *services.HaulingService
+}
+
+// NewHaulingHandler creates a new hauling handler.
+func NewHaulingHandler(service *services.HaulingService) *HaulingHandler {
+	return &HaulingHandler{service: service}
+}
+
+// FindRoutes handles POST /api/v1/trading/hauling/routes
+//
+// @Summary Find profitable station→station hauling routes in the neighborhood
+// @Description From the character's current region + adjacent regions, finds cross-region
+// @Description arbitrage routes with an optimal per-trip cargo load (cargo + capital).
+// @Tags Trading
+// @Accept json
+// @Produce json
+// @Param request body models.HaulingRequest true "Hauling parameters"
+// @Success 200 {object} models.HaulingResponse
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/trading/hauling/routes [post]
+func (h *HaulingHandler) FindRoutes(c *fiber.Ctx) error {
+	var req models.HaulingRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+	if req.ShipTypeID <= 0 || req.Capital <= 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "ship_type_id and capital are required"})
+	}
+
+	characterID := c.Locals("character_id")
+	accessToken := c.Locals("access_token")
+	if characterID == nil || accessToken == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Authentication required"})
+	}
+	cid, ok := characterID.(int)
+	tok, ok2 := accessToken.(string)
+	if !ok || !ok2 {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid authentication context"})
+	}
+
+	result, err := h.service.FindRoutes(c.UserContext(), &req, cid, tok)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to find hauling routes"})
+	}
+	return c.JSON(result)
+}

--- a/backend/internal/models/hauling.go
+++ b/backend/internal/models/hauling.go
@@ -1,0 +1,48 @@
+package models
+
+// HaulingRequest is the body for POST /api/v1/trading/hauling/routes.
+type HaulingRequest struct {
+	OriginRegionID int     `json:"origin_region_id"` // 0 = use character's current region
+	ShipTypeID     int     `json:"ship_type_id"`
+	Capital        float64 `json:"capital"`
+	AvoidLowSec    bool    `json:"avoid_low_sec"`
+	MaxRoutes      int     `json:"max_routes"` // 0 = default 15
+} // @name HaulingRequest
+
+// HaulingItem is one item in a route's optimal cargo load.
+type HaulingItem struct {
+	TypeID      int     `json:"type_id"`
+	Name        string  `json:"name"`
+	Quantity    int     `json:"quantity"`
+	BuyPrice    float64 `json:"buy_price"`
+	SellPrice   float64 `json:"sell_price"`
+	UnitVolume  float64 `json:"unit_volume"`
+	Profit      float64 `json:"profit"` // net profit for this position
+	ProfitPerM3 float64 `json:"profit_per_m3"`
+} // @name HaulingItem
+
+// HaulingRoute is one buy-station → sell-station haul with its optimal load.
+type HaulingRoute struct {
+	BuySystemName   string        `json:"buy_system_name"`
+	BuyStationName  string        `json:"buy_station_name"`
+	BuyStationID    int64         `json:"buy_station_id"`
+	SellSystemName  string        `json:"sell_system_name"`
+	SellStationName string        `json:"sell_station_name"`
+	SellStationID   int64         `json:"sell_station_id"`
+	Jumps           int           `json:"jumps"`
+	TravelTimeMin   float64       `json:"travel_time_min"`
+	SecurityRisk    string        `json:"security_risk"` // "safe" | "caution" | "danger"
+	TotalProfit     float64       `json:"total_profit"`
+	TotalCapital    float64       `json:"total_capital"`
+	TotalVolume     float64       `json:"total_volume"`
+	ISKPerHour      float64       `json:"isk_per_hour"`
+	Items           []HaulingItem `json:"items"`
+} // @name HaulingRoute
+
+// HaulingResponse is the response for POST /api/v1/trading/hauling/routes.
+type HaulingResponse struct {
+	OriginRegionID int            `json:"origin_region_id"`
+	RegionsScanned []int          `json:"regions_scanned"`
+	Routes         []HaulingRoute `json:"routes"`
+	SkillsApplied  SkillsApplied  `json:"skills_applied"`
+} // @name HaulingResponse

--- a/backend/internal/services/hauling_matcher.go
+++ b/backend/internal/services/hauling_matcher.go
@@ -1,0 +1,87 @@
+package services
+
+// matchOrder is the minimal order shape the matcher needs.
+type matchOrder struct {
+	TypeID       int
+	StationID    int64
+	IsBuyOrder   bool
+	Price        float64
+	VolumeRemain int
+}
+
+// RouteCandidate is one (buy station → sell station) leg with its profitable items.
+type RouteCandidate struct {
+	BuyStationID  int64
+	SellStationID int64
+	Items         []HaulItem
+}
+
+// MatchHauls finds, per item type, the cheapest sell order (buy source) and highest
+// buy order (sell target) across all stations, keeps profitable cross-station hauls
+// (net of salesTaxRate on the sell), and groups them by (buy station → sell station).
+func MatchHauls(orders []matchOrder, salesTaxRate float64) []RouteCandidate {
+	type best struct {
+		sellPrice float64
+		sellQty   int
+		sellStn   int64
+		hasSell   bool
+		buyPrice  float64
+		buyQty    int
+		buyStn    int64
+		hasBuy    bool
+	}
+	byType := map[int]*best{}
+	for _, o := range orders {
+		if o.VolumeRemain <= 0 || o.Price <= 0 {
+			continue
+		}
+		b := byType[o.TypeID]
+		if b == nil {
+			b = &best{}
+			byType[o.TypeID] = b
+		}
+		if o.IsBuyOrder { // someone buys here → a SELL target for us
+			if !b.hasBuy || o.Price > b.buyPrice {
+				b.buyPrice, b.buyQty, b.buyStn, b.hasBuy = o.Price, o.VolumeRemain, o.StationID, true
+			}
+		} else { // someone sells here → a BUY source for us
+			if !b.hasSell || o.Price < b.sellPrice {
+				b.sellPrice, b.sellQty, b.sellStn, b.hasSell = o.Price, o.VolumeRemain, o.StationID, true
+			}
+		}
+	}
+
+	grouped := map[[2]int64]*RouteCandidate{}
+	for typeID, b := range byType {
+		if !b.hasSell || !b.hasBuy || b.sellStn == b.buyStn {
+			continue
+		}
+		net := b.buyPrice*(1-salesTaxRate) - b.sellPrice
+		if net <= 0 {
+			continue
+		}
+		qty := b.sellQty
+		if b.buyQty < qty {
+			qty = b.buyQty
+		}
+		key := [2]int64{b.sellStn, b.buyStn} // buy at sellStn (cheapest sell order), sell at buyStn
+		rc := grouped[key]
+		if rc == nil {
+			rc = &RouteCandidate{BuyStationID: b.sellStn, SellStationID: b.buyStn}
+			grouped[key] = rc
+		}
+		rc.Items = append(rc.Items, HaulItem{
+			TypeID:        typeID,
+			BuyPrice:      b.sellPrice,
+			ProfitPerUnit: net,
+			AvailableQty:  qty,
+			// Name + UnitVolume filled by the service from SDE (matcher is price-only).
+		})
+	}
+
+	out := make([]RouteCandidate, 0, len(grouped))
+	for _, rc := range grouped {
+		out = append(out, *rc)
+	}
+	return out
+}

--- a/backend/internal/services/hauling_matcher_test.go
+++ b/backend/internal/services/hauling_matcher_test.go
@@ -1,0 +1,46 @@
+package services
+
+import "testing"
+
+func mo(typeID int, station int64, buy bool, price float64, vol int) matchOrder {
+	return matchOrder{TypeID: typeID, StationID: station, IsBuyOrder: buy, Price: price, VolumeRemain: vol}
+}
+
+func TestMatchHauls_GroupsByRoute(t *testing.T) {
+	orders := []matchOrder{
+		mo(1, 100, false, 5.0, 50), mo(1, 100, false, 6.0, 10),
+		mo(1, 200, true, 8.0, 40),
+		mo(2, 100, false, 3.0, 100), mo(2, 200, true, 4.0, 100),
+		mo(3, 300, false, 10, 5), mo(3, 300, true, 12, 5), // same station → no haul
+	}
+	routes := MatchHauls(orders, 0.0)
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route (100→200), got %d", len(routes))
+	}
+	r := routes[0]
+	if r.BuyStationID != 100 || r.SellStationID != 200 {
+		t.Errorf("route stations wrong: %d→%d", r.BuyStationID, r.SellStationID)
+	}
+	if len(r.Items) != 2 {
+		t.Errorf("expected 2 items on route, got %d", len(r.Items))
+	}
+	var i1 *HaulItem
+	for k := range r.Items {
+		if r.Items[k].TypeID == 1 {
+			i1 = &r.Items[k]
+		}
+	}
+	if i1 == nil || i1.ProfitPerUnit != 3.0 || i1.AvailableQty != 40 || i1.BuyPrice != 5.0 {
+		t.Errorf("type1 economics wrong: %+v", i1)
+	}
+}
+
+func TestMatchHauls_SalesTaxRemovesThinMargin(t *testing.T) {
+	orders := []matchOrder{
+		mo(1, 100, false, 100, 10), mo(1, 200, true, 101, 10),
+	}
+	routes := MatchHauls(orders, 0.05)
+	if len(routes) != 0 {
+		t.Errorf("expected no profitable route after tax, got %d", len(routes))
+	}
+}

--- a/backend/internal/services/hauling_optimizer.go
+++ b/backend/internal/services/hauling_optimizer.go
@@ -1,0 +1,77 @@
+package services
+
+import "sort"
+
+// HaulItem is a candidate for a single route's cargo (net profit pre-computed).
+type HaulItem struct {
+	TypeID        int
+	Name          string
+	BuyPrice      float64 // capital cost per unit
+	ProfitPerUnit float64 // net profit per unit
+	UnitVolume    float64 // m³ per unit
+	AvailableQty  int     // min(buy-side available, sell-side demand)
+}
+
+// HaulLoadItem is one selected position.
+type HaulLoadItem struct {
+	TypeID      int
+	Name        string
+	Quantity    int
+	CapitalUsed float64
+	Profit      float64
+}
+
+// HaulLoad is the optimal cargo for one route.
+type HaulLoad struct {
+	Items        []HaulLoadItem
+	TotalProfit  float64
+	TotalCapital float64
+	TotalVolume  float64
+}
+
+// HaulingOptimizer fills one ship for one route greedily by profit per m³.
+type HaulingOptimizer struct{}
+
+// NewHaulingOptimizer creates a new optimizer.
+func NewHaulingOptimizer() *HaulingOptimizer { return &HaulingOptimizer{} }
+
+// FillCargo greedily adds the most profit-dense items (profit per m³) until cargo m³,
+// capital or per-item availability is exhausted.
+func (o *HaulingOptimizer) FillCargo(items []HaulItem, cargoM3, capital float64) HaulLoad {
+	cand := make([]HaulItem, 0, len(items))
+	for _, it := range items {
+		if it.UnitVolume <= 0 || it.BuyPrice <= 0 || it.ProfitPerUnit <= 0 || it.AvailableQty < 1 {
+			continue
+		}
+		cand = append(cand, it)
+	}
+	sort.SliceStable(cand, func(i, j int) bool {
+		return cand[i].ProfitPerUnit/cand[i].UnitVolume > cand[j].ProfitPerUnit/cand[j].UnitVolume
+	})
+
+	cargoLeft, capitalLeft := cargoM3, capital
+	var load HaulLoad
+	for _, it := range cand {
+		qty := it.AvailableQty
+		if byVol := int(cargoLeft / it.UnitVolume); byVol < qty {
+			qty = byVol
+		}
+		if byCap := int(capitalLeft / it.BuyPrice); byCap < qty {
+			qty = byCap
+		}
+		if qty < 1 {
+			continue
+		}
+		capUsed := float64(qty) * it.BuyPrice
+		profit := float64(qty) * it.ProfitPerUnit
+		load.Items = append(load.Items, HaulLoadItem{
+			TypeID: it.TypeID, Name: it.Name, Quantity: qty, CapitalUsed: capUsed, Profit: profit,
+		})
+		cargoLeft -= float64(qty) * it.UnitVolume
+		capitalLeft -= capUsed
+		load.TotalProfit += profit
+		load.TotalCapital += capUsed
+		load.TotalVolume += float64(qty) * it.UnitVolume
+	}
+	return load
+}

--- a/backend/internal/services/hauling_optimizer_test.go
+++ b/backend/internal/services/hauling_optimizer_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"math"
+	"testing"
+)
+
+func happrox(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func hitem(id int, name string, buy, profit, vol float64, qty int) HaulItem {
+	return HaulItem{TypeID: id, Name: name, BuyPrice: buy, ProfitPerUnit: profit, UnitVolume: vol, AvailableQty: qty}
+}
+
+func TestFillCargo_RespectsCargoCapitalAndQty(t *testing.T) {
+	opt := NewHaulingOptimizer()
+	load := opt.FillCargo([]HaulItem{
+		hitem(1, "A", 100, 20, 1, 100), // profit/m³ = 20
+		hitem(2, "B", 50, 5, 1, 100),   // profit/m³ = 5
+	}, 10, 1000)
+	if len(load.Items) == 0 || load.Items[0].TypeID != 1 || load.Items[0].Quantity != 10 {
+		t.Fatalf("expected 10x A first, got %+v", load.Items)
+	}
+	if !happrox(load.TotalVolume, 10) || !happrox(load.TotalProfit, 200) {
+		t.Errorf("totals wrong: %+v", load)
+	}
+}
+
+func TestFillCargo_CapitalBinds(t *testing.T) {
+	opt := NewHaulingOptimizer()
+	load := opt.FillCargo([]HaulItem{hitem(1, "A", 100, 20, 1, 100)}, 1e9, 250)
+	if load.Items[0].Quantity != 2 {
+		t.Errorf("capital should bind to 2 units, got %d", load.Items[0].Quantity)
+	}
+}
+
+func TestFillCargo_QtyBinds(t *testing.T) {
+	opt := NewHaulingOptimizer()
+	load := opt.FillCargo([]HaulItem{hitem(1, "A", 1, 5, 1, 3)}, 1e9, 1e9)
+	if load.Items[0].Quantity != 3 {
+		t.Errorf("available qty should bind to 3, got %d", load.Items[0].Quantity)
+	}
+}
+
+func TestFillCargo_Empty(t *testing.T) {
+	opt := NewHaulingOptimizer()
+	load := opt.FillCargo(nil, 10, 10)
+	if len(load.Items) != 0 || load.TotalProfit != 0 {
+		t.Errorf("empty input → empty load, got %+v", load)
+	}
+}

--- a/backend/internal/services/hauling_service.go
+++ b/backend/internal/services/hauling_service.go
@@ -1,0 +1,258 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/cargo"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/navigation"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+)
+
+const defaultMaxHaulingRoutes = 15
+
+// HaulingService finds neighborhood hauling routes (#45): origin region + adjacent
+// regions, cross-region station→station arbitrage, optimal cargo per route.
+type HaulingService struct {
+	sdeRepo     *database.SDERepository
+	routeFinder *RouteFinder
+	fitting     FittingServicer
+	skills      SkillsServicer
+	charHelper  *CharacterHelper
+	sdeDB       *sql.DB
+	optimizer   *HaulingOptimizer
+	logger      *logger.Logger
+}
+
+// NewHaulingService creates a new hauling service.
+func NewHaulingService(
+	sdeRepo *database.SDERepository,
+	routeFinder *RouteFinder,
+	fitting FittingServicer,
+	skills SkillsServicer,
+	charHelper *CharacterHelper,
+	sdeDB *sql.DB,
+	logger *logger.Logger,
+) *HaulingService {
+	return &HaulingService{
+		sdeRepo: sdeRepo, routeFinder: routeFinder, fitting: fitting, skills: skills,
+		charHelper: charHelper, sdeDB: sdeDB, optimizer: NewHaulingOptimizer(), logger: logger,
+	}
+}
+
+// FindRoutes computes ranked hauling routes for the request.
+func (s *HaulingService) FindRoutes(ctx context.Context, req *models.HaulingRequest, characterID int, accessToken string) (*models.HaulingResponse, error) {
+	// 1. Origin region.
+	origin := req.OriginRegionID
+	if origin <= 0 {
+		loc, err := s.charHelper.GetCharacterLocation(ctx, characterID, accessToken)
+		if err != nil {
+			return nil, err
+		}
+		region, err := s.sdeRepo.GetRegionIDForSystem(ctx, loc.SolarSystemID)
+		if err != nil {
+			return nil, err
+		}
+		origin = region
+	}
+
+	// 2. Region set = origin + neighbors.
+	neighbors, err := s.sdeRepo.GetNeighborRegions(ctx, origin)
+	if err != nil {
+		return nil, err
+	}
+	regions := append([]int{origin}, neighbors...)
+
+	// 3. Skills + ship cargo.
+	skills, serr := s.skills.GetCharacterSkills(ctx, characterID, accessToken)
+	if serr != nil || skills == nil {
+		skills = &TradingSkills{}
+	}
+	salesTaxRate := SalesTaxRate(skills.Accounting)
+	cargoM3 := 0.0
+	if fit, err := s.fitting.GetShipFitting(ctx, characterID, req.ShipTypeID, accessToken); err == nil && fit != nil {
+		cargoM3 = fit.Bonuses.EffectiveCargo
+	}
+
+	// 4. Load orders for the region set.
+	var orders []matchOrder
+	for _, region := range regions {
+		regionOrders, err := s.routeFinder.fetchMarketOrders(ctx, region)
+		if err != nil {
+			s.logger.Warn("hauling: region order fetch failed", "error", err, "region", region)
+			continue
+		}
+		for _, o := range regionOrders {
+			orders = append(orders, matchOrder{
+				TypeID: o.TypeID, StationID: o.LocationID, IsBuyOrder: o.IsBuyOrder,
+				Price: o.Price, VolumeRemain: o.VolumeRemain,
+			})
+		}
+	}
+
+	// 5. Match + build routes.
+	cands := MatchHauls(orders, salesTaxRate)
+	maxRoutes := req.MaxRoutes
+	if maxRoutes <= 0 {
+		maxRoutes = defaultMaxHaulingRoutes
+	}
+
+	routes := make([]models.HaulingRoute, 0, len(cands))
+	for _, c := range cands {
+		route, ok := s.buildRoute(ctx, c, cargoM3, req.Capital, req.AvoidLowSec)
+		if ok {
+			routes = append(routes, route)
+		}
+	}
+
+	sort.SliceStable(routes, func(i, j int) bool { return routes[i].ISKPerHour > routes[j].ISKPerHour })
+	if len(routes) > maxRoutes {
+		routes = routes[:maxRoutes]
+	}
+
+	return &models.HaulingResponse{
+		OriginRegionID: origin,
+		RegionsScanned: regions,
+		Routes:         routes,
+		SkillsApplied: models.SkillsApplied{
+			Applied:         serr == nil,
+			Accounting:      skills.Accounting,
+			BrokerRelations: skills.BrokerRelations,
+			SalesTaxRate:    salesTaxRate,
+			BrokerFeeRate:   BrokerFeeRate(skills.BrokerRelations, skills.AdvancedBrokerRelations, skills.FactionStanding, skills.CorpStanding),
+		},
+	}, nil
+}
+
+// buildRoute enriches a candidate with volumes, packs the cargo, resolves the route
+// and computes time/risk/ISK-per-hour. Returns ok=false if not viable.
+func (s *HaulingService) buildRoute(ctx context.Context, c RouteCandidate, cargoM3, capital float64, avoidLowSec bool) (models.HaulingRoute, bool) {
+	// Enrich items with name + unit volume.
+	items := make([]HaulItem, 0, len(c.Items))
+	for _, it := range c.Items {
+		vol, err := cargo.GetItemVolume(s.sdeDB, int64(it.TypeID))
+		if err != nil || vol == nil || vol.Volume <= 0 {
+			continue
+		}
+		it.UnitVolume = vol.Volume
+		if info, err := s.sdeRepo.GetTypeInfo(ctx, it.TypeID); err == nil && info != nil {
+			it.Name = info.Name
+		}
+		items = append(items, it)
+	}
+	load := s.optimizer.FillCargo(items, cargoM3, capital)
+	if len(load.Items) == 0 {
+		return models.HaulingRoute{}, false
+	}
+
+	buySystem, err := s.sdeRepo.GetSystemIDForLocation(ctx, c.BuyStationID)
+	if err != nil {
+		return models.HaulingRoute{}, false
+	}
+	sellSystem, err := s.sdeRepo.GetSystemIDForLocation(ctx, c.SellStationID)
+	if err != nil {
+		return models.HaulingRoute{}, false
+	}
+
+	travel, err := navigation.CalculateTravelTime(s.sdeDB, buySystem, sellSystem, &navigation.NavigationParams{AvoidLowSec: avoidLowSec}, false)
+	if err != nil {
+		return models.HaulingRoute{}, false // e.g. no high-sec route when avoidLowSec
+	}
+	minSec := s.minRouteSecurity(travel.Route)
+	if avoidLowSec && minSec < 0.5 {
+		return models.HaulingRoute{}, false
+	}
+
+	iskPerHour := 0.0
+	if travel.TotalMinutes > 0 {
+		iskPerHour = load.TotalProfit / (travel.TotalMinutes / 60.0)
+	}
+
+	profitByType := map[int]float64{}
+	buyByType := map[int]float64{}
+	for _, in := range items {
+		profitByType[in.TypeID] = in.ProfitPerUnit
+		buyByType[in.TypeID] = in.BuyPrice
+	}
+	outItems := make([]models.HaulingItem, 0, len(load.Items))
+	for _, li := range load.Items {
+		ppu := profitByType[li.TypeID]
+		buy := buyByType[li.TypeID]
+		var vol float64
+		if v, err := cargo.GetItemVolume(s.sdeDB, int64(li.TypeID)); err == nil && v != nil {
+			vol = v.Volume
+		}
+		ppm3 := 0.0
+		if vol > 0 {
+			ppm3 = ppu / vol
+		}
+		outItems = append(outItems, models.HaulingItem{
+			TypeID: li.TypeID, Name: li.Name, Quantity: li.Quantity,
+			BuyPrice: buy, SellPrice: buy + ppu, UnitVolume: vol,
+			Profit: li.Profit, ProfitPerM3: ppm3,
+		})
+	}
+
+	return models.HaulingRoute{
+		BuyStationID:    c.BuyStationID,
+		BuyStationName:  s.stationName(ctx, c.BuyStationID),
+		BuySystemName:   s.systemName(ctx, buySystem),
+		SellStationID:   c.SellStationID,
+		SellStationName: s.stationName(ctx, c.SellStationID),
+		SellSystemName:  s.systemName(ctx, sellSystem),
+		Jumps:           travel.Jumps,
+		TravelTimeMin:   travel.TotalMinutes,
+		SecurityRisk:    securityRisk(minSec),
+		TotalProfit:     load.TotalProfit,
+		TotalCapital:    load.TotalCapital,
+		TotalVolume:     load.TotalVolume,
+		ISKPerHour:      iskPerHour,
+		Items:           outItems,
+	}, true
+}
+
+func (s *HaulingService) minRouteSecurity(route []int64) float64 {
+	if len(route) == 0 {
+		return 1.0
+	}
+	min := 1.0
+	for _, sysID := range route {
+		var sec float64
+		if err := s.sdeDB.QueryRowContext(context.Background(),
+			"SELECT securityStatus FROM mapSolarSystems WHERE _key = ?", sysID).Scan(&sec); err != nil {
+			continue
+		}
+		if sec < min {
+			min = sec
+		}
+	}
+	return min
+}
+
+func (s *HaulingService) stationName(ctx context.Context, stationID int64) string {
+	if name, err := s.sdeRepo.GetStationName(ctx, stationID); err == nil {
+		return name
+	}
+	return ""
+}
+
+func (s *HaulingService) systemName(ctx context.Context, systemID int64) string {
+	if name, err := s.sdeRepo.GetSystemName(ctx, systemID); err == nil {
+		return name
+	}
+	return ""
+}
+
+func securityRisk(minSec float64) string {
+	switch {
+	case minSec >= 0.5:
+		return "safe"
+	case minSec > 0.0:
+		return "caution"
+	default:
+		return "danger"
+	}
+}

--- a/docs/superpowers/plans/2026-05-29-hauling-routes.md
+++ b/docs/superpowers/plans/2026-05-29-hauling-routes.md
@@ -1,0 +1,566 @@
+# Umkreis-Hauling Routes (#45) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** From the character's current region + adjacent regions, find profitable station→station hauling routes (buy cheap in one station, sell dear in another) with an optimal per-trip cargo load under cargo + capital constraints.
+
+**Architecture:** Reuse the per-region order fetch, navigation, cargo-knapsack and character-location services. New: region adjacency from `v_stargate_graph`, a pure cross-region matcher (orders → per-item best buy/sell → routes), and a cargo+capital greedy `HaulingOptimizer`. Surfaced via `POST /api/v1/trading/hauling/routes`, a web `/hauling` page and a Flutter screen.
+
+**Tech Stack:** Go/Fiber (pgx, existing services), Next.js 16 + React Query + Tailwind, Flutter + Riverpod + dio. Spec: `docs/superpowers/specs/2026-05-29-hauling-routes-design.md`.
+
+---
+
+## File Structure
+
+**Backend (`backend/`)**
+- Create `internal/models/hauling.go` — `HaulingRequest`, `HaulingRoute`, `HaulingItem`, `HaulingResponse`.
+- Create `internal/services/hauling_optimizer.go` — pure cargo+capital greedy fill + unit tests.
+- Create `internal/services/hauling_matcher.go` — pure cross-region matcher (orders → routes) + unit tests.
+- Create `internal/services/hauling_service.go` — orchestration (location → regions → fetch → match → optimize → navigation → rank).
+- Modify `internal/database/sde.go` — add `GetNeighborRegions`. Test: `internal/database/sde_neighbor_integration_test.go`.
+- Create `internal/handlers/hauling.go`; Modify `cmd/api/container.go`, `cmd/api/main.go`.
+
+**Web (`frontend/`)** — Create `src/app/hauling/page.tsx`, `src/components/trading/HaulingRouteList.tsx`, `HaulingRouteDetail.tsx`; Modify `src/lib/api-client.ts`, `src/types/trading.ts`, nav. Tests: `tests/components/HaulingRouteList.test.tsx`, `tests/e2e/auth/hauling.spec.ts`.
+
+**Flutter (`app/`)** — Create `lib/api/hauling_models.dart`, `lib/features/trading/hauling_screen.dart`, `lib/features/trading/hauling_providers.dart`; Modify `lib/api/trading_api.dart`, `lib/core/router.dart`. Tests: `test/hauling_models_test.dart`, `test/hauling_screen_layout_test.dart`, extend `test/e2e/*`.
+
+---
+
+## Task 1: Backend models
+
+**Files:** Create `backend/internal/models/hauling.go`
+
+- [ ] **Step 1: Write `hauling.go`**
+
+```go
+package models
+
+// HaulingRequest is the body for POST /api/v1/trading/hauling/routes.
+type HaulingRequest struct {
+	OriginRegionID int     `json:"origin_region_id"` // 0 = use character's current region
+	ShipTypeID     int     `json:"ship_type_id"`
+	Capital        float64 `json:"capital"`
+	AvoidLowSec    bool    `json:"avoid_low_sec"`
+	MaxRoutes      int     `json:"max_routes"` // 0 = default 15
+} // @name HaulingRequest
+
+// HaulingItem is one item in a route's optimal cargo load.
+type HaulingItem struct {
+	TypeID      int     `json:"type_id"`
+	Name        string  `json:"name"`
+	Quantity    int     `json:"quantity"`
+	BuyPrice    float64 `json:"buy_price"`
+	SellPrice   float64 `json:"sell_price"`
+	UnitVolume  float64 `json:"unit_volume"`
+	Profit      float64 `json:"profit"`        // net profit for this position
+	ProfitPerM3 float64 `json:"profit_per_m3"`
+} // @name HaulingItem
+
+// HaulingRoute is one buy-station → sell-station haul with its optimal load.
+type HaulingRoute struct {
+	BuySystemName   string  `json:"buy_system_name"`
+	BuyStationName  string  `json:"buy_station_name"`
+	BuyStationID    int64   `json:"buy_station_id"`
+	SellSystemName  string  `json:"sell_system_name"`
+	SellStationName string  `json:"sell_station_name"`
+	SellStationID   int64   `json:"sell_station_id"`
+	Jumps           int     `json:"jumps"`
+	TravelTimeMin   float64 `json:"travel_time_min"`
+	SecurityRisk    string  `json:"security_risk"` // "safe" | "caution" | "danger"
+	TotalProfit     float64 `json:"total_profit"`
+	TotalCapital    float64 `json:"total_capital"`
+	TotalVolume     float64 `json:"total_volume"`
+	ISKPerHour      float64 `json:"isk_per_hour"`
+	Items           []HaulingItem `json:"items"`
+} // @name HaulingRoute
+
+// HaulingResponse is the response.
+type HaulingResponse struct {
+	OriginRegionID int            `json:"origin_region_id"`
+	RegionsScanned []int          `json:"regions_scanned"`
+	Routes         []HaulingRoute `json:"routes"`
+	SkillsApplied  SkillsApplied  `json:"skills_applied"`
+} // @name HaulingResponse
+```
+
+- [ ] **Step 2:** `cd backend && go build ./...` → ok. Commit: `git add backend/internal/models/hauling.go && git commit -m "feat(hauling): models (#45)"`
+
+---
+
+## Task 2: GetNeighborRegions (SDE) — TDD
+
+**Files:** Modify `backend/internal/database/sde.go`; Test `backend/internal/database/sde_neighbor_integration_test.go`
+
+- [ ] **Step 1: Write integration test** (`//go:build integration`)
+
+```go
+//go:build integration
+
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNeighborRegions_TheForge(t *testing.T) {
+	// SDE is read-only SQLite; open it like other SDE integration tests do.
+	repo := newSDERepoForTest(t) // see existing SDE integration tests for the helper/open pattern
+	ctx := context.Background()
+	neighbors, err := repo.GetNeighborRegions(ctx, 10000002) // The Forge
+	require.NoError(t, err)
+	// The Forge borders 8 regions incl. Lonetrek (10000016), Sinq Laison (10000032),
+	// Metropolis (10000042), The Citadel (10000033).
+	assert.GreaterOrEqual(t, len(neighbors), 6)
+	assert.Contains(t, neighbors, 10000016)
+	assert.Contains(t, neighbors, 10000032)
+	assert.NotContains(t, neighbors, 10000002) // excludes self
+}
+```
+
+NOTE: use the same SDE-open pattern the existing SDE integration tests use (look for how other `*_integration_test.go` in `internal/database` obtain an `*SDERepository` against `backend/data/sde/eve-sde.db`). If none exists, open `sql.Open("sqlite3", "file:../../data/sde/eve-sde.db?mode=ro&immutable=1")` and `NewSDERepository(db)`.
+
+- [ ] **Step 2: Run, verify fail** — `go test -tags integration -run TestGetNeighborRegions ./internal/database/` → FAIL (undefined method).
+
+- [ ] **Step 3: Implement `GetNeighborRegions`** in `sde.go`
+
+```go
+// GetNeighborRegions returns region IDs adjacent to regionID — regions whose system
+// is connected by a stargate to a system in regionID. Excludes regionID itself.
+func (r *SDERepository) GetNeighborRegions(ctx context.Context, regionID int) ([]int, error) {
+	const q = `
+		SELECT DISTINCT s2.regionID
+		FROM v_stargate_graph g
+		JOIN mapSolarSystems s1 ON g.from_system_id = s1._key
+		JOIN mapSolarSystems s2 ON g.to_system_id   = s2._key
+		WHERE s1.regionID = ? AND s2.regionID <> ?
+		ORDER BY s2.regionID`
+	rows, err := r.db.QueryContext(ctx, q, regionID, regionID)
+	if err != nil {
+		return nil, fmt.Errorf("query neighbor regions: %w", err)
+	}
+	defer rows.Close()
+	var out []int
+	for rows.Next() {
+		var rid int
+		if err := rows.Scan(&rid); err != nil {
+			return nil, fmt.Errorf("scan neighbor region: %w", err)
+		}
+		out = append(out, rid)
+	}
+	return out, rows.Err()
+}
+```
+
+(Use the SDERepository's existing `*sql.DB` field/accessor — match how other methods in `sde.go` query, e.g. `r.db.QueryContext` or the repo's query helper.)
+
+- [ ] **Step 4: Run** — `go test -tags integration -run TestGetNeighborRegions ./internal/database/` → PASS (needs Docker? No — SDE is local SQLite; runs directly).
+
+- [ ] **Step 5: Commit** — `git add backend/internal/database/ && git commit -m "feat(hauling): SDE GetNeighborRegions from stargate graph (#45)"`
+
+---
+
+## Task 3: HaulingOptimizer (cargo + capital greedy) — TDD
+
+**Files:** Create `backend/internal/services/hauling_optimizer.go`, `..._test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+package services
+
+import (
+	"math"
+	"testing"
+)
+
+func happrox(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func hitem(id int, name string, buy, profit, vol float64, qty int) HaulItem {
+	return HaulItem{TypeID: id, Name: name, BuyPrice: buy, ProfitPerUnit: profit, UnitVolume: vol, AvailableQty: qty}
+}
+
+func TestFillCargo_RespectsCargoCapitalAndQty(t *testing.T) {
+	opt := NewHaulingOptimizer()
+	// Item A: best profit/m³; B: worse. Cargo 10 m³, capital 1000.
+	load := opt.FillCargo([]HaulItem{
+		hitem(1, "A", 100, 20, 1, 100), // profit/m³ = 20
+		hitem(2, "B", 50, 5, 1, 100),   // profit/m³ = 5
+	}, 10, 1000)
+	// Cargo (10 m³ → 10 units) binds before capital (1000/100=10) — 10x A.
+	if len(load.Items) == 0 || load.Items[0].TypeID != 1 || load.Items[0].Quantity != 10 {
+		t.Fatalf("expected 10x A first, got %+v", load.Items)
+	}
+	if !happrox(load.TotalVolume, 10) || !happrox(load.TotalProfit, 200) {
+		t.Errorf("totals wrong: %+v", load)
+	}
+}
+
+func TestFillCargo_CapitalBinds(t *testing.T) {
+	opt := NewHaulingOptimizer()
+	// Cargo huge, capital 250 → at buy 100 only 2 units affordable.
+	load := opt.FillCargo([]HaulItem{hitem(1, "A", 100, 20, 1, 100)}, 1e9, 250)
+	if load.Items[0].Quantity != 2 {
+		t.Errorf("capital should bind to 2 units, got %d", load.Items[0].Quantity)
+	}
+}
+
+func TestFillCargo_QtyBinds(t *testing.T) {
+	opt := NewHaulingOptimizer()
+	load := opt.FillCargo([]HaulItem{hitem(1, "A", 1, 5, 1, 3)}, 1e9, 1e9)
+	if load.Items[0].Quantity != 3 {
+		t.Errorf("available qty should bind to 3, got %d", load.Items[0].Quantity)
+	}
+}
+
+func TestFillCargo_Empty(t *testing.T) {
+	opt := NewHaulingOptimizer()
+	load := opt.FillCargo(nil, 10, 10)
+	if len(load.Items) != 0 || load.TotalProfit != 0 {
+		t.Errorf("empty input → empty load, got %+v", load)
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify fail** — `go test ./internal/services/ -run TestFillCargo` → FAIL (undefined).
+
+- [ ] **Step 3: Implement `hauling_optimizer.go`**
+
+```go
+package services
+
+import "sort"
+
+// HaulItem is a candidate for a single route's cargo (net profit pre-computed).
+type HaulItem struct {
+	TypeID        int
+	Name          string
+	BuyPrice      float64 // capital cost per unit
+	ProfitPerUnit float64 // net profit per unit
+	UnitVolume    float64 // m³ per unit
+	AvailableQty  int     // min(buy-side available, sell-side demand)
+}
+
+// HaulLoadItem is one selected position.
+type HaulLoadItem struct {
+	TypeID      int
+	Name        string
+	Quantity    int
+	CapitalUsed float64
+	Profit      float64
+}
+
+// HaulLoad is the optimal cargo for one route.
+type HaulLoad struct {
+	Items       []HaulLoadItem
+	TotalProfit float64
+	TotalCapital float64
+	TotalVolume float64
+}
+
+// HaulingOptimizer fills one ship for one route greedily by profit per m³.
+type HaulingOptimizer struct{}
+
+func NewHaulingOptimizer() *HaulingOptimizer { return &HaulingOptimizer{} }
+
+// FillCargo greedily adds the most profit-dense items (profit per m³) until cargo m³,
+// capital or per-item availability is exhausted.
+func (o *HaulingOptimizer) FillCargo(items []HaulItem, cargoM3, capital float64) HaulLoad {
+	cand := make([]HaulItem, 0, len(items))
+	for _, it := range items {
+		if it.UnitVolume <= 0 || it.BuyPrice <= 0 || it.ProfitPerUnit <= 0 || it.AvailableQty < 1 {
+			continue
+		}
+		cand = append(cand, it)
+	}
+	sort.SliceStable(cand, func(i, j int) bool {
+		return cand[i].ProfitPerUnit/cand[i].UnitVolume > cand[j].ProfitPerUnit/cand[j].UnitVolume
+	})
+
+	cargoLeft, capitalLeft := cargoM3, capital
+	var load HaulLoad
+	for _, it := range cand {
+		qty := it.AvailableQty
+		if byVol := int(cargoLeft / it.UnitVolume); byVol < qty {
+			qty = byVol
+		}
+		if byCap := int(capitalLeft / it.BuyPrice); byCap < qty {
+			qty = byCap
+		}
+		if qty < 1 {
+			continue
+		}
+		capUsed := float64(qty) * it.BuyPrice
+		profit := float64(qty) * it.ProfitPerUnit
+		load.Items = append(load.Items, HaulLoadItem{
+			TypeID: it.TypeID, Name: it.Name, Quantity: qty, CapitalUsed: capUsed, Profit: profit,
+		})
+		cargoLeft -= float64(qty) * it.UnitVolume
+		capitalLeft -= capUsed
+		load.TotalProfit += profit
+		load.TotalCapital += capUsed
+		load.TotalVolume += float64(qty) * it.UnitVolume
+	}
+	return load
+}
+```
+
+- [ ] **Step 4: Run** — `go test ./internal/services/ -run TestFillCargo -v` → PASS. Fix until green.
+
+- [ ] **Step 5: Commit** — `gofmt -w internal/services/hauling_optimizer*.go && git add backend/internal/services/hauling_optimizer*.go && git commit -m "feat(hauling): cargo+capital greedy optimizer + tests (#45)"`
+
+---
+
+## Task 4: Cross-region matcher — TDD
+
+**Files:** Create `backend/internal/services/hauling_matcher.go`, `..._test.go`
+
+The matcher is pure over a flat order list (decoupled from ESI/DB). Order shape it needs:
+
+```go
+type matchOrder struct {
+	TypeID     int
+	StationID  int64
+	IsBuyOrder bool
+	Price      float64
+	VolumeRemain int
+}
+```
+
+For each type: cheapest active SELL order (= where to BUY, source) and highest active BUY order (= where to SELL, target). An opportunity exists when source and target are different stations and `targetBuyPrice*(1-salesTaxRate) > sourceSellPrice`. Group opportunities by `(buyStationID → sellStationID)`.
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+package services
+
+import "testing"
+
+func mo(typeID int, station int64, buy bool, price float64, vol int) matchOrder {
+	return matchOrder{TypeID: typeID, StationID: station, IsBuyOrder: buy, Price: price, VolumeRemain: vol}
+}
+
+func TestMatchHauls_GroupsByRoute(t *testing.T) {
+	orders := []matchOrder{
+		// type 1: cheapest sell at station 100 (5.0), highest buy at station 200 (8.0) → profitable haul 100→200
+		mo(1, 100, false, 5.0, 50), mo(1, 100, false, 6.0, 10),
+		mo(1, 200, true, 8.0, 40),
+		// type 2: also cheapest sell @100 (3.0), highest buy @200 (4.0) → same route 100→200
+		mo(2, 100, false, 3.0, 100), mo(2, 200, true, 4.0, 100),
+		// type 3: sell and buy at same station 300 → no haul
+		mo(3, 300, false, 10, 5), mo(3, 300, true, 12, 5),
+	}
+	routes := MatchHauls(orders, 0.0) // 0% sales tax for the test
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route (100→200), got %d", len(routes))
+	}
+	r := routes[0]
+	if r.BuyStationID != 100 || r.SellStationID != 200 {
+		t.Errorf("route stations wrong: %d→%d", r.BuyStationID, r.SellStationID)
+	}
+	if len(r.Items) != 2 { // type 1 and 2
+		t.Errorf("expected 2 items on route, got %d", len(r.Items))
+	}
+	// type 1: profit/unit = 8-5 = 3; available = min(50,40)=40
+	var i1 *HaulItem
+	for k := range r.Items {
+		if r.Items[k].TypeID == 1 {
+			i1 = &r.Items[k]
+		}
+	}
+	if i1 == nil || i1.ProfitPerUnit != 3.0 || i1.AvailableQty != 40 || i1.BuyPrice != 5.0 {
+		t.Errorf("type1 economics wrong: %+v", i1)
+	}
+}
+
+func TestMatchHauls_SalesTaxRemovesThinMargin(t *testing.T) {
+	orders := []matchOrder{
+		mo(1, 100, false, 100, 10), mo(1, 200, true, 101, 10), // 1% gross; 5% tax → net negative
+	}
+	routes := MatchHauls(orders, 0.05)
+	if len(routes) != 0 {
+		t.Errorf("expected no profitable route after tax, got %d", len(routes))
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify fail** — `go test ./internal/services/ -run TestMatchHauls` → FAIL.
+
+- [ ] **Step 3: Implement `hauling_matcher.go`**
+
+```go
+package services
+
+// matchOrder is the minimal order shape the matcher needs.
+type matchOrder struct {
+	TypeID       int
+	StationID    int64
+	IsBuyOrder   bool
+	Price        float64
+	VolumeRemain int
+}
+
+// RouteCandidate is one (buy station → sell station) leg with its profitable items.
+type RouteCandidate struct {
+	BuyStationID  int64
+	SellStationID int64
+	Items         []HaulItem
+}
+
+// MatchHauls finds, per item type, the cheapest sell order (buy source) and highest
+// buy order (sell target) across all stations, keeps profitable cross-station hauls
+// (net of salesTaxRate on the sell), and groups them by (buy station → sell station).
+func MatchHauls(orders []matchOrder, salesTaxRate float64) []RouteCandidate {
+	type best struct {
+		sellPrice float64
+		sellQty   int
+		sellStn   int64
+		hasSell   bool
+		buyPrice  float64
+		buyQty    int
+		buyStn    int64
+		hasBuy    bool
+	}
+	byType := map[int]*best{}
+	for _, o := range orders {
+		if o.VolumeRemain <= 0 || o.Price <= 0 {
+			continue
+		}
+		b := byType[o.TypeID]
+		if b == nil {
+			b = &best{}
+			byType[o.TypeID] = b
+		}
+		if o.IsBuyOrder { // someone buys here → a SELL target for us
+			if !b.hasBuy || o.Price > b.buyPrice {
+				b.buyPrice, b.buyQty, b.buyStn, b.hasBuy = o.Price, o.VolumeRemain, o.StationID, true
+			}
+		} else { // someone sells here → a BUY source for us
+			if !b.hasSell || o.Price < b.sellPrice {
+				b.sellPrice, b.sellQty, b.sellStn, b.hasSell = o.Price, o.VolumeRemain, o.StationID, true
+			}
+		}
+	}
+
+	grouped := map[[2]int64]*RouteCandidate{}
+	for typeID, b := range byType {
+		if !b.hasSell || !b.hasBuy || b.sellStn == b.buyStn {
+			continue
+		}
+		net := b.buyPrice*(1-salesTaxRate) - b.sellPrice
+		if net <= 0 {
+			continue
+		}
+		qty := b.sellQty
+		if b.buyQty < qty {
+			qty = b.buyQty
+		}
+		key := [2]int64{b.sellStn, b.buyStn} // buy at sellStn (cheapest sell order), sell at buyStn
+		rc := grouped[key]
+		if rc == nil {
+			rc = &RouteCandidate{BuyStationID: b.sellStn, SellStationID: b.buyStn}
+			grouped[key] = rc
+		}
+		rc.Items = append(rc.Items, HaulItem{
+			TypeID:        typeID,
+			BuyPrice:      b.sellPrice,
+			ProfitPerUnit: net,
+			AvailableQty:  qty,
+			// Name + UnitVolume filled by the service from SDE (matcher is price-only).
+		})
+	}
+
+	out := make([]RouteCandidate, 0, len(grouped))
+	for _, rc := range grouped {
+		out = append(out, *rc)
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run** — `go test ./internal/services/ -run TestMatchHauls -v` → PASS. NOTE: tests don't set Name/UnitVolume; the service enriches those from the SDE before optimizing.
+
+- [ ] **Step 5: Commit** — `gofmt -w internal/services/hauling_matcher*.go && git add backend/internal/services/hauling_matcher*.go && git commit -m "feat(hauling): cross-region order matcher + tests (#45)"`
+
+---
+
+## Task 5: HaulingService + handler + route + wiring
+
+**Files:** Create `backend/internal/services/hauling_service.go`, `backend/internal/handlers/hauling.go`; Modify `cmd/api/container.go`, `cmd/api/main.go`
+
+- [ ] **Step 1: Implement `HaulingService.FindRoutes(ctx, req, characterID, accessToken) (*models.HaulingResponse, error)`**
+
+Orchestration (use the existing services via small injected interfaces for testability where practical; concrete wiring in container.go):
+1. Resolve origin region: if `req.OriginRegionID > 0` use it; else `characterHelper.GetCharacterLocation` → system → `sdeRepo.GetRegionIDForSystem`.
+2. `regions = append(GetNeighborRegions(origin), origin)`.
+3. For each region: `routeFinder.fetchMarketOrders(ctx, region)` (reuse; tolerate per-region errors with a logged warn). Convert each `database.MarketOrder` → `matchOrder{TypeID, StationID: LocationID, IsBuyOrder, Price, VolumeRemain}`.
+4. `salesTaxRate := SalesTaxRate(skills.Accounting)` (skills via `skillsService.GetCharacterSkills`, graceful default).
+5. `cands := MatchHauls(allOrders, salesTaxRate)`.
+6. Enrich each candidate's items with `Name` + `UnitVolume` from SDE (`sdeRepo.GetTypeInfo` / `cargo.GetItemVolume`); drop items with no volume. Compute effective cargo capacity for the ship (reuse the route/fitting path: `fittingService.GetShipFitting`→ `EffectiveCargo`, like `route_service.applyCharacterSkills`).
+7. For each candidate route: `load := optimizer.FillCargo(items, effectiveCargo, req.Capital)`; skip empty loads. Resolve buy/sell systems from station IDs (`sdeRepo.GetSystemIDForLocation`) + station/system names. Compute travel via `navigation.ShortestPath(buySystem, sellSystem, req.AvoidLowSec)` + `navigation.CalculateTravelTime(...)`; `jumps`, `travel_time_min`, min-sec → `security_risk` (≥0.5 safe, >0.0 caution, ≤0.0 danger); if `AvoidLowSec` and route has <0.5 hop → skip. `ISKPerHour = TotalProfit / (roundTripMinutes/60)`.
+8. Map to `models.HaulingRoute` (incl. per-item `SellPrice` = BuyPrice+ProfitPerUnit before tax-display, `ProfitPerM3`), rank by `ISKPerHour` desc, cap to `MaxRoutes` (default 15). Build `models.HaulingResponse` with `RegionsScanned` + `SkillsApplied`.
+
+- [ ] **Step 2: Implement handler** `hauling.go` — mirror `internal/handlers/portfolio.go`: parse `HaulingRequest`, validate `ShipTypeID>0 && Capital>0`, extract `character_id`/`access_token` from Locals (int/string, 401 if missing), call `service.FindRoutes`, JSON; 500 on error.
+
+- [ ] **Step 3: Wire** in `container.go`: build `HaulingService` with the existing `c.SDERepo`, the route finder / market repo, `navigation` (via `c.DB.SDE`), `fittingService`, `skillsService`, `characterHelper`, `NewHaulingOptimizer()`, logger; build `c.HaulingHandler`. Register in `main.go`:
+```go
+api.Post("/trading/hauling/routes", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.HaulingHandler.FindRoutes)
+```
+
+- [ ] **Step 4: Build + vet** — `go build ./... && go vet ./internal/... ./cmd/...` → clean. `go test -short ./internal/...` → PASS.
+
+- [ ] **Step 5: Commit** — `git add backend/ && git commit -m "feat(hauling): service + handler + route + wiring (#45)"`
+
+---
+
+## Task 6: Backend gates + CHANGELOG
+
+- [ ] **Step 1:** `gofmt -l internal/ cmd/` empty; `go test -short ./internal/...` PASS; `go build -tags integration ./...` ok.
+- [ ] **Step 2:** Add `CHANGELOG.md` `[Unreleased] ### Added` entry for the hauling endpoint.
+- [ ] **Step 3: Commit** — `git add backend CHANGELOG.md && git commit -m "chore(hauling): changelog + gates (#45)"`
+
+---
+
+## Task 7: Web `/hauling` + tests
+
+Follow #44/#107 patterns exactly: `src/app/roi-calculator/page.tsx` (form + mutation + auth gate), `PortfolioResultTable.tsx` (table + waypoint button + `setWaypoint` helper in `api-client.ts`), `tests/components/PortfolioResultTable.test.tsx`, `tests/e2e/auth/roi-calculator.spec.ts`.
+
+- [ ] **Step 1:** Types in `src/types/trading.ts`: `HaulingRequest`, `HaulingRoute`, `HaulingItem`, `HaulingResponse`.
+- [ ] **Step 2:** `src/lib/api-client.ts` → `findHaulingRoutes(req)` (authed POST `/api/v1/trading/hauling/routes`).
+- [ ] **Step 3:** `HaulingRouteList.tsx` (one card/row per route: buy→sell system, jumps, travel time, security badge safe/caution/danger, ISK/h, total profit, cargo fill %) + `HaulingRouteDetail.tsx` (expand → cargo table: Item, Menge, Kauf@Station, Verkauf@Station, Volumen, Gewinn, Gewinn/m³ + reuse the **`setWaypoint`** helper for a "Route an EVE übertragen" button: clear+buyStationID, then sellStationID). `formatISKWithSeparators` for ISK.
+- [ ] **Step 4:** `src/app/hauling/page.tsx`: auth gate + ErrorBoundary + form (Ship select, Capital, avoid-low-sec; origin region shown from character location) → `useMutation(findHaulingRoutes)` → route list. Empty-state "Keine profitablen Routen im Umkreis". Add a nav entry for /hauling.
+- [ ] **Step 5:** Vitest `tests/components/HaulingRouteList.test.tsx` (route fields, security badge, cargo table on expand, waypoint button calls buy-then-sell IDs) + Playwright `tests/e2e/auth/hauling.spec.ts`. `npm run test` + `npm run lint` green.
+- [ ] **Step 6: Commit** — `git add frontend && git commit -m "feat(frontend): hauling routes page + tests (#45)"`
+
+---
+
+## Task 8: Flutter `/hauling` + tests
+
+Follow `hub_comparison_*` / `roi_*` + `route_detail.dart` (waypoint) patterns exactly.
+
+- [ ] **Step 1:** `lib/api/hauling_models.dart` — `HaulingRequest`/`HaulingRoute`/`HaulingItem`/`HaulingResponse`, null/float-robust `fromJson`.
+- [ ] **Step 2:** `lib/api/trading_api.dart` add `findHaulingRoutes(HaulingRequest)`; `lib/features/trading/hauling_providers.dart` `AsyncNotifier<HaulingResponse?>`.
+- [ ] **Step 3:** `lib/features/trading/hauling_screen.dart` adaptive `isTwoPane(840)`: form + route list; route detail = cargo DataTable + security badge + per-route "Route an EVE übertragen" button (reuse `route_detail.dart` waypoint pattern: buy station then sell station).
+- [ ] **Step 4:** `lib/core/router.dart` add `/hauling` GoRoute + a NavigationDestination ("Hauling").
+- [ ] **Step 5:** `test/hauling_models_test.dart` (parse incl. empty routes), `test/hauling_screen_layout_test.dart` (1-/2-pane), e2e group + `fakeHaulingResponse()` in `test/e2e/support/fakes.dart`. `flutter analyze` clean + `flutter test` pass.
+- [ ] **Step 6: Commit** — `git add app && git commit -m "feat(app): hauling routes screen + tests (#45)"`
+
+---
+
+## Task 9: Ship
+
+- [ ] **Step 1:** PR `feat/hauling-routes` → CI green → merge.
+- [ ] **Step 2:** `make release VERSION=0.11.0` → release PR → merge → tag `v0.11.0` → deploy (backend + frontend) → smoke success.
+- [ ] **Step 3:** Prod verify: `/version`, `/hauling` 200, `POST /trading/hauling/routes` 401 without auth. Flutter APK rebuild + on-device happy path (current region → routes → cargo + waypoint button).
+- [ ] **Step 4:** Comment summary on issue #45; close.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** inter-hub price differentials (Task 4 matcher) ✓; navigation travel time (Task 5 step 7) ✓; cargo optimizer max profit/m³ (Task 3) ✓; risk assessment low/null-sec (Task 5 step 7 + AvoidLowSec) ✓; origin = current region + neighbors (Task 2 + Task 5 step 1-2) ✓; station-granular any→any (Task 4 groups by station, both directions via per-type best buy/sell) ✓; capital constraint (Task 3) ✓; web+flutter + waypoint reuse (Tasks 7,8) ✓.
+- **Placeholders:** Task 5 describes orchestration by pointing at concrete reuse (`fetchMarketOrders`, `navigation.ShortestPath`, `GetShipFitting`, `portfolio.go` handler analogue) — reuse, not placeholder; all new pure logic (Tasks 2,3,4) has complete code.
+- **Type consistency:** `HaulItem`/`HaulLoad` (optimizer, internal) ↔ `RouteCandidate` (matcher, internal, holds `[]HaulItem`) ↔ `models.HaulingRoute`/`HaulingItem` (API); service maps between them. `MatchHauls(orders, salesTaxRate)` and `FillCargo(items, cargoM3, capital)` signatures consistent across tasks. `findHaulingRoutes`/`FindRoutes` naming consistent.

--- a/docs/superpowers/specs/2026-05-29-hauling-routes-design.md
+++ b/docs/superpowers/specs/2026-05-29-hauling-routes-design.md
@@ -1,0 +1,73 @@
+# Umkreis-Hauling Routes (Issue #45) — Design
+
+- **Datum:** 2026-05-29
+- **Issue:** Sternrassler/eve-o-provit#45 (siehe Scope-Update im Issue-Body)
+- **Status:** In Umsetzung
+
+## Use Case
+
+Inter-Region-Arbitrage durch Transport, **direkt kaufen/verkaufen** (Taker, kein Order-Platzieren): ein Item günstig in einer Station kaufen (aus deren Sell-Orders), in eine andere Station transportieren und dort teurer verkaufen (in deren Buy-Orders). Gewinn = Preisdifferenz − Transportkosten (Zeit/Risiko).
+
+**Scope (abgestimmt):** „Umkreis-Hauling". Origin = die **aktuelle Region** des Characters (automatisch); Zielmenge = Origin **+ alle angrenzenden Regionen** (1 Hop). **Stationsgenau** (kein Hub-Zwang), **any→any** innerhalb des Sets. Bounded — kein globaler Markt-Ingest.
+
+## Eingaben
+
+- **Ship** (`ship_type_id` → effektives Cargo via Skills) — Pflicht.
+- **Kapital** (`capital`, ISK-Budget) — Pflicht (zweiter Constraint neben Cargo).
+- **Low-Sec meiden** (`avoid_low_sec`).
+- **Origin-Region** (`origin_region_id`, optional) — Default = aktuelle Region aus `GetCharacterLocation`.
+- **max_routes** (optional, Default 15).
+- **Skills** automatisch (Cargo via Industrial/Hauler, Fees via Accounting/Broker).
+
+## Zielfunktion / Modell
+
+Pro **Route** = (Kauf-Station → Verkauf-Station) die **optimale Ladung** für **einen** Trip: Cargo füllen mit dem Item-Mix, der den Gewinn maximiert, unter den Constraints **Cargo-m³**, **Kapital-Budget** und **Liquidität** (verfügbare Menge je Item = min(Kauf-Angebot, Verkauf-Nachfrage)). Routen nach **ISK/h** (Routen-Netto-Gewinn / Round-Trip-Fahrtzeit) ranken.
+
+## Architektur
+
+### Backend
+- **Regions-Adjazenz (neu):** `SDERepository.GetNeighborRegions(ctx, regionID) ([]int, error)` — aus `v_stargate_graph` + `mapSolarSystems.regionID`: Regionen, deren System per Stargate mit einem System der Origin-Region verbunden ist. Verifiziert: ⌀ ~4.8, max 10 Nachbarn.
+- **`HaulingService`** `internal/services/hauling_service.go`:
+  1. Origin-Region bestimmen (Param oder `GetCharacterLocation` → System → Region via SDE).
+  2. `regions = {origin} ∪ GetNeighborRegions(origin)`.
+  3. Pro Region Orderbuch laden (Wiederverwendung `RouteFinder.fetchMarketOrders(regionID)` — ESI-Batch + Redis-Cache + Upsert).
+  4. **Cross-Region-Matching:** pro Item-Typ über alle Stationen des Sets den günstigsten aktiven **Sell-Order** (Kauf-Quelle: Station/System/Preis) und den höchsten aktiven **Buy-Order** (Verkauf-Ziel) bestimmen; profitabel, wenn an **verschiedenen** Stationen und `sellTargetBuyPrice > buySourceSellPrice` nach Fees. Verfügbare Menge = min(VolumeRemain Kauf, VolumeRemain Verkauf).
+  5. **Routen bilden:** Item-Chancen nach `(Kauf-Station → Verkauf-Station)` gruppieren.
+  6. Pro Route **optimale Ladung** packen — `HaulingOptimizer` (greedy nach Gewinn/m³, fügt Einheiten hinzu solange Cargo-m³ **und** Restkapital **und** Item-Liquidität reichen). Baut auf der `CargoService.KnapsackDP`-Logik auf, um die **Kapital-Dimension** erweitert.
+  7. Pro Route Reisezeit + Sprünge + min-Sec via `navigation.ShortestPath(buySystem, sellSystem, avoidLowSec)` / `CalculateTravelTime` + `getMinRouteSecurityStatus`; `avoid_low_sec` filtert Routen mit Low/Null-Sprüngen. `security_risk` ∈ {safe, caution, danger} aus min-Sec. ISK/h = Routen-Netto / Round-Trip-Minuten.
+  8. Nach ISK/h ranken, auf `max_routes` begrenzen. Skills einmal für `skills_applied`.
+- **Fees:** Netto-Gewinn je Item via Sales-Tax + (Modell: Sofort-Arbitrage → Sales-Tax beim Verkauf; Broker-Fees wie im bestehenden Routen-Modell). Wiederverwendung `FeeService`/Rate-Helper.
+- **Models** `internal/models/hauling.go`: `HaulingRequest`, `HaulingRoute`, `HaulingItem`, `HaulingResponse`.
+- **Handler** `internal/handlers/hauling.go` → `POST /api/v1/trading/hauling/routes` (protected, rate-limited); Route in `cmd/api/main.go`.
+- **Testbarkeit:** Cross-Region-Matching + Routen-Gruppierung + `HaulingOptimizer` arbeiten über reine Eingaben (Order-Listen / Candidate-Slices), damit unit-testbar ohne ESI/DB.
+
+### Web (`frontend/src/app/hauling/page.tsx`, neu + Nav-Eintrag)
+Eingabe-Formular (Ship, Kapital, Low-Sec-meiden; Origin-Region angezeigt, aus Character-Location) → `useMutation` auf `/hauling/routes`. Ergebnis: **Routen-Liste** (Kauf→Verkauf-System, Jumps, Reisezeit, Sec-Badge safe/caution/danger, ISK/h, Gesamtgewinn, Cargo-Füllstand), je Route aufklappbar zur **Ladungs-Tabelle** (Item, Menge, Kauf@Station, Verkauf@Station, Volumen, Gewinn, Gewinn/m³) + **„Route an EVE übertragen"-Button** (Wiederverwendung `setWaypoint`-Helper: clear+Kauf-Station, dann Verkauf-Station). Empty-State „Keine profitablen Routen im Umkreis".
+
+### Flutter (`app/lib/features/trading/hauling_screen.dart`, neu + Route + Nav)
+Adaptiver Screen via `isTwoPane(840)`: Eingaben + Routen-Liste, Route-Detail mit Ladungs-Tabelle + Waypoint-Button (Wiederverwendung `route_detail`-Pattern). DTOs `hauling_models.dart` (null/float-robust), Provider `hauling_providers.dart` (`AsyncNotifier`), `trading_api.findHaulingRoutes(...)`.
+
+## Datenfluss
+
+`Eingaben → POST /hauling/routes → Origin (CharacterLocation) → GetNeighborRegions → fetchMarketOrders je Region → Cross-Region-Matching je Item → Gruppierung nach (Kauf→Verkauf-Station) → HaulingOptimizer (Cargo+Kapital) je Route → Navigation (Zeit/Sec) → Ranking → Response`.
+
+## Error-Handling
+- Auth-pflichtig; Skills fehlen → Base-Werte (`skills_applied=false`).
+- Keine profitablen Routen / leeres Set → leere Liste mit Hinweis.
+- Region ohne Marktdaten → übersprungen (kein Hard-Fail). Keine geleakten Roh-Fehler. Mobile-DTO null/float-robust.
+- Cold-Cache: Lade-Anzeige; Region-Fetch-Fehler einzeln tolerieren.
+
+## Tests (Pyramide)
+- **Backend Unit:** `hauling_service_test.go` — Cross-Region-Matching (bester Kauf/Verkauf je Item über Stationen), Routen-Gruppierung, `HaulingOptimizer` (respektiert Cargo-m³ **und** Kapital **und** Liquidität; ISK/h-Ranking; avoid-low-sec filtert). Reine Eingaben, keine ESI/DB.
+- **Backend Integration** (`//go:build integration`): `GetNeighborRegions` gegen echte SDE (z.B. The Forge → 8 Nachbarn).
+- **Web:** Vitest (Routen-Liste + Ladungs-Tabelle + Sec-Badge + Waypoint-Button-Call) + Playwright authed E2E.
+- **Flutter:** Unit (Parsing), Widget (adaptiv 1-/2-Pane + Route-Detail), E2E-Gruppe (Provider-Override).
+
+## Deployment
+Backend tag-basiert (v0.x → GHCR → deploy-app.sh) + Frontend-Image (same-origin). Keine Migration nötig (read-only/berechnend). Flutter APK + On-Device-Happy-Path.
+
+## Out of Scope (YAGNI)
+- Global „alle Regionen überall" (eigenes Daten-Pipeline-Projekt).
+- >1 Hop Reichweite (später konfigurierbar).
+- Order-Platzieren / Market-Maker (#46).
+- Multi-Trip-Logistik über mehrere Tage (ISK/h pro Route reicht).

--- a/frontend/src/app/hauling/page.tsx
+++ b/frontend/src/app/hauling/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useAuth } from "@/lib/auth-context";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ShipSelect } from "@/components/trading/ShipSelect";
+import { HaulingRouteList } from "@/components/trading/HaulingRouteList";
+import { SkillsAppliedPanel } from "@/components/trading/SkillsAppliedPanel";
+import { findHaulingRoutes } from "@/lib/api-client";
+import { HaulingRequest } from "@/types/trading";
+import { Loader2 } from "lucide-react";
+
+const DEFAULT_SHIP = "649";
+const DEFAULT_CAPITAL = 500_000_000;
+const DEFAULT_MAX_ROUTES = 15;
+
+interface HaulingFormState {
+  ship: string;
+  capital: number;
+  avoidLowSec: boolean;
+}
+
+const defaultForm: HaulingFormState = {
+  ship: DEFAULT_SHIP,
+  capital: DEFAULT_CAPITAL,
+  avoidLowSec: true,
+};
+
+function buildRequest(form: HaulingFormState): HaulingRequest {
+  return {
+    origin_region_id: 0, // backend uses the character's current region
+    ship_type_id: parseInt(form.ship, 10),
+    capital: form.capital,
+    avoid_low_sec: form.avoidLowSec,
+    max_routes: DEFAULT_MAX_ROUTES,
+  };
+}
+
+function HaulingPageContent() {
+  const { isAuthenticated } = useAuth();
+  const [form, setForm] = useState<HaulingFormState>(defaultForm);
+
+  const haulingMutation = useMutation({
+    mutationFn: (req: HaulingRequest) => findHaulingRoutes(req),
+  });
+
+  const handleSubmit = () => {
+    haulingMutation.mutate(buildRequest(form));
+  };
+
+  const apiError = haulingMutation.isError
+    ? haulingMutation.error instanceof Error
+      ? haulingMutation.error.message
+      : "Unbekannter Fehler"
+    : undefined;
+
+  const disabled = !isAuthenticated || haulingMutation.isPending;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold">Neighborhood Hauling Routes</h1>
+        <p className="text-muted-foreground">
+          Profitable Station-zu-Station Hauling-Routen in deiner aktuellen
+          Region und den angrenzenden Regionen
+        </p>
+      </div>
+
+      {!isAuthenticated && (
+        <Alert className="mb-6">
+          <AlertTitle>Login erforderlich</AlertTitle>
+          <AlertDescription>
+            Melde dich per EVE SSO an, um Hauling-Routen rund um deine aktuelle
+            Position zu finden.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-[340px_1fr]">
+        {/* Input form */}
+        <form
+          className="space-y-4 rounded-lg border p-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <ShipSelect
+            value={form.ship}
+            onChange={(v) => setForm((s) => ({ ...s, ship: v }))}
+            disabled={disabled}
+            authenticated={isAuthenticated}
+          />
+
+          <div className="space-y-2">
+            <Label htmlFor="capital">Kapital (ISK)</Label>
+            <Input
+              id="capital"
+              type="number"
+              min={0}
+              value={form.capital}
+              disabled={disabled}
+              onChange={(e) =>
+                setForm((s) => ({ ...s, capital: Number(e.target.value) }))
+              }
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="avoid-low-sec"
+              checked={form.avoidLowSec}
+              disabled={disabled}
+              onCheckedChange={(c) =>
+                setForm((s) => ({ ...s, avoidLowSec: c === true }))
+              }
+            />
+            <Label htmlFor="avoid-low-sec" className="font-normal">
+              Low-Sec meiden
+            </Label>
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={disabled || !form.ship}
+          >
+            {haulingMutation.isPending && (
+              <Loader2 className="mr-2 size-4 animate-spin" />
+            )}
+            {haulingMutation.isPending ? "Suche Routen..." : "Routen finden"}
+          </Button>
+        </form>
+
+        {/* Results */}
+        <div className="space-y-6">
+          {haulingMutation.isPending && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Suche profitable Hauling-Routen im Umkreis...
+            </div>
+          )}
+
+          {apiError && (
+            <Alert variant="destructive">
+              <AlertTitle>Fehler</AlertTitle>
+              <AlertDescription className="flex items-center justify-between gap-4">
+                <span>{apiError}</span>
+                <Button variant="outline" size="sm" onClick={handleSubmit}>
+                  Erneut versuchen
+                </Button>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {haulingMutation.isSuccess && haulingMutation.data && (
+            <div className="space-y-6">
+              <HaulingRouteList routes={haulingMutation.data.routes} />
+              <SkillsAppliedPanel
+                skills={haulingMutation.data.skills_applied}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function HaulingPage() {
+  return (
+    <ErrorBoundary>
+      <HaulingPageContent />
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/components/navigation.tsx
+++ b/frontend/src/components/navigation.tsx
@@ -16,6 +16,7 @@ const navItems = [
   { href: "/character", label: "Character" },
   { href: "/multi-hub", label: "Multi-Hub", badge: "Phase 2" },
   { href: "/roi-calculator", label: "ROI Calculator", badge: "Phase 2" },
+  { href: "/hauling", label: "Hauling", badge: "Phase 2" },
   { href: "/trends", label: "Trends", badge: "Phase 3" },
   { href: "/watchlist", label: "Watchlist", badge: "Phase 3" },
 ];

--- a/frontend/src/components/trading/HaulingRouteList.tsx
+++ b/frontend/src/components/trading/HaulingRouteList.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, Loader2, Navigation } from "lucide-react";
+import { HaulingRoute, HaulingItem, SecurityRisk } from "@/types/trading";
+import { cn, formatISKWithSeparators } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/lib/auth-context";
+import { setWaypoint } from "@/lib/api-client";
+
+interface HaulingRouteListProps {
+  routes: HaulingRoute[];
+}
+
+const SECURITY_BADGE: Record<
+  SecurityRisk,
+  { label: string; className: string }
+> = {
+  safe: {
+    label: "Sicher",
+    className:
+      "border-green-300 bg-green-50 text-green-700 dark:border-green-700 dark:bg-green-900/20 dark:text-green-300",
+  },
+  caution: {
+    label: "Vorsicht",
+    className:
+      "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-300",
+  },
+  danger: {
+    label: "Gefahr",
+    className:
+      "border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-900/20 dark:text-red-300",
+  },
+};
+
+function SecurityBadge({ risk }: { risk: SecurityRisk }) {
+  const cfg = SECURITY_BADGE[risk] ?? SECURITY_BADGE.caution;
+  return (
+    <span
+      data-testid="security-badge"
+      data-risk={risk}
+      className={cn(
+        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold",
+        cfg.className
+      )}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+/**
+ * Profitable station→station hauling routes in the character's neighborhood.
+ * Routes arrive pre-sorted by ISK/h (best first). Each route is expandable to a
+ * cargo table and can be pushed to the in-game autopilot. An empty list means
+ * no profitable routes were found nearby.
+ */
+export function HaulingRouteList({ routes }: HaulingRouteListProps) {
+  if (routes.length === 0) {
+    return (
+      <div
+        data-testid="hauling-empty"
+        className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
+      >
+        Keine profitablen Routen im Umkreis
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="hauling-route-list">
+      {routes.map((route, idx) => (
+        <HaulingRouteCard
+          key={`${route.buy_station_id}-${route.sell_station_id}-${idx}`}
+          route={route}
+        />
+      ))}
+    </div>
+  );
+}
+
+function HaulingRouteCard({ route }: { route: HaulingRoute }) {
+  const { isAuthenticated } = useAuth();
+  const { toast } = useToast();
+  const [expanded, setExpanded] = useState(false);
+  const [isSettingRoute, setIsSettingRoute] = useState(false);
+
+  const handleSetRoute = async () => {
+    if (!isAuthenticated) {
+      toast({
+        title: "Nicht eingeloggt",
+        description: "EVE SSO Login erforderlich",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSettingRoute(true);
+    try {
+      await setWaypoint(route.buy_station_id, { clearOtherWaypoints: true });
+      await setWaypoint(route.sell_station_id, { clearOtherWaypoints: false });
+
+      toast({
+        title: "Route gesetzt",
+        description: `Waypoints in EVE gesetzt: ${route.buy_station_name} → ${route.sell_station_name}`,
+      });
+    } catch (err) {
+      toast({
+        title: "Fehler",
+        description: err instanceof Error ? err.message : "Unbekannter Fehler",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSettingRoute(false);
+    }
+  };
+
+  return (
+    <Card data-testid="hauling-route">
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle
+              className="text-lg"
+              title={`${route.buy_station_name} → ${route.sell_station_name}`}
+            >
+              {route.buy_system_name} → {route.sell_system_name}
+            </CardTitle>
+            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <SecurityBadge risk={route.security_risk} />
+              <span>{route.jumps} Sprünge</span>
+              <span aria-hidden>·</span>
+              <span>{route.travel_time_min.toFixed(1)} Min</span>
+              <span aria-hidden>·</span>
+              <span>{route.total_volume.toLocaleString("de-DE")} m³</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSetRoute}
+              disabled={isSettingRoute}
+              title="Route an EVE übertragen"
+              aria-label="Route an EVE übertragen"
+            >
+              {isSettingRoute ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Navigation className="size-4" />
+              )}
+              <span className="ml-2 hidden sm:inline">
+                Route an EVE übertragen
+              </span>
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <Metric label="ISK/h" value={formatISKWithSeparators(route.isk_per_hour)} positive />
+          <Metric
+            label="Gesamtgewinn"
+            value={formatISKWithSeparators(route.total_profit)}
+            positive
+          />
+          <Metric
+            label="Kapitaleinsatz"
+            value={formatISKWithSeparators(route.total_capital)}
+          />
+          <Metric
+            label="Volumen"
+            value={`${route.total_volume.toLocaleString("de-DE")} m³`}
+          />
+        </div>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="w-full justify-between"
+          data-testid="hauling-expand"
+        >
+          <span>Ladung ({route.items.length})</span>
+          <ChevronDown
+            className={cn(
+              "size-4 transition-transform",
+              expanded && "rotate-180"
+            )}
+          />
+        </Button>
+
+        {expanded && <CargoTable items={route.items} route={route} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  positive,
+}: {
+  label: string;
+  value: string;
+  positive?: boolean;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div
+        className={cn(
+          "font-semibold",
+          positive && "text-green-600 dark:text-green-400"
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function CargoTable({
+  items,
+  route,
+}: {
+  items: HaulingItem[];
+  route: HaulingRoute;
+}) {
+  return (
+    <div className="overflow-x-auto" data-testid="cargo-table">
+      <table className="w-full text-sm" aria-label="Ladung">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th scope="col" className="px-3 py-2 font-medium">
+              Item
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Menge
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Kauf@{route.buy_system_name}
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Verkauf@{route.sell_system_name}
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Volumen
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Gewinn
+            </th>
+            <th scope="col" className="px-3 py-2 text-right font-medium">
+              Gewinn/m³
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              key={item.type_id}
+              data-testid="cargo-row"
+              data-type-id={item.type_id}
+              className="border-b transition-colors hover:bg-muted/40"
+            >
+              <td className="px-3 py-2 font-medium">{item.name}</td>
+              <td className="px-3 py-2 text-right">
+                {item.quantity.toLocaleString("de-DE")}
+              </td>
+              <td className="px-3 py-2 text-right">
+                {formatISKWithSeparators(item.buy_price)}
+              </td>
+              <td className="px-3 py-2 text-right">
+                {formatISKWithSeparators(item.sell_price)}
+              </td>
+              <td className="px-3 py-2 text-right">
+                {(item.unit_volume * item.quantity).toLocaleString("de-DE")} m³
+              </td>
+              <td className="px-3 py-2 text-right font-medium text-green-600 dark:text-green-400">
+                {formatISKWithSeparators(item.profit)}
+              </td>
+              <td className="px-3 py-2 text-right">
+                {formatISKWithSeparators(item.profit_per_m3)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -11,6 +11,8 @@ import {
   HubComparisonResult,
   PortfolioRequest,
   PortfolioResult,
+  HaulingRequest,
+  HaulingResponse,
 } from "@/types/trading";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:9001";
@@ -192,6 +194,33 @@ export async function optimizePortfolio(
 
   if (!response.ok) {
     throw new Error(`Failed to optimize portfolio: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Find profitable station→station hauling routes in the character's current
+ * region plus adjacent regions (requires authentication). Routes are returned
+ * pre-sorted by isk_per_hour descending; an empty routes array means no
+ * profitable routes were found nearby.
+ * @param req - hauling search parameters (origin_region_id 0 ⇒ current region)
+ */
+export async function findHaulingRoutes(
+  req: HaulingRequest
+): Promise<HaulingResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/trading/hauling/routes`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(req),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to find hauling routes: ${response.statusText}`);
   }
 
   return response.json();

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -185,6 +185,53 @@ export interface PortfolioResult {
   skills_applied: SkillsApplied;
 }
 
+// Neighborhood Hauling Routes (Issue #45)
+
+export type SecurityRisk = "safe" | "caution" | "danger";
+
+export interface HaulingRequest {
+  origin_region_id: number; // 0 ⇒ backend uses character's current region
+  ship_type_id: number;
+  capital: number;
+  avoid_low_sec: boolean;
+  max_routes: number;
+}
+
+export interface HaulingItem {
+  type_id: number;
+  name: string;
+  quantity: number;
+  buy_price: number;
+  sell_price: number;
+  unit_volume: number;
+  profit: number;
+  profit_per_m3: number;
+}
+
+export interface HaulingRoute {
+  buy_system_name: string;
+  buy_station_name: string;
+  buy_station_id: number;
+  sell_system_name: string;
+  sell_station_name: string;
+  sell_station_id: number;
+  jumps: number;
+  travel_time_min: number;
+  security_risk: SecurityRisk;
+  total_profit: number;
+  total_capital: number;
+  total_volume: number;
+  isk_per_hour: number;
+  items: HaulingItem[];
+}
+
+export interface HaulingResponse {
+  origin_region_id: number;
+  regions_scanned: number[];
+  routes: HaulingRoute[]; // pre-sorted by isk_per_hour desc
+  skills_applied: SkillsApplied;
+}
+
 export interface InventorySellRequest {
   type_id: number;
   quantity: number;

--- a/frontend/tests/components/HaulingRouteList.test.tsx
+++ b/frontend/tests/components/HaulingRouteList.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+  act,
+} from "@testing-library/react";
+import { HaulingRouteList } from "@/components/trading/HaulingRouteList";
+import { HaulingRoute } from "@/types/trading";
+import { setWaypoint } from "@/lib/api-client";
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+  }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  setWaypoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+const setWaypointMock = vi.mocked(setWaypoint);
+
+beforeEach(() => {
+  setWaypointMock.mockClear();
+});
+
+function makeRoute(overrides: Partial<HaulingRoute> = {}): HaulingRoute {
+  return {
+    buy_system_name: "Osmon",
+    buy_station_name: "Osmon V - Moon 5 - Sisters of EVE Bureau",
+    buy_station_id: 60000001,
+    sell_system_name: "Jita",
+    sell_station_name: "Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+    sell_station_id: 60003760,
+    jumps: 7,
+    travel_time_min: 12.5,
+    security_risk: "safe",
+    total_profit: 1.2e8,
+    total_capital: 3.4e8,
+    total_volume: 2400,
+    isk_per_hour: 4.8e8,
+    items: [
+      {
+        type_id: 34,
+        name: "Meta-4 Module A",
+        quantity: 50,
+        buy_price: 1.0e6,
+        sell_price: 1.9e6,
+        unit_volume: 10,
+        profit: 4.5e7,
+        profit_per_m3: 90000,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("HaulingRouteList", () => {
+  it("renders one card per route with the buy → sell systems, jumps, travel time and ISK/h", () => {
+    render(<HaulingRouteList routes={[makeRoute()]} />);
+
+    const cards = screen.getAllByTestId("hauling-route");
+    expect(cards).toHaveLength(1);
+
+    const card = cards[0];
+    expect(
+      within(card).getByText((_, el) => el?.textContent === "Osmon → Jita")
+    ).toBeInTheDocument();
+    expect(within(card).getByText("7 Sprünge")).toBeInTheDocument();
+    expect(within(card).getByText("12.5 Min")).toBeInTheDocument();
+    expect(
+      within(card).getByText("480.000.000,00 ISK")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a security badge with the correct color per risk level", () => {
+    const { rerender } = render(
+      <HaulingRouteList routes={[makeRoute({ security_risk: "safe" })]} />
+    );
+    let badge = screen.getByTestId("security-badge");
+    expect(badge).toHaveAttribute("data-risk", "safe");
+    expect(badge.className).toContain("green");
+
+    rerender(
+      <HaulingRouteList routes={[makeRoute({ security_risk: "caution" })]} />
+    );
+    badge = screen.getByTestId("security-badge");
+    expect(badge).toHaveAttribute("data-risk", "caution");
+    expect(badge.className).toContain("amber");
+
+    rerender(
+      <HaulingRouteList routes={[makeRoute({ security_risk: "danger" })]} />
+    );
+    badge = screen.getByTestId("security-badge");
+    expect(badge).toHaveAttribute("data-risk", "danger");
+    expect(badge.className).toContain("red");
+  });
+
+  it("shows the cargo table only after expanding the route", () => {
+    render(<HaulingRouteList routes={[makeRoute()]} />);
+
+    expect(screen.queryByTestId("cargo-table")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("hauling-expand"));
+
+    expect(screen.getByTestId("cargo-table")).toBeInTheDocument();
+    const cargoRow = screen.getByTestId("cargo-row");
+    expect(within(cargoRow).getByText("Meta-4 Module A")).toBeInTheDocument();
+    // quantity 50, profit/m³ 90000
+    expect(within(cargoRow).getByText("50")).toBeInTheDocument();
+    expect(within(cargoRow).getByText("90.000,00 ISK")).toBeInTheDocument();
+  });
+
+  it("calls setWaypoint with buy then sell station IDs when pushing the route", async () => {
+    render(<HaulingRouteList routes={[makeRoute()]} />);
+
+    const button = screen.getByRole("button", {
+      name: "Route an EVE übertragen",
+    });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    await vi.waitFor(() => {
+      expect(setWaypointMock).toHaveBeenCalledTimes(2);
+    });
+    expect(setWaypointMock).toHaveBeenNthCalledWith(1, 60000001, {
+      clearOtherWaypoints: true,
+    });
+    expect(setWaypointMock).toHaveBeenNthCalledWith(2, 60003760, {
+      clearOtherWaypoints: false,
+    });
+  });
+
+  it("renders the empty-state when no routes exist", () => {
+    render(<HaulingRouteList routes={[]} />);
+
+    expect(screen.getByTestId("hauling-empty")).toBeInTheDocument();
+    expect(
+      screen.getByText("Keine profitablen Routen im Umkreis")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("hauling-route")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/e2e/auth/hauling.spec.ts
+++ b/frontend/tests/e2e/auth/hauling.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Neighborhood Hauling Routes workflow (Issue #45) — only operable when
+ * authenticated (the hauling endpoint requires the session cookie and uses the
+ * character's current region). The auth project injects the captured session
+ * via storageState, so this spec runs against the real backend.
+ *
+ * Structure assertions only — live market values vary. The scan hits a live
+ * multi-region market lookup and can be slow, so timeouts are generous.
+ */
+test.describe('Authenticated hauling routes', () => {
+  test('fill the form, search, see route list or empty-state', async ({
+    page,
+  }) => {
+    // The hauling endpoint scans the current + adjacent regions live; give the
+    // whole workflow a wide envelope while per-step timeouts still catch a hang.
+    test.setTimeout(120_000);
+
+    await page.goto('/hauling');
+    await expect(page.locator('h1')).toContainText('Hauling Routes');
+
+    // Submit button is enabled once authenticated (ship defaults filled).
+    const submit = page.getByRole('button', { name: /Routen finden/i });
+    await expect(submit).toBeEnabled({ timeout: 30000 });
+
+    // Adjust capital to a healthy budget and submit.
+    const capital = page.getByLabel('Kapital (ISK)');
+    await capital.fill('500000000');
+    await submit.click();
+
+    // Either route cards appear, or the empty-state hint (no profitable routes
+    // nearby) — both are valid backend outcomes.
+    const routeList = page.getByTestId('hauling-route-list');
+    const empty = page.getByTestId('hauling-empty');
+    await expect(routeList.or(empty)).toBeVisible({ timeout: 90000 });
+
+    if (await routeList.isVisible()) {
+      const firstRoute = page.getByTestId('hauling-route').first();
+      await expect(firstRoute).toBeVisible();
+      // Security badge renders on the route card.
+      await expect(
+        firstRoute.getByTestId('security-badge')
+      ).toBeVisible();
+      // Expanding reveals the cargo table.
+      await firstRoute.getByTestId('hauling-expand').click();
+      await expect(page.getByTestId('cargo-table').first()).toBeVisible();
+    }
+
+    // The skills-applied panel is shown alongside the results.
+    await expect(page.getByText('Skills angewendet')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #45 — **Umkreis-Hauling**: from the character's current region + adjacent regions (1 stargate hop), find profitable cross-region station→station arbitrage routes with an optimal per-trip cargo load, ranked by ISK/h.

- **Backend:** `POST /api/v1/trading/hauling/routes`. Resolves origin region (from character location or request), expands to neighbor regions via the stargate graph, fetches region orders, matches buy-cheap/sell-dear per type (taker model, sales-tax aware), packs cargo greedily under cargo-m³ + capital + liquidity, computes travel time/jumps/min-security → risk (safe/caution/danger) and ISK/h. New `SDERepository.GetNeighborRegions`; reuses order fetch, navigation, fitting cargo, skills.
- **Web (`/hauling`):** auth-gated form (ship + capital + avoid-low-sec) → route list (buy→sell, jumps, travel, security badge, ISK/h, profit) with expandable cargo table + "Route an EVE übertragen" (buy→sell autopilot waypoints).
- **Flutter (`/hauling`):** adaptive screen mirroring #43/#44; route cards + cargo detail + waypoint button.

Direct buy/sell only (taker). Market-maker / order-placing is out of scope (deferred to #46).

## Test plan
- [x] Backend: `gofmt`/`go vet` clean, `go test -short ./internal/...` pass (optimizer, matcher, GetNeighborRegions unit tests)
- [x] Web: Vitest 51/51 pass (incl. HaulingRouteList: fields, security badge, cargo expand, waypoint call order, empty state); ESLint clean
- [x] Flutter: `flutter analyze` clean; `flutter test` 9/9 (model fromJson + screen layout/chips/detail/empty)
- [ ] CI green
- [ ] Post-deploy: `/hauling` 200, routes 401 noauth; APK on-device

🤖 Generated with [Claude Code](https://claude.com/claude-code)