### PR TITLE
feat: sell-from-assets (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sell-from-Assets (#107):** `GET /api/v1/trading/assets` (owned items aggregated by type + location) and `POST /api/v1/trading/assets/sell-options` — for a selected item, ranks taker sell locations (instant sell into a buy order, net of sales tax) across the 5 major hubs + every station in the item's current region, each with route (jumps, travel time, security risk). Ranked by total net proceeds. New paginated character-assets fetch; reuses hub price fetch, fee/skills, and navigation.
+
 ## [0.11.0] - 2026-05-29
 
 ### Added

--- a/app/lib/api/asset_models.dart
+++ b/app/lib/api/asset_models.dart
@@ -1,0 +1,297 @@
+/// Sell-from-Assets DTOs — field names map exactly to the backend json tags
+/// for GET /api/v1/trading/assets and POST /api/v1/trading/assets/sell-options.
+///
+/// CRITICAL: parsing is null/float-robust (mirrors hauling_models.dart /
+/// hub_comparison_models.dart). Every numeric field tolerates absent/null
+/// values and accepts any [num] (int or double). A past production bug was
+/// caused by non-robust mobile DTO parsing.
+library;
+
+import 'hub_comparison_models.dart' show SkillsApplied;
+
+export 'hub_comparison_models.dart' show SkillsApplied;
+
+// ---------------------------------------------------------------------------
+// AssetItem
+// ---------------------------------------------------------------------------
+
+/// A single item the character owns, from GET /api/v1/trading/assets.
+/// Backend: an element of the `assets` array.
+///
+/// When [marketable] is false the item cannot be sold via this feature; the UI
+/// must still show it but disabled in the picker.
+class AssetItem {
+  const AssetItem({
+    required this.typeId,
+    required this.name,
+    required this.quantity,
+    required this.locationId,
+    required this.locationName,
+    required this.systemId,
+    required this.regionId,
+    required this.marketable,
+  });
+
+  /// Backend: `type_id`
+  final int typeId;
+
+  /// Backend: `name`
+  final String name;
+
+  /// Backend: `quantity` — units owned in this stack.
+  final int quantity;
+
+  /// Backend: `location_id` — station/structure where the stack sits.
+  final int locationId;
+
+  /// Backend: `location_name`
+  final String locationName;
+
+  /// Backend: `system_id` — solar system of the stack's location.
+  final int systemId;
+
+  /// Backend: `region_id` — region of the stack's location.
+  final int regionId;
+
+  /// Backend: `marketable` — false ⇒ cannot be sold (disabled in picker).
+  final bool marketable;
+
+  factory AssetItem.fromJson(Map<String, dynamic> json) {
+    return AssetItem(
+      typeId: (json['type_id'] as num?)?.toInt() ?? 0,
+      name: json['name'] as String? ?? '',
+      quantity: (json['quantity'] as num?)?.toInt() ?? 0,
+      locationId: (json['location_id'] as num?)?.toInt() ?? 0,
+      locationName: json['location_name'] as String? ?? '',
+      systemId: (json['system_id'] as num?)?.toInt() ?? 0,
+      regionId: (json['region_id'] as num?)?.toInt() ?? 0,
+      marketable: json['marketable'] as bool? ?? false,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AssetsResponse
+// ---------------------------------------------------------------------------
+
+/// Response from GET /api/v1/trading/assets.
+class AssetsResponse {
+  const AssetsResponse({
+    required this.assets,
+    required this.count,
+  });
+
+  /// Backend: `assets`
+  final List<AssetItem> assets;
+
+  /// Backend: `count`
+  final int count;
+
+  /// True when the character owns no (marketable or otherwise) assets.
+  bool get isEmpty => assets.isEmpty;
+
+  factory AssetsResponse.fromJson(Map<String, dynamic> json) {
+    final rawAssets = json['assets'] as List<dynamic>? ?? const [];
+    return AssetsResponse(
+      assets: rawAssets
+          .whereType<Map<String, dynamic>>()
+          .map(AssetItem.fromJson)
+          .toList(),
+      count: (json['count'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SellOptionsRequest
+// ---------------------------------------------------------------------------
+
+/// Request body for POST /api/v1/trading/assets/sell-options.
+/// Mirrors the backend request struct exactly (snake_case json tags).
+class SellOptionsRequest {
+  const SellOptionsRequest({
+    required this.typeId,
+    required this.locationId,
+    required this.quantity,
+    required this.avoidLowSec,
+  });
+
+  /// Backend: `type_id`
+  final int typeId;
+
+  /// Backend: `location_id` — the asset stack's current location (origin).
+  final int locationId;
+
+  /// Backend: `quantity` — units to sell.
+  final int quantity;
+
+  /// Backend: `avoid_low_sec` — when true, low-sec hops are excluded.
+  final bool avoidLowSec;
+
+  Map<String, dynamic> toJson() => {
+        'type_id': typeId,
+        'location_id': locationId,
+        'quantity': quantity,
+        'avoid_low_sec': avoidLowSec,
+      };
+}
+
+// ---------------------------------------------------------------------------
+// SellOption
+// ---------------------------------------------------------------------------
+
+/// A single ranked sell location for the chosen asset.
+/// Backend: an element of the `options` array (pre-sorted by total_net desc).
+///
+/// When [hasData] is false there is no buy order / route ("kein Marktpreis");
+/// the numeric fields default to 0 and the UI must render the option muted.
+class SellOption {
+  const SellOption({
+    required this.scope,
+    required this.regionId,
+    required this.regionName,
+    required this.stationId,
+    required this.stationName,
+    required this.systemName,
+    required this.buyPrice,
+    required this.unitNet,
+    required this.totalNet,
+    required this.jumps,
+    required this.travelTimeMin,
+    required this.securityRisk,
+    required this.hasData,
+  });
+
+  /// Backend: `scope` — "hub" | "current_region".
+  final String scope;
+
+  /// Backend: `region_id`
+  final int regionId;
+
+  /// Backend: `region_name`
+  final String regionName;
+
+  /// Backend: `station_id` — used as the autopilot waypoint destination.
+  final int stationId;
+
+  /// Backend: `station_name`
+  final String stationName;
+
+  /// Backend: `system_name`
+  final String systemName;
+
+  /// Backend: `buy_price` — best buy-order price at this station.
+  final double buyPrice;
+
+  /// Backend: `unit_net` — per-unit net ISK after sales tax.
+  final double unitNet;
+
+  /// Backend: `total_net` — total net ISK for the full quantity (headline).
+  final double totalNet;
+
+  /// Backend: `jumps` — number of jumps from the asset's origin system.
+  final int jumps;
+
+  /// Backend: `travel_time_min` — estimated travel time in minutes.
+  final double travelTimeMin;
+
+  /// Backend: `security_risk` — "safe" | "caution" | "danger".
+  final String securityRisk;
+
+  /// Backend: `has_data` — false ⇒ no market price / route (render muted).
+  final bool hasData;
+
+  /// True when this option represents one of the major trade hubs.
+  bool get isHub => scope == 'hub';
+
+  factory SellOption.fromJson(Map<String, dynamic> json) {
+    return SellOption(
+      scope: json['scope'] as String? ?? 'current_region',
+      regionId: (json['region_id'] as num?)?.toInt() ?? 0,
+      regionName: json['region_name'] as String? ?? '',
+      stationId: (json['station_id'] as num?)?.toInt() ?? 0,
+      stationName: json['station_name'] as String? ?? '',
+      systemName: json['system_name'] as String? ?? '',
+      buyPrice: (json['buy_price'] as num?)?.toDouble() ?? 0,
+      unitNet: (json['unit_net'] as num?)?.toDouble() ?? 0,
+      totalNet: (json['total_net'] as num?)?.toDouble() ?? 0,
+      jumps: (json['jumps'] as num?)?.toInt() ?? 0,
+      travelTimeMin: (json['travel_time_min'] as num?)?.toDouble() ?? 0,
+      securityRisk: json['security_risk'] as String? ?? 'safe',
+      hasData: json['has_data'] as bool? ?? false,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SellOptionsResponse
+// ---------------------------------------------------------------------------
+
+/// Response from POST /api/v1/trading/assets/sell-options.
+///
+/// [options] is pre-sorted by the backend (total_net desc). [best] is the top
+/// actionable option, or null when there is none. An empty [options] list is a
+/// valid, successful "no sell locations found" result — it is NOT an error.
+class SellOptionsResponse {
+  const SellOptionsResponse({
+    required this.typeId,
+    required this.name,
+    required this.quantity,
+    required this.originSystemId,
+    required this.best,
+    required this.options,
+    required this.skillsApplied,
+  });
+
+  /// Backend: `type_id`
+  final int typeId;
+
+  /// Backend: `name`
+  final String name;
+
+  /// Backend: `quantity`
+  final int quantity;
+
+  /// Backend: `origin_system_id`
+  final int originSystemId;
+
+  /// Backend: `best` — top actionable option, or null.
+  final SellOption? best;
+
+  /// Backend: `options` — pre-sorted by total_net desc.
+  final List<SellOption> options;
+
+  /// Backend: `skills_applied`
+  final SkillsApplied skillsApplied;
+
+  /// True when no sell locations were returned.
+  bool get isEmpty => options.isEmpty;
+
+  factory SellOptionsResponse.fromJson(Map<String, dynamic> json) {
+    final rawOptions = json['options'] as List<dynamic>? ?? const [];
+    final bestRaw = json['best'];
+    final skillsRaw = json['skills_applied'];
+    return SellOptionsResponse(
+      typeId: (json['type_id'] as num?)?.toInt() ?? 0,
+      name: json['name'] as String? ?? '',
+      quantity: (json['quantity'] as num?)?.toInt() ?? 0,
+      originSystemId: (json['origin_system_id'] as num?)?.toInt() ?? 0,
+      best: bestRaw is Map<String, dynamic>
+          ? SellOption.fromJson(bestRaw)
+          : null,
+      options: rawOptions
+          .whereType<Map<String, dynamic>>()
+          .map(SellOption.fromJson)
+          .toList(),
+      skillsApplied: skillsRaw is Map<String, dynamic>
+          ? SkillsApplied.fromJson(skillsRaw)
+          : const SkillsApplied(
+              applied: false,
+              accounting: 0,
+              brokerRelations: 0,
+              salesTaxRate: 0,
+              brokerFeeRate: 0,
+            ),
+    );
+  }
+}

--- a/app/lib/api/trading_api.dart
+++ b/app/lib/api/trading_api.dart
@@ -7,6 +7,7 @@ library;
 
 import 'package:dio/dio.dart';
 
+import 'asset_models.dart';
 import 'hauling_models.dart';
 import 'hub_comparison_models.dart';
 import 'portfolio_models.dart';
@@ -66,6 +67,33 @@ class TradingApi {
       data: request.toJson(),
     );
     return HaulingResponse.fromJson(response.data!);
+  }
+
+  // ── GET /api/v1/trading/assets ─────────────────────────────────────────────
+
+  /// Lists the marketable (and non-marketable) items the character owns, used
+  /// as the source for the Sell-from-Assets picker.
+  Future<AssetsResponse> listAssets() async {
+    final response =
+        await _dio.get<Map<String, dynamic>>('/api/v1/trading/assets');
+    return AssetsResponse.fromJson(response.data!);
+  }
+
+  // ── POST /api/v1/trading/assets/sell-options ───────────────────────────────
+
+  /// Finds ranked sell locations (taker model: instant sell into a buy order,
+  /// net of sales tax) for an owned asset across the major hubs plus every
+  /// station in the item's current region. Returns a [SellOptionsResponse] with
+  /// options pre-sorted by total_net desc; an empty `options` list means no
+  /// sell locations were found.
+  Future<SellOptionsResponse> findSellOptions(
+    SellOptionsRequest request,
+  ) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/api/v1/trading/assets/sell-options',
+      data: request.toJson(),
+    );
+    return SellOptionsResponse.fromJson(response.data!);
   }
 
   // ── POST /api/v1/trading/routes/calculate ──────────────────────────────────

--- a/app/lib/core/router.dart
+++ b/app/lib/core/router.dart
@@ -23,6 +23,7 @@ import '../features/character/character_screen.dart';
 import '../features/trading/hauling_screen.dart';
 import '../features/trading/hub_comparison_screen.dart';
 import '../features/trading/roi_calculator_screen.dart';
+import '../features/trading/sell_assets_screen.dart';
 import '../features/trading/trading_screen.dart';
 
 // ---------------------------------------------------------------------------
@@ -106,6 +107,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             builder: (context, state) => const HaulingScreen(),
           ),
           GoRoute(
+            path: '/sell-assets',
+            builder: (context, state) => const SellAssetsScreen(),
+          ),
+          GoRoute(
             path: '/character',
             builder: (context, state) => const CharacterScreen(),
           ),
@@ -146,6 +151,10 @@ class _AppShell extends ConsumerWidget {
       label: 'Hauling',
     ),
     NavigationDestination(
+      icon: Icon(Icons.sell_rounded),
+      label: 'Verkaufen',
+    ),
+    NavigationDestination(
       icon: Icon(Icons.person_outline_rounded),
       selectedIcon: Icon(Icons.person_rounded),
       label: 'Character',
@@ -160,7 +169,8 @@ class _AppShell extends ConsumerWidget {
     if (location.startsWith('/hub-comparison')) return 1;
     if (location.startsWith('/roi-calculator')) return 2;
     if (location.startsWith('/hauling')) return 3;
-    if (location.startsWith('/character')) return 4;
+    if (location.startsWith('/sell-assets')) return 4;
+    if (location.startsWith('/character')) return 5;
     return 0; // /trading is default; "Abmelden" is never a selected state
   }
 
@@ -181,8 +191,10 @@ class _AppShell extends ConsumerWidget {
             case 3:
               context.go('/hauling');
             case 4:
-              context.go('/character');
+              context.go('/sell-assets');
             case 5:
+              context.go('/character');
+            case 6:
               _confirmLogout(context, ref);
           }
         },

--- a/app/lib/features/trading/sell_assets_providers.dart
+++ b/app/lib/features/trading/sell_assets_providers.dart
@@ -1,0 +1,57 @@
+/// Riverpod providers for the Sell-from-Assets feature.
+///
+/// Provider graph (reuses [tradingApiProvider] from providers.dart):
+///   tradingApiProvider → characterAssetsProvider (FutureProvider)
+///                      → sellOptionsProvider (AsyncNotifier)
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/asset_models.dart';
+import 'providers.dart' show tradingApiProvider;
+
+// ---------------------------------------------------------------------------
+// characterAssetsProvider — FutureProvider<AssetsResponse>
+// ---------------------------------------------------------------------------
+
+/// Fetches the character's owned items (the picker source) via
+/// GET /api/v1/trading/assets. Errors propagate so the UI can surface them.
+final characterAssetsProvider = FutureProvider<AssetsResponse>((ref) async {
+  final api = ref.watch(tradingApiProvider);
+  return api.listAssets();
+});
+
+// ---------------------------------------------------------------------------
+// SellOptionsNotifier — AsyncNotifier<SellOptionsResponse?>
+// ---------------------------------------------------------------------------
+
+/// Owns the sell-options-search lifecycle.
+///
+/// [build] returns null — no search has been performed yet. Call [find] with a
+/// [SellOptionsRequest] to trigger one; it sets [AsyncLoading] then guards the
+/// API call. An empty `options` list on the resulting [SellOptionsResponse] is
+/// a valid, successful "no sell locations found" state — NOT an error.
+class SellOptionsNotifier extends AsyncNotifier<SellOptionsResponse?> {
+  @override
+  Future<SellOptionsResponse?> build() async => null;
+
+  /// Runs a sell-options search for [request].
+  Future<void> find(SellOptionsRequest request) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final api = ref.read(tradingApiProvider);
+      return api.findSellOptions(request);
+    });
+  }
+
+  /// Clears the current result (e.g. when a different asset is selected).
+  void reset() {
+    state = const AsyncData(null);
+  }
+}
+
+/// Provider for [SellOptionsNotifier].
+final sellOptionsProvider =
+    AsyncNotifierProvider<SellOptionsNotifier, SellOptionsResponse?>(
+  SellOptionsNotifier.new,
+);

--- a/app/lib/features/trading/sell_assets_screen.dart
+++ b/app/lib/features/trading/sell_assets_screen.dart
@@ -1,0 +1,929 @@
+/// Adaptive Sell-from-Assets screen (GitHub issue #107).
+///
+/// The user picks an item they already own (from their character's assets) and
+/// gets a ranked answer to "where do I sell this for the most net ISK, and how
+/// do I get there?" — a taker model (instant sell into a buy order, net of
+/// sales tax) compared across the 5 major hubs + every station in the item's
+/// current region, each with a route (jumps, travel time, security risk). The
+/// user can push the chosen sell location to the in-game autopilot.
+///
+/// Layout (via [isTwoPane] / [kTwoPaneBreakpoint] = 840 dp):
+///   • <840 dp  → single-pane: asset picker + form above a scrollable option
+///                list; tapping an option pushes a detail page.
+///   • ≥840 dp  → two-pane: picker + form on the left, option list on the
+///                right; tapping an option shows its detail in a dialog.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/asset_models.dart';
+import '../../core/breakpoint.dart';
+import 'providers.dart';
+import 'sell_assets_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Security-risk → colour / label mapping (safe=green, caution=amber, danger=red)
+// ---------------------------------------------------------------------------
+
+const Color _kSafeColor = Color(0xFF66BB6A);
+const Color _kCautionColor = Color(0xFFFF9800);
+const Color _kDangerColor = Color(0xFFF44336);
+
+/// Maps a backend `security_risk` value to its chip colour.
+Color sellSecurityRiskColor(String risk) {
+  switch (risk) {
+    case 'danger':
+      return _kDangerColor;
+    case 'caution':
+      return _kCautionColor;
+    case 'safe':
+    default:
+      return _kSafeColor;
+  }
+}
+
+/// Maps a backend `security_risk` value to a German chip label.
+String sellSecurityRiskLabel(String risk) {
+  switch (risk) {
+    case 'danger':
+      return 'Gefahr';
+    case 'caution':
+      return 'Vorsicht';
+    case 'safe':
+    default:
+      return 'Sicher';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// The Sell-from-Assets screen.
+class SellAssetsScreen extends ConsumerWidget {
+  const SellAssetsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Aus Besitz verkaufen'),
+        centerTitle: false,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final twoPane = isTwoPane(constraints.maxWidth);
+          if (twoPane) {
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: const [
+                SizedBox(
+                  width: 360,
+                  child: _PickerPane(),
+                ),
+                VerticalDivider(width: 1),
+                Expanded(child: _ResultPane(twoPane: true)),
+              ],
+            );
+          }
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: const [
+              Flexible(child: _PickerPane()),
+              Divider(height: 1),
+              Expanded(child: _ResultPane(twoPane: false)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Picker pane — asset search + list, then quantity + avoid-low-sec + button
+// ---------------------------------------------------------------------------
+
+class _PickerPane extends ConsumerStatefulWidget {
+  const _PickerPane();
+
+  @override
+  ConsumerState<_PickerPane> createState() => _PickerPaneState();
+}
+
+class _PickerPaneState extends ConsumerState<_PickerPane> {
+  final _searchController = TextEditingController();
+  final _quantityController = TextEditingController();
+  String _query = '';
+  AssetItem? _selected;
+  bool _avoidLowSec = true;
+  String? _error;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _quantityController.dispose();
+    super.dispose();
+  }
+
+  void _select(AssetItem asset) {
+    setState(() {
+      _selected = asset;
+      _quantityController.text = asset.quantity.toString();
+      _error = null;
+    });
+    // A new selection invalidates any previous search result.
+    ref.read(sellOptionsProvider.notifier).reset();
+  }
+
+  Future<void> _search() async {
+    final asset = _selected;
+    if (asset == null) {
+      setState(() => _error = 'Bitte ein Item auswählen.');
+      return;
+    }
+    final qty = int.tryParse(
+        _quantityController.text.replaceAll(RegExp(r'[^0-9]'), ''));
+    if (qty == null || qty <= 0) {
+      setState(() => _error = 'Bitte eine gültige Menge eingeben.');
+      return;
+    }
+    setState(() => _error = null);
+
+    final request = SellOptionsRequest(
+      typeId: asset.typeId,
+      locationId: asset.locationId,
+      quantity: qty,
+      avoidLowSec: _avoidLowSec,
+    );
+    await ref.read(sellOptionsProvider.notifier).find(request);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final busy = ref.watch(sellOptionsProvider).isLoading;
+    final assetsAsync = ref.watch(characterAssetsProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // ── Search field ───────────────────────────────────────────────────
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: TextField(
+            key: const Key('sell-asset-search'),
+            controller: _searchController,
+            enabled: !busy,
+            onChanged: (v) => setState(() => _query = v.trim().toLowerCase()),
+            decoration: const InputDecoration(
+              labelText: 'Item suchen',
+              prefixIcon: Icon(Icons.search_rounded),
+              border: OutlineInputBorder(),
+              isDense: true,
+              contentPadding:
+                  EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            ),
+          ),
+        ),
+
+        // ── Asset list ─────────────────────────────────────────────────────
+        Expanded(
+          child: assetsAsync.when(
+            loading: () =>
+                const Center(child: CircularProgressIndicator()),
+            error: (err, _) => Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Besitz konnte nicht geladen werden.\n$err',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                      color: Theme.of(context).colorScheme.error),
+                ),
+              ),
+            ),
+            data: (resp) {
+              final filtered = resp.assets
+                  .where((a) =>
+                      _query.isEmpty || a.name.toLowerCase().contains(_query))
+                  .toList();
+              if (resp.isEmpty) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(24),
+                    child: Text(
+                      'Kein verkaufbarer Besitz gefunden.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                );
+              }
+              return ListView.builder(
+                key: const Key('sell-asset-list'),
+                itemCount: filtered.length,
+                itemBuilder: (context, i) {
+                  final asset = filtered[i];
+                  final selected = identical(asset, _selected) ||
+                      (_selected != null &&
+                          asset.typeId == _selected!.typeId &&
+                          asset.locationId == _selected!.locationId);
+                  return ListTile(
+                    key: Key(
+                        'sell-asset-${asset.typeId}-${asset.locationId}'),
+                    enabled: asset.marketable && !busy,
+                    selected: selected,
+                    title: Text(
+                      asset.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    subtitle: Text(
+                      '${_fmtUnits(asset.quantity.toDouble())} × '
+                      '${asset.locationName}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    trailing: asset.marketable
+                        ? null
+                        : const Text('nicht handelbar',
+                            style: TextStyle(fontSize: 11)),
+                    onTap: asset.marketable && !busy
+                        ? () => _select(asset)
+                        : null,
+                  );
+                },
+              );
+            },
+          ),
+        ),
+
+        // ── Selection form (quantity + avoid-low-sec + search) ───────────────
+        if (_selected != null) ...[
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  _selected!.name,
+                  style: Theme.of(context).textTheme.titleMedium,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  key: const Key('sell-quantity'),
+                  controller: _quantityController,
+                  enabled: !busy,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [
+                    FilteringTextInputFormatter.digitsOnly
+                  ],
+                  decoration: const InputDecoration(
+                    labelText: 'Menge',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                    suffixText: 'Stk',
+                    contentPadding:
+                        EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  ),
+                ),
+                const SizedBox(height: 4),
+                SwitchListTile(
+                  key: const Key('sell-avoid-lowsec'),
+                  value: _avoidLowSec,
+                  onChanged:
+                      busy ? null : (v) => setState(() => _avoidLowSec = v),
+                  title: const Text(
+                    'Low-Sec vermeiden',
+                    style: TextStyle(fontSize: 14),
+                  ),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+                if (_error != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    _error!,
+                    style: TextStyle(
+                        color: Theme.of(context).colorScheme.error),
+                  ),
+                ],
+                const SizedBox(height: 12),
+                FilledButton.icon(
+                  key: const Key('sell-search-button'),
+                  onPressed: busy ? null : _search,
+                  icon: busy
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child:
+                              CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.sell_rounded),
+                  label: const Text('Verkaufsorte suchen'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result pane — async-aware
+// ---------------------------------------------------------------------------
+
+class _ResultPane extends ConsumerWidget {
+  const _ResultPane({required this.twoPane});
+
+  final bool twoPane;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(sellOptionsProvider);
+
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (err, _) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Suche fehlgeschlagen.\n$err',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ),
+      ),
+      data: (resp) {
+        if (resp == null) {
+          return const _IdleHint();
+        }
+        if (resp.isEmpty) {
+          return const _EmptyResult();
+        }
+        return _OptionList(response: resp, twoPane: twoPane);
+      },
+    );
+  }
+}
+
+class _IdleHint extends StatelessWidget {
+  const _IdleHint();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sell_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Item wählen und Verkaufsorte suchen',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(120),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyResult extends StatelessWidget {
+  const _EmptyResult();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          key: const Key('sell-empty-state'),
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sentiment_dissatisfied_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Keine Verkaufsorte gefunden',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(140),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Option list — `best` highlighted, then the ranked list
+// ---------------------------------------------------------------------------
+
+class _OptionList extends StatelessWidget {
+  const _OptionList({required this.response, required this.twoPane});
+
+  final SellOptionsResponse response;
+  final bool twoPane;
+
+  @override
+  Widget build(BuildContext context) {
+    final skills = response.skillsApplied;
+    final best = response.best;
+    return ListView(
+      key: const Key('sell-option-list'),
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          'Verkaufsorte für ${response.name}',
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          skills.applied
+              ? 'Skill-bereinigt (Accounting ${skills.accounting}, '
+                  'Verkaufssteuer '
+                  '${(skills.salesTaxRate * 100).toStringAsFixed(1)}%)'
+              : 'Ohne Skill-Bereinigung',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 12),
+        if (best != null) ...[
+          _OptionCard(option: best, twoPane: twoPane, isBest: true),
+          const SizedBox(height: 4),
+        ],
+        for (final option in response.options)
+          _OptionCard(option: option, twoPane: twoPane, isBest: false),
+      ],
+    );
+  }
+}
+
+class _OptionCard extends StatelessWidget {
+  const _OptionCard({
+    required this.option,
+    required this.twoPane,
+    required this.isBest,
+  });
+
+  final SellOption option;
+  final bool twoPane;
+  final bool isBest;
+
+  void _openDetail(BuildContext context) {
+    if (twoPane) {
+      showDialog<void>(
+        context: context,
+        builder: (_) => Dialog(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560, maxHeight: 720),
+            child: SellOptionDetail(option: option, itemName: option.systemName),
+          ),
+        ),
+      );
+    } else {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => Scaffold(
+            appBar: AppBar(title: Text(option.systemName)),
+            body: SellOptionDetail(option: option, itemName: option.systemName),
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = Theme.of(context).colorScheme.primary;
+    final muted = Theme.of(context).colorScheme.onSurface.withAlpha(153);
+    final scheme = Theme.of(context).colorScheme;
+
+    // has_data:false → muted "kein Marktpreis" card, not tappable.
+    if (!option.hasData) {
+      return Card(
+        key: Key('sell-option-${option.stationId}'),
+        margin: const EdgeInsets.only(bottom: 12),
+        color: scheme.surfaceContainerHighest.withAlpha(80),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      option.systemName,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            color: muted,
+                          ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  _ScopeBadge(scope: option.scope),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                option.stationName,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: muted),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'kein Marktpreis',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: muted,
+                      fontStyle: FontStyle.italic,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Card(
+      key: Key('sell-option-${option.stationId}'),
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: isBest
+          ? RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: BorderSide(color: accent, width: 2),
+            )
+          : null,
+      child: InkWell(
+        onTap: () => _openDetail(context),
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // ── Header: system + best badge + scope + sec-risk ─────────────
+              Row(
+                children: [
+                  if (isBest) ...[
+                    Icon(Icons.star_rounded, size: 18, color: accent),
+                    const SizedBox(width: 4),
+                  ],
+                  Expanded(
+                    child: Text(
+                      option.systemName,
+                      style:
+                          Theme.of(context).textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.w700,
+                              ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  _ScopeBadge(scope: option.scope),
+                  const SizedBox(width: 6),
+                  _SecurityRiskChip(risk: option.securityRisk),
+                ],
+              ),
+              const SizedBox(height: 2),
+              Text(
+                option.stationName,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodySmall
+                    ?.copyWith(color: muted),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 8),
+
+              // ── total_net — large accent (headline) ────────────────────────
+              Text(
+                '${_fmtIsk(option.totalNet)} ISK',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      color: accent,
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 8),
+
+              // ── Meta row: buy_price, unit_net, jumps, travel time ──────────
+              Wrap(
+                spacing: 16,
+                runSpacing: 4,
+                children: [
+                  _Meta(
+                    icon: Icons.shopping_cart_rounded,
+                    label: 'Kauf ${_fmtIsk(option.buyPrice)}',
+                  ),
+                  _Meta(
+                    icon: Icons.attach_money_rounded,
+                    label: 'Netto/Stk ${_fmtIsk(option.unitNet)}',
+                  ),
+                  _Meta(
+                    icon: Icons.alt_route_rounded,
+                    label: '${option.jumps} Sprünge',
+                  ),
+                  _Meta(
+                    icon: Icons.schedule_rounded,
+                    label: '${option.travelTimeMin.toStringAsFixed(1)} min',
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Meta extends StatelessWidget {
+  const _Meta({required this.icon, required this.label});
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final muted = Theme.of(context).colorScheme.onSurface.withAlpha(153);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: muted),
+        const SizedBox(width: 4),
+        Text(label, style: TextStyle(color: muted)),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scope badge (Hub / Region)
+// ---------------------------------------------------------------------------
+
+class _ScopeBadge extends StatelessWidget {
+  const _ScopeBadge({required this.scope});
+
+  final String scope;
+
+  @override
+  Widget build(BuildContext context) {
+    final isHub = scope == 'hub';
+    final color = isHub
+        ? Theme.of(context).colorScheme.primary
+        : Theme.of(context).colorScheme.tertiary;
+    return Container(
+      key: Key('sell-scope-badge-$scope'),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withAlpha(40),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: color.withAlpha(150)),
+      ),
+      child: Text(
+        isHub ? 'Hub' : 'Region',
+        style: TextStyle(
+          color: color,
+          fontWeight: FontWeight.w600,
+          fontSize: 11,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Security-risk chip (safe=green / caution=amber / danger=red)
+// ---------------------------------------------------------------------------
+
+class _SecurityRiskChip extends StatelessWidget {
+  const _SecurityRiskChip({required this.risk});
+
+  final String risk;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = sellSecurityRiskColor(risk);
+    return Container(
+      key: Key('sell-risk-chip-$risk'),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withAlpha(40),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color.withAlpha(150)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.shield_rounded, size: 14, color: color),
+          const SizedBox(width: 4),
+          Text(
+            sellSecurityRiskLabel(risk),
+            style: TextStyle(
+              color: color,
+              fontWeight: FontWeight.w600,
+              fontSize: 12,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Option detail — full breakdown + "Route an EVE übertragen" button
+// ---------------------------------------------------------------------------
+
+/// Full detail view for a [SellOption]: a metrics breakdown plus a button that
+/// pushes the sell station to the in-game autopilot (clearing other waypoints).
+class SellOptionDetail extends ConsumerWidget {
+  const SellOptionDetail({
+    super.key,
+    required this.option,
+    required this.itemName,
+  });
+
+  final SellOption option;
+
+  /// Used only for the snackbar confirmation message.
+  final String itemName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accent = Theme.of(context).colorScheme.primary;
+    final muted = Theme.of(context).colorScheme.onSurface.withAlpha(153);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Verkaufsort',
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: muted,
+                  letterSpacing: 1.1,
+                ),
+          ),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  option.systemName,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _ScopeBadge(scope: option.scope),
+              const SizedBox(width: 6),
+              _SecurityRiskChip(risk: option.securityRisk),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            option.stationName,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: muted),
+          ),
+          const SizedBox(height: 12),
+
+          Text(
+            '${_fmtIsk(option.totalNet)} ISK netto',
+            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  color: accent,
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 8),
+
+          // ── Summary row ──────────────────────────────────────────────────
+          Wrap(
+            spacing: 16,
+            runSpacing: 4,
+            children: [
+              _Meta(
+                icon: Icons.shopping_cart_rounded,
+                label: 'Kaufpreis ${_fmtIsk(option.buyPrice)}',
+              ),
+              _Meta(
+                icon: Icons.attach_money_rounded,
+                label: 'Netto/Stk ${_fmtIsk(option.unitNet)}',
+              ),
+              _Meta(
+                icon: Icons.alt_route_rounded,
+                label: '${option.jumps} Sprünge',
+              ),
+              _Meta(
+                icon: Icons.schedule_rounded,
+                label: '${option.travelTimeMin.toStringAsFixed(1)} min',
+              ),
+              _Meta(
+                icon: Icons.public_rounded,
+                label: option.regionName,
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+
+          // ── Action button ────────────────────────────────────────────────
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              key: const Key('sell-waypoint-button'),
+              onPressed: () => _setWaypoint(context, ref),
+              icon: const Icon(Icons.navigation_rounded),
+              label: const Text('Route an EVE übertragen'),
+              style: FilledButton.styleFrom(
+                backgroundColor: accent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                textStyle: const TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 16,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _setWaypoint(BuildContext context, WidgetRef ref) async {
+    final api = ref.read(tradingApiProvider);
+    try {
+      // Single sell destination; clear any existing route.
+      await api.setWaypoint(
+        destinationId: option.stationId,
+        clearOtherWaypoints: true,
+        addToBeginning: false,
+      );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Route gesetzt: ${option.systemName}'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Fehler beim Setzen der Route: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers (mirrors hauling/roi/hub screens)
+// ---------------------------------------------------------------------------
+
+String _fmtIsk(double v) {
+  if (v >= 1e9) return '${(v / 1e9).toStringAsFixed(2)}B';
+  if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(2)}M';
+  if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+  return v.toStringAsFixed(2);
+}
+
+String _fmtUnits(double v) {
+  if (v >= 1e6) return '${(v / 1e6).toStringAsFixed(1)}M';
+  if (v >= 1e3) return '${(v / 1e3).toStringAsFixed(1)}K';
+  return v.toStringAsFixed(0);
+}

--- a/app/test/asset_models_test.dart
+++ b/app/test/asset_models_test.dart
@@ -1,0 +1,207 @@
+/// Unit tests for asset_models — exercises the null/float-robust parsing
+/// required for the mobile DTO layer (Sell-from-Assets, issue #107).
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/asset_models.dart';
+
+void main() {
+  group('AssetsResponse.fromJson', () {
+    test('parses assets + count', () {
+      final resp = AssetsResponse.fromJson(const {
+        'assets': [
+          {
+            'type_id': 34,
+            'name': 'Tritanium',
+            'quantity': 120000,
+            'location_id': 60003760,
+            'location_name': 'Jita IV - Moon 4 - CNAP',
+            'system_id': 30000142,
+            'region_id': 10000002,
+            'marketable': true,
+          },
+          {
+            'type_id': 99,
+            'name': 'Blueprint Copy',
+            'quantity': 1,
+            'location_id': 60003760,
+            'location_name': 'Jita IV - Moon 4 - CNAP',
+            'system_id': 30000142,
+            'region_id': 10000002,
+            'marketable': false,
+          },
+        ],
+        'count': 2,
+      });
+
+      expect(resp.count, 2);
+      expect(resp.assets, hasLength(2));
+      expect(resp.isEmpty, isFalse);
+
+      final trit = resp.assets.first;
+      expect(trit.typeId, 34);
+      expect(trit.name, 'Tritanium');
+      expect(trit.quantity, 120000);
+      expect(trit.locationId, 60003760);
+      expect(trit.locationName, 'Jita IV - Moon 4 - CNAP');
+      expect(trit.systemId, 30000142);
+      expect(trit.regionId, 10000002);
+      expect(trit.marketable, isTrue);
+
+      expect(resp.assets[1].marketable, isFalse);
+    });
+
+    test('tolerates missing / null fields', () {
+      final resp = AssetsResponse.fromJson(const {
+        'assets': [
+          {'name': 'Mystery'},
+        ],
+      });
+      expect(resp.count, 0);
+      final a = resp.assets.single;
+      expect(a.typeId, 0);
+      expect(a.quantity, 0);
+      expect(a.locationId, 0);
+      expect(a.marketable, isFalse);
+    });
+
+    test('empty assets is a valid result', () {
+      final resp = AssetsResponse.fromJson(const {'assets': [], 'count': 0});
+      expect(resp.isEmpty, isTrue);
+      expect(resp.assets, isEmpty);
+    });
+  });
+
+  group('SellOptionsResponse.fromJson', () {
+    const Map<String, dynamic> sample = {
+      'type_id': 34,
+      'name': 'Tritanium',
+      'quantity': 120000,
+      'origin_system_id': 30000142,
+      'best': {
+        'scope': 'hub',
+        'region_id': 10000002,
+        'region_name': 'The Forge',
+        'station_id': 60003760,
+        'station_name': 'Jita IV - Moon 4 - CNAP',
+        'system_name': 'Jita',
+        'buy_price': 5.5,
+        'unit_net': 5.36,
+        'total_net': 643200,
+        'jumps': 0,
+        'travel_time_min': 0,
+        'security_risk': 'safe',
+        'has_data': true,
+      },
+      'options': [
+        {
+          'scope': 'hub',
+          'region_id': 10000002,
+          'region_name': 'The Forge',
+          'station_id': 60003760,
+          'station_name': 'Jita IV - Moon 4 - CNAP',
+          'system_name': 'Jita',
+          'buy_price': 5.5,
+          'unit_net': 5.36,
+          'total_net': 643200,
+          'jumps': 0,
+          'travel_time_min': 0,
+          'security_risk': 'safe',
+          'has_data': true,
+        },
+        {
+          'scope': 'current_region',
+          'region_id': 10000002,
+          'region_name': 'The Forge',
+          'station_id': 60000001,
+          'station_name': 'Some Outpost',
+          'system_name': 'Sobaseki',
+          'security_risk': 'danger',
+          'has_data': false,
+        },
+      ],
+      'skills_applied': {
+        'applied': true,
+        'accounting': 5,
+        'broker_relations': 5,
+        'sales_tax_rate': 0.025,
+        'broker_fee_rate': 0.015,
+      },
+    };
+
+    test('parses all fields including best + nested options', () {
+      final resp = SellOptionsResponse.fromJson(sample);
+
+      expect(resp.typeId, 34);
+      expect(resp.name, 'Tritanium');
+      expect(resp.quantity, 120000);
+      expect(resp.originSystemId, 30000142);
+      expect(resp.isEmpty, isFalse);
+      expect(resp.options, hasLength(2));
+      expect(resp.skillsApplied.applied, isTrue);
+      expect(resp.skillsApplied.salesTaxRate, 0.025);
+
+      final best = resp.best!;
+      expect(best.scope, 'hub');
+      expect(best.isHub, isTrue);
+      expect(best.regionName, 'The Forge');
+      expect(best.stationId, 60003760);
+      expect(best.systemName, 'Jita');
+      expect(best.buyPrice, 5.5);
+      expect(best.unitNet, 5.36);
+      expect(best.totalNet, 643200);
+      expect(best.jumps, 0);
+      expect(best.travelTimeMin, 0);
+      expect(best.securityRisk, 'safe');
+      expect(best.hasData, isTrue);
+
+      // has_data:false option defaults numeric fields to 0.
+      final noData = resp.options[1];
+      expect(noData.hasData, isFalse);
+      expect(noData.scope, 'current_region');
+      expect(noData.isHub, isFalse);
+      expect(noData.buyPrice, 0);
+      expect(noData.totalNet, 0);
+      expect(noData.securityRisk, 'danger');
+    });
+
+    test('tolerates missing / null fields (defaults, not exceptions)', () {
+      final resp = SellOptionsResponse.fromJson(const {
+        'options': [
+          {
+            'system_name': 'Jita',
+            // everything else absent
+          },
+        ],
+      });
+
+      expect(resp.typeId, 0);
+      expect(resp.name, '');
+      expect(resp.quantity, 0);
+      expect(resp.skillsApplied.applied, isFalse);
+      expect(resp.best, isNull);
+
+      final opt = resp.options.single;
+      expect(opt.scope, 'current_region'); // defaulted
+      expect(opt.jumps, 0);
+      expect(opt.totalNet, 0);
+      expect(opt.securityRisk, 'safe'); // defaulted
+      expect(opt.hasData, isFalse);
+    });
+
+    test('best:null + empty options is a valid result', () {
+      final resp = SellOptionsResponse.fromJson(const {
+        'type_id': 34,
+        'name': 'Tritanium',
+        'quantity': 120000,
+        'origin_system_id': 30000142,
+        'best': null,
+        'options': [],
+      });
+      expect(resp.best, isNull);
+      expect(resp.isEmpty, isTrue);
+      expect(resp.options, isEmpty);
+    });
+  });
+}

--- a/app/test/sell_assets_screen_layout_test.dart
+++ b/app/test/sell_assets_screen_layout_test.dart
@@ -1,0 +1,290 @@
+/// Widget tests for SellAssetsScreen adaptive layout + option list + detail.
+///
+/// 1. Small view (<840 dp) → single-pane: no VerticalDivider.
+/// 2. Large view (≥840 dp) → two-pane: at least one VerticalDivider.
+/// Plus: option list renders from a seeded response (system → station), the
+/// security-risk chip uses the right colour, tapping an option opens the detail
+/// with the waypoint button, and an empty `options` result shows the empty
+/// state. Mirrors hauling_screen_layout_test.dart.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/asset_models.dart';
+import 'package:eve_o_provit/api/trading_api.dart';
+import 'package:eve_o_provit/core/theme.dart';
+import 'package:eve_o_provit/features/trading/providers.dart';
+import 'package:eve_o_provit/features/trading/sell_assets_providers.dart';
+import 'package:eve_o_provit/features/trading/sell_assets_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Canned data + fakes
+// ---------------------------------------------------------------------------
+
+AssetsResponse _fakeAssets() => const AssetsResponse(
+      count: 1,
+      assets: [
+        AssetItem(
+          typeId: 34,
+          name: 'Tritanium',
+          quantity: 120000,
+          locationId: 60003760,
+          locationName: 'Jita IV - Moon 4 - CNAP',
+          systemId: 30000142,
+          regionId: 10000002,
+          marketable: true,
+        ),
+      ],
+    );
+
+SellOptionsResponse _fakeResponse() => const SellOptionsResponse(
+      typeId: 34,
+      name: 'Tritanium',
+      quantity: 120000,
+      originSystemId: 30000142,
+      best: SellOption(
+        scope: 'hub',
+        regionId: 10000002,
+        regionName: 'The Forge',
+        stationId: 60003760,
+        stationName: 'Jita IV - Moon 4 - CNAP',
+        systemName: 'Jita',
+        buyPrice: 5.5,
+        unitNet: 5.36,
+        totalNet: 643200,
+        jumps: 0,
+        travelTimeMin: 0,
+        securityRisk: 'safe',
+        hasData: true,
+      ),
+      options: [
+        SellOption(
+          scope: 'hub',
+          regionId: 10000002,
+          regionName: 'The Forge',
+          stationId: 60003760,
+          stationName: 'Jita IV - Moon 4 - CNAP',
+          systemName: 'Jita',
+          buyPrice: 5.5,
+          unitNet: 5.36,
+          totalNet: 643200,
+          jumps: 0,
+          travelTimeMin: 0,
+          securityRisk: 'safe',
+          hasData: true,
+        ),
+        SellOption(
+          scope: 'current_region',
+          regionId: 10000002,
+          regionName: 'The Forge',
+          stationId: 60000002,
+          stationName: 'Sobaseki Outpost',
+          systemName: 'Sobaseki',
+          buyPrice: 5.1,
+          unitNet: 4.97,
+          totalNet: 596400,
+          jumps: 3,
+          travelTimeMin: 5.0,
+          securityRisk: 'danger',
+          hasData: true,
+        ),
+        SellOption(
+          scope: 'current_region',
+          regionId: 10000002,
+          regionName: 'The Forge',
+          stationId: 60000003,
+          stationName: 'Nowhere Station',
+          systemName: 'Nowhere',
+          buyPrice: 0,
+          unitNet: 0,
+          totalNet: 0,
+          jumps: 0,
+          travelTimeMin: 0,
+          securityRisk: 'caution',
+          hasData: false,
+        ),
+      ],
+      skillsApplied: SkillsApplied(
+        applied: true,
+        accounting: 5,
+        brokerRelations: 5,
+        salesTaxRate: 0.025,
+        brokerFeeRate: 0.015,
+      ),
+    );
+
+SellOptionsResponse _emptyResponse() => const SellOptionsResponse(
+      typeId: 34,
+      name: 'Tritanium',
+      quantity: 120000,
+      originSystemId: 30000142,
+      best: null,
+      options: [],
+      skillsApplied: SkillsApplied(
+        applied: false,
+        accounting: 0,
+        brokerRelations: 0,
+        salesTaxRate: 0,
+        brokerFeeRate: 0,
+      ),
+    );
+
+class _FakeTradingApi extends TradingApi {
+  _FakeTradingApi() : super(Dio());
+
+  @override
+  Future<AssetsResponse> listAssets() async => _fakeAssets();
+
+  @override
+  Future<SellOptionsResponse> findSellOptions(
+    SellOptionsRequest request,
+  ) async =>
+      _fakeResponse();
+}
+
+class _StubNotifier extends SellOptionsNotifier {
+  @override
+  Future<SellOptionsResponse?> build() async => _fakeResponse();
+}
+
+class _EmptyNotifier extends SellOptionsNotifier {
+  @override
+  Future<SellOptionsResponse?> build() async => _emptyResponse();
+}
+
+class _IdleNotifier extends SellOptionsNotifier {
+  @override
+  Future<SellOptionsResponse?> build() async => null;
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  double width, {
+  double height = 1400,
+  SellOptionsNotifier Function() notifier = _StubNotifier.new,
+}) async {
+  tester.view.physicalSize = Size(width, height);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tradingApiProvider.overrideWithValue(_FakeTradingApi()),
+        sellOptionsProvider.overrideWith(notifier),
+      ],
+      child: MaterialApp(
+        theme: buildTheme(Brightness.light),
+        home: const SellAssetsScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('Single-pane (width 800): no VerticalDivider', (tester) async {
+    await _pumpScreen(tester, 800);
+
+    expect(find.byType(VerticalDivider), findsNothing);
+    expect(find.byKey(const Key('sell-asset-search')), findsOneWidget);
+  });
+
+  testWidgets('Two-pane (width 1280): at least one VerticalDivider',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byType(VerticalDivider), findsAtLeastNWidgets(1));
+    expect(find.byKey(const Key('sell-asset-search')), findsOneWidget);
+  });
+
+  testWidgets('Asset picker lists owned items with quantity + location',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byKey(const Key('sell-asset-list')), findsOneWidget);
+    expect(find.text('Tritanium'), findsWidgets);
+    expect(find.textContaining('Jita IV - Moon 4 - CNAP'), findsWidgets);
+  });
+
+  testWidgets('Option list renders system → station headers', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byKey(const Key('sell-option-list')), findsOneWidget);
+    // system_name headers (best is also Jita, so findsWidgets).
+    expect(find.text('Jita'), findsWidgets);
+    expect(find.text('Sobaseki'), findsOneWidget);
+    // station_name subtitle.
+    expect(find.text('Sobaseki Outpost'), findsOneWidget);
+  });
+
+  testWidgets('has_data:false option renders muted "kein Marktpreis"',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.text('kein Marktpreis'), findsOneWidget);
+    expect(find.text('Nowhere'), findsOneWidget);
+  });
+
+  testWidgets('Security risk chips use the correct colour', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    final safeChip = tester.widget<Container>(
+      find.byKey(const Key('sell-risk-chip-safe')).first,
+    );
+    final safeDeco = safeChip.decoration as BoxDecoration;
+    expect(safeDeco.color, sellSecurityRiskColor('safe').withAlpha(40));
+    expect(sellSecurityRiskColor('safe'), const Color(0xFF66BB6A)); // green
+
+    final dangerChip = tester.widget<Container>(
+      find.byKey(const Key('sell-risk-chip-danger')).first,
+    );
+    final dangerDeco = dangerChip.decoration as BoxDecoration;
+    expect(dangerDeco.color, sellSecurityRiskColor('danger').withAlpha(40));
+    expect(sellSecurityRiskColor('danger'), const Color(0xFFF44336)); // red
+
+    // caution maps to amber.
+    expect(sellSecurityRiskColor('caution'), const Color(0xFFFF9800));
+  });
+
+  testWidgets('Scope badge renders Hub and Region labels', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byKey(const Key('sell-scope-badge-hub')), findsWidgets);
+    expect(
+        find.byKey(const Key('sell-scope-badge-current_region')), findsWidgets);
+    expect(find.text('Hub'), findsWidgets);
+    expect(find.text('Region'), findsWidgets);
+  });
+
+  testWidgets('Tapping an option opens the detail with the waypoint button',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    // Tap the second (current_region) option; the best+first share station id.
+    await tester.tap(find.text('Sobaseki Outpost'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('sell-waypoint-button')), findsOneWidget);
+    expect(find.text('Route an EVE übertragen'), findsOneWidget);
+  });
+
+  testWidgets('Empty options result shows the empty-state', (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _EmptyNotifier.new);
+
+    expect(find.byKey(const Key('sell-empty-state')), findsOneWidget);
+    expect(find.text('Keine Verkaufsorte gefunden'), findsOneWidget);
+    expect(find.byKey(const Key('sell-option-list')), findsNothing);
+  });
+
+  testWidgets('Idle state shows the hint before any search', (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _IdleNotifier.new);
+
+    expect(find.text('Item wählen und Verkaufsorte suchen'), findsOneWidget);
+    expect(find.byKey(const Key('sell-option-list')), findsNothing);
+  });
+}

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -37,6 +37,7 @@ type AppContainer struct {
 	MultiHubHandler    *handlers.MultiHubHandler
 	PortfolioHandler   *handlers.PortfolioHandler
 	HaulingHandler     *handlers.HaulingHandler
+	AssetsHandler      *handlers.AssetsHandler
 
 	// Background workers
 	CompetitionCollector *services.CompetitionCollector
@@ -162,6 +163,10 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 	haulingRouteFinder := services.NewRouteFinder(c.ESIClient, c.MarketRepo, c.SDERepo, c.DB.SDE, c.Redis)
 	haulingService := services.NewHaulingService(c.SDERepo, haulingRouteFinder, fittingService, skillsService, characterHelper, c.DB.SDE, c.AppLogger)
 	c.HaulingHandler = handlers.NewHaulingHandler(haulingService)
+
+	// Sell-from-assets (#107) — reuses hub price fetch + skills + navigation.
+	assetSaleService := services.NewAssetSaleService(skillsService, c.ESIClient, c.SDERepo, services.NewESIAssetFetcher(), c.SDERepo, c.DB.SDE, c.AppLogger)
+	c.AssetsHandler = handlers.NewAssetsHandler(assetSaleService)
 
 	// Start the competition collector in the background (lazy-tracked pairs).
 	go c.CompetitionCollector.Start(ctx)

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -155,6 +155,8 @@ func setupApp(c *AppContainer) *fiber.App {
 	api.Post("/trading/hubs/compare", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.MultiHubHandler.CompareHubs)
 	api.Post("/trading/portfolio/optimize", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.PortfolioHandler.Optimize)
 	api.Post("/trading/hauling/routes", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.HaulingHandler.FindRoutes)
+	api.Get("/trading/assets", evesso.NewAuthMiddleware(c.TokenValidator), c.AssetsHandler.ListAssets)
+	api.Post("/trading/assets/sell-options", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.AssetsHandler.SellOptions)
 	api.Get("/items/search", c.TradingHandler.SearchItems)
 
 	api.Post("/calculations/cargo", c.CalculationHandler.CalculateCargo)

--- a/backend/internal/handlers/assets.go
+++ b/backend/internal/handlers/assets.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
+)
+
+// AssetsHandler serves the sell-from-assets endpoints (Issue #107).
+type AssetsHandler struct {
+	service *services.AssetSaleService
+}
+
+// NewAssetsHandler creates a new assets handler.
+func NewAssetsHandler(service *services.AssetSaleService) *AssetsHandler {
+	return &AssetsHandler{service: service}
+}
+
+func assetsAuthCtx(c *fiber.Ctx) (int, string, bool) {
+	cid, ok1 := c.Locals("character_id").(int)
+	tok, ok2 := c.Locals("access_token").(string)
+	return cid, tok, ok1 && ok2
+}
+
+// ListAssets handles GET /api/v1/trading/assets
+//
+// @Summary List owned items aggregated by type and location
+// @Description Returns the character's assets aggregated by (type, location) with quantity.
+// @Tags Trading
+// @Produce json
+// @Success 200 {object} models.AssetsResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/trading/assets [get]
+func (h *AssetsHandler) ListAssets(c *fiber.Ctx) error {
+	cid, tok, ok := assetsAuthCtx(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Authentication required"})
+	}
+	res, err := h.service.ListAssets(c.UserContext(), cid, tok)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to list assets"})
+	}
+	return c.JSON(res)
+}
+
+// SellOptions handles POST /api/v1/trading/assets/sell-options
+//
+// @Summary Rank taker sell locations for one owned item
+// @Description For a selected owned item, ranks instant-sell (taker) locations across the
+// @Description major hubs + the item's current region by net proceeds, with route info.
+// @Tags Trading
+// @Accept json
+// @Produce json
+// @Param request body models.SellOptionsRequest true "Selected item"
+// @Success 200 {object} models.SellOptionsResponse
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/trading/assets/sell-options [post]
+func (h *AssetsHandler) SellOptions(c *fiber.Ctx) error {
+	var req models.SellOptionsRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+	if req.TypeID <= 0 || req.Quantity <= 0 || req.LocationID <= 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "type_id, location_id and quantity are required"})
+	}
+	cid, tok, ok := assetsAuthCtx(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Authentication required"})
+	}
+	res, err := h.service.SellOptions(c.UserContext(), &req, cid, tok)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to compute sell options"})
+	}
+	return c.JSON(res)
+}

--- a/backend/internal/handlers/assets_test.go
+++ b/backend/internal/handlers/assets_test.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestAssetsHandler_SellOptions_BadRequest(t *testing.T) {
+	app := fiber.New()
+	h := &AssetsHandler{} // validation happens before any service call
+	app.Post("/sell", func(c *fiber.Ctx) error {
+		c.Locals("character_id", 1)
+		c.Locals("access_token", "tok")
+		return h.SellOptions(c)
+	})
+	req := httptest.NewRequest("POST", "/sell", strings.NewReader(`{"type_id":0,"location_id":1,"quantity":0}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+	if resp.StatusCode != 400 {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestAssetsHandler_SellOptions_Unauthorized(t *testing.T) {
+	app := fiber.New()
+	h := &AssetsHandler{}
+	app.Post("/sell", h.SellOptions)
+	req := httptest.NewRequest("POST", "/sell", strings.NewReader(`{"type_id":34,"location_id":60003760,"quantity":10}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+	if resp.StatusCode != 401 {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestAssetsHandler_ListAssets_Unauthorized(t *testing.T) {
+	app := fiber.New()
+	h := &AssetsHandler{}
+	app.Get("/assets", h.ListAssets)
+	req := httptest.NewRequest("GET", "/assets", nil)
+	resp, _ := app.Test(req)
+	if resp.StatusCode != 401 {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}

--- a/backend/internal/models/assets.go
+++ b/backend/internal/models/assets.go
@@ -1,0 +1,55 @@
+package models
+
+// AssetItem is one aggregated owned stack: a type at a location with a summed quantity.
+type AssetItem struct {
+	TypeID       int    `json:"type_id"`
+	Name         string `json:"name"`
+	Quantity     int    `json:"quantity"`
+	LocationID   int64  `json:"location_id"`
+	LocationName string `json:"location_name"`
+	SystemID     int    `json:"system_id"`
+	RegionID     int    `json:"region_id"`
+	Marketable   bool   `json:"marketable"`
+}
+
+// AssetsResponse is the GET /trading/assets payload.
+type AssetsResponse struct {
+	Assets []AssetItem `json:"assets"`
+	Count  int         `json:"count"`
+}
+
+// SellOptionsRequest is the POST /trading/assets/sell-options body.
+type SellOptionsRequest struct {
+	TypeID      int   `json:"type_id"`
+	LocationID  int64 `json:"location_id"`
+	Quantity    int   `json:"quantity"`
+	AvoidLowSec bool  `json:"avoid_low_sec"`
+}
+
+// SellOption is one ranked place to sell the item (taker / sell into a buy order).
+type SellOption struct {
+	Scope         string  `json:"scope"` // "hub" | "current_region"
+	RegionID      int     `json:"region_id"`
+	RegionName    string  `json:"region_name"`
+	StationID     int64   `json:"station_id"`
+	StationName   string  `json:"station_name"`
+	SystemName    string  `json:"system_name"`
+	BuyPrice      float64 `json:"buy_price"`
+	UnitNet       float64 `json:"unit_net"`
+	TotalNet      float64 `json:"total_net"`
+	Jumps         int     `json:"jumps"`
+	TravelTimeMin float64 `json:"travel_time_min"`
+	SecurityRisk  string  `json:"security_risk"` // "safe" | "caution" | "danger"
+	HasData       bool    `json:"has_data"`
+}
+
+// SellOptionsResponse is the ranked result for one selected item.
+type SellOptionsResponse struct {
+	TypeID         int           `json:"type_id"`
+	Name           string        `json:"name"`
+	Quantity       int           `json:"quantity"`
+	OriginSystemID int           `json:"origin_system_id"`
+	Best           *SellOption   `json:"best"`
+	Options        []SellOption  `json:"options"`
+	SkillsApplied  SkillsApplied `json:"skills_applied"`
+}

--- a/backend/internal/services/asset_fetcher.go
+++ b/backend/internal/services/asset_fetcher.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// RawAsset is the minimal ESI asset shape the aggregator needs.
+type RawAsset struct {
+	TypeID       int
+	LocationID   int64
+	Quantity     int
+	LocationFlag string
+}
+
+// assetFetcher fetches a character's full asset list (keeps AssetSaleService testable).
+type assetFetcher interface {
+	FetchCharacterAssets(ctx context.Context, characterID int, accessToken string) ([]RawAsset, error)
+}
+
+// ESIAssetFetcher calls /characters/{id}/assets/ with pagination (X-Pages).
+type ESIAssetFetcher struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewESIAssetFetcher creates a fetcher against the live ESI base URL.
+func NewESIAssetFetcher() *ESIAssetFetcher {
+	return &ESIAssetFetcher{
+		baseURL: "https://esi.evetech.net",
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+type esiAssetPage struct {
+	TypeID       int    `json:"type_id"`
+	LocationID   int64  `json:"location_id"`
+	Quantity     int    `json:"quantity"`
+	LocationFlag string `json:"location_flag"`
+}
+
+// FetchCharacterAssets pulls every page of the character's assets.
+func (f *ESIAssetFetcher) FetchCharacterAssets(ctx context.Context, characterID int, accessToken string) ([]RawAsset, error) {
+	base := fmt.Sprintf("%s/latest/characters/%d/assets/", f.baseURL, characterID)
+	first, pages, err := f.page(ctx, base, accessToken, 1)
+	if err != nil {
+		return nil, err
+	}
+	all := first
+	for p := 2; p <= pages; p++ {
+		more, _, err := f.page(ctx, base, accessToken, p)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, more...)
+	}
+	return all, nil
+}
+
+func (f *ESIAssetFetcher) page(ctx context.Context, base, token string, page int) ([]RawAsset, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"?page="+strconv.Itoa(page), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, 0, fmt.Errorf("unauthorized")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, fmt.Errorf("ESI assets status %d", resp.StatusCode)
+	}
+	pages := 1
+	if x := resp.Header.Get("X-Pages"); x != "" {
+		if v, err := strconv.Atoi(x); err == nil {
+			pages = v
+		}
+	}
+	var raw []esiAssetPage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, 0, err
+	}
+	out := make([]RawAsset, 0, len(raw))
+	for _, a := range raw {
+		out = append(out, RawAsset{TypeID: a.TypeID, LocationID: a.LocationID, Quantity: a.Quantity, LocationFlag: a.LocationFlag})
+	}
+	return out, pages, nil
+}

--- a/backend/internal/services/asset_fetcher_test.go
+++ b/backend/internal/services/asset_fetcher_test.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestESIAssetFetcher_Paginates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Pages", "2")
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			fmt.Fprint(w, `[{"type_id":34,"location_id":60003760,"quantity":100,"location_flag":"Hangar"}]`)
+		case "2":
+			fmt.Fprint(w, `[{"type_id":35,"location_id":60003760,"quantity":7,"location_flag":"Hangar"}]`)
+		}
+	}))
+	defer srv.Close()
+
+	f := &ESIAssetFetcher{baseURL: srv.URL, client: srv.Client()}
+	got, err := f.FetchCharacterAssets(context.Background(), 123, "token")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 2 || got[0].TypeID != 34 || got[0].Quantity != 100 || got[1].TypeID != 35 {
+		t.Fatalf("unexpected assets: %+v", got)
+	}
+}
+
+func TestESIAssetFetcher_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	f := &ESIAssetFetcher{baseURL: srv.URL, client: srv.Client()}
+	if _, err := f.FetchCharacterAssets(context.Background(), 1, "bad"); err == nil {
+		t.Fatalf("expected error on 401")
+	}
+}

--- a/backend/internal/services/asset_sale_service.go
+++ b/backend/internal/services/asset_sale_service.go
@@ -1,7 +1,15 @@
 package services
 
 import (
+	"context"
+	"database/sql"
+	"sort"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/navigation"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
 )
 
 // takerUnitNet is the per-unit proceeds when selling instantly into a buy order:
@@ -59,4 +67,181 @@ func aggregateAssets(raw []RawAsset) []aggStack {
 		out = append(out, aggStack{typeID: r.TypeID, locationID: r.LocationID, quantity: r.Quantity})
 	}
 	return out
+}
+
+// AssetSaleService lists owned items and ranks taker sell locations (Issue #107).
+type AssetSaleService struct {
+	skills  SkillsServicer
+	market  hubOrderFetcher
+	types   typeNamer
+	assets  assetFetcher
+	sdeRepo *database.SDERepository
+	sdeDB   *sql.DB
+	logger  *logger.Logger
+}
+
+// NewAssetSaleService creates a new service.
+func NewAssetSaleService(
+	skills SkillsServicer,
+	market hubOrderFetcher,
+	types typeNamer,
+	assets assetFetcher,
+	sdeRepo *database.SDERepository,
+	sdeDB *sql.DB,
+	logger *logger.Logger,
+) *AssetSaleService {
+	return &AssetSaleService{skills: skills, market: market, types: types, assets: assets, sdeRepo: sdeRepo, sdeDB: sdeDB, logger: logger}
+}
+
+// ListAssets returns the character's owned items aggregated by (type, location).
+func (s *AssetSaleService) ListAssets(ctx context.Context, characterID int, accessToken string) (*models.AssetsResponse, error) {
+	raw, err := s.assets.FetchCharacterAssets(ctx, characterID, accessToken)
+	if err != nil {
+		return nil, err
+	}
+	stacks := aggregateAssets(raw)
+	items := make([]models.AssetItem, 0, len(stacks))
+	for _, st := range stacks {
+		item := models.AssetItem{TypeID: st.typeID, Quantity: st.quantity, LocationID: st.locationID}
+		if info, err := s.types.GetTypeInfo(ctx, st.typeID); err == nil && info != nil {
+			item.Name = info.Name
+			item.Marketable = info.MarketGroup != nil
+		}
+		if sysID, err := s.sdeRepo.GetSystemIDForLocation(ctx, st.locationID); err == nil {
+			item.SystemID = int(sysID)
+			if rid, err := s.sdeRepo.GetRegionIDForSystem(ctx, sysID); err == nil {
+				item.RegionID = rid
+			}
+		}
+		if name, err := s.sdeRepo.GetStationName(ctx, st.locationID); err == nil {
+			item.LocationName = name
+		}
+		items = append(items, item)
+	}
+	return &models.AssetsResponse{Assets: items, Count: len(items)}, nil
+}
+
+// SellOptions ranks taker sell locations for one owned item.
+func (s *AssetSaleService) SellOptions(ctx context.Context, req *models.SellOptionsRequest, characterID int, accessToken string) (*models.SellOptionsResponse, error) {
+	skills, serr := s.skills.GetCharacterSkills(ctx, characterID, accessToken)
+	if serr != nil || skills == nil {
+		skills = &TradingSkills{}
+	}
+	salesTaxRate := SalesTaxRate(skills.Accounting)
+
+	name := ""
+	if info, err := s.types.GetTypeInfo(ctx, req.TypeID); err == nil && info != nil {
+		name = info.Name
+	}
+
+	resp := &models.SellOptionsResponse{
+		TypeID: req.TypeID, Name: name, Quantity: req.Quantity,
+		SkillsApplied: models.SkillsApplied{
+			Applied: serr == nil, Accounting: skills.Accounting, BrokerRelations: skills.BrokerRelations,
+			SalesTaxRate:  salesTaxRate,
+			BrokerFeeRate: BrokerFeeRate(skills.BrokerRelations, skills.AdvancedBrokerRelations, skills.FactionStanding, skills.CorpStanding),
+		},
+	}
+
+	originSys, err := s.sdeRepo.GetSystemIDForLocation(ctx, req.LocationID)
+	if err != nil {
+		return resp, nil // origin unresolvable -> empty options
+	}
+	resp.OriginSystemID = int(originSys)
+	currentRegion, _ := s.sdeRepo.GetRegionIDForSystem(ctx, originSys)
+
+	var options []models.SellOption
+
+	// 5 major hubs: region-best buy order, route to hub system.
+	for _, hub := range MajorHubs {
+		orders, err := s.market.FetchMarketOrdersForType(ctx, hub.RegionID, req.TypeID)
+		if err != nil {
+			s.logger.Warn("sell-options: hub fetch failed", "error", err, "region", hub.RegionID)
+			options = append(options, models.SellOption{Scope: "hub", RegionID: hub.RegionID, RegionName: hub.RegionName, SystemName: hub.Name, HasData: false})
+			continue
+		}
+		price, stationID, ok := bestBuyInRegion(orders)
+		opt := s.buildOption(ctx, "hub", hub.RegionID, hub.RegionName, stationID, int64(hub.SystemID), originSys, price, ok, req, salesTaxRate)
+		if opt.SystemName == "" {
+			opt.SystemName = hub.Name
+		}
+		options = append(options, opt)
+	}
+
+	// Current region: per-station best buy, route to each station's system.
+	if currentRegion != 0 {
+		if orders, err := s.market.FetchMarketOrdersForType(ctx, currentRegion, req.TypeID); err == nil {
+			for stationID, price := range bestBuyByStation(orders) {
+				sysID, err := s.sdeRepo.GetSystemIDForLocation(ctx, stationID)
+				if err != nil {
+					continue // unresolvable (player structure) -> skip
+				}
+				opt := s.buildOption(ctx, "current_region", currentRegion, "", stationID, sysID, originSys, price, true, req, salesTaxRate)
+				options = append(options, opt)
+			}
+		}
+	}
+
+	sort.SliceStable(options, func(i, j int) bool { return options[i].TotalNet > options[j].TotalNet })
+	resp.Options = options
+	for i := range options {
+		if options[i].HasData && options[i].TotalNet > 0 {
+			best := options[i]
+			resp.Best = &best
+			break
+		}
+	}
+	return resp, nil
+}
+
+// buildOption computes net + route for one sell location. destSys is the system to route
+// to; stationID is the buy-order station (for the waypoint + name).
+func (s *AssetSaleService) buildOption(ctx context.Context, scope string, regionID int, regionName string, stationID, destSys, originSys int64, buyPrice float64, hasData bool, req *models.SellOptionsRequest, salesTaxRate float64) models.SellOption {
+	opt := models.SellOption{Scope: scope, RegionID: regionID, RegionName: regionName, StationID: stationID, HasData: hasData}
+	if name, err := s.sdeRepo.GetStationName(ctx, stationID); err == nil {
+		opt.StationName = name
+	}
+	if name, err := s.sdeRepo.GetSystemName(ctx, destSys); err == nil {
+		opt.SystemName = name
+	}
+	if !hasData {
+		return opt
+	}
+	opt.BuyPrice = buyPrice
+	opt.UnitNet = takerUnitNet(buyPrice, salesTaxRate)
+	opt.TotalNet = opt.UnitNet * float64(req.Quantity)
+
+	if destSys == originSys {
+		opt.Jumps = 0
+		opt.TravelTimeMin = 0
+		opt.SecurityRisk = securityRisk(minRouteSecurityStatus(s.sdeDB, []int64{originSys}))
+		return opt
+	}
+	travel, err := navigation.CalculateTravelTime(s.sdeDB, originSys, destSys, &navigation.NavigationParams{AvoidLowSec: req.AvoidLowSec}, false)
+	if err != nil {
+		opt.HasData = false // no route (e.g. high-sec-only filter) -> not actionable
+		return opt
+	}
+	opt.Jumps = travel.Jumps
+	opt.TravelTimeMin = travel.TotalMinutes
+	opt.SecurityRisk = securityRisk(minRouteSecurityStatus(s.sdeDB, travel.Route))
+	return opt
+}
+
+// minRouteSecurityStatus returns the lowest securityStatus along a route (1.0 if empty/unknown).
+func minRouteSecurityStatus(db *sql.DB, route []int64) float64 {
+	if len(route) == 0 {
+		return 1.0
+	}
+	minSec := 1.0
+	for _, sysID := range route {
+		var sec float64
+		if err := db.QueryRowContext(context.Background(), "SELECT securityStatus FROM mapSolarSystems WHERE _key = ?", sysID).Scan(&sec); err != nil {
+			continue
+		}
+		if sec < minSec {
+			minSec = sec
+		}
+	}
+	return minSec
 }

--- a/backend/internal/services/asset_sale_service.go
+++ b/backend/internal/services/asset_sale_service.go
@@ -1,0 +1,62 @@
+package services
+
+import (
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+)
+
+// takerUnitNet is the per-unit proceeds when selling instantly into a buy order:
+// buy price minus sales tax. No broker fee (that applies only to placed orders).
+func takerUnitNet(buyPrice, salesTaxRate float64) float64 {
+	return buyPrice * (1 - salesTaxRate)
+}
+
+// bestBuyInRegion returns the highest active buy-order price across all stations in a
+// region, plus the station it sits at.
+func bestBuyInRegion(orders []esi.ESIMarketOrder) (price float64, stationID int64, ok bool) {
+	for _, o := range orders {
+		if !o.IsBuyOrder || o.VolumeRemain <= 0 {
+			continue
+		}
+		if !ok || o.Price > price {
+			price, stationID, ok = o.Price, o.LocationID, true
+		}
+	}
+	return price, stationID, ok
+}
+
+// bestBuyByStation returns the highest active buy-order price per station.
+func bestBuyByStation(orders []esi.ESIMarketOrder) map[int64]float64 {
+	best := map[int64]float64{}
+	for _, o := range orders {
+		if !o.IsBuyOrder || o.VolumeRemain <= 0 {
+			continue
+		}
+		if cur, seen := best[o.LocationID]; !seen || o.Price > cur {
+			best[o.LocationID] = o.Price
+		}
+	}
+	return best
+}
+
+// aggStack is an aggregated (type, location) quantity, pre-enrichment.
+type aggStack struct {
+	typeID     int
+	locationID int64
+	quantity   int
+}
+
+// aggregateAssets sums quantities for identical (type, location) pairs.
+func aggregateAssets(raw []RawAsset) []aggStack {
+	idx := map[[2]int64]int{} // (typeID, locationID) -> index in out
+	var out []aggStack
+	for _, r := range raw {
+		key := [2]int64{int64(r.TypeID), r.LocationID}
+		if i, ok := idx[key]; ok {
+			out[i].quantity += r.Quantity
+			continue
+		}
+		idx[key] = len(out)
+		out = append(out, aggStack{typeID: r.TypeID, locationID: r.LocationID, quantity: r.Quantity})
+	}
+	return out
+}

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+)
+
+func TestTakerUnitNet(t *testing.T) {
+	// 100 ISK buy order, 2.5% sales tax -> 97.5 net, no broker fee.
+	got := takerUnitNet(100.0, 0.025)
+	if got != 97.5 {
+		t.Fatalf("takerUnitNet = %v, want 97.5", got)
+	}
+}
+
+func TestBestBuyInRegion(t *testing.T) {
+	orders := []esi.ESIMarketOrder{
+		{IsBuyOrder: true, Price: 90, VolumeRemain: 10, LocationID: 1},
+		{IsBuyOrder: true, Price: 110, VolumeRemain: 5, LocationID: 2},
+		{IsBuyOrder: false, Price: 200, VolumeRemain: 5, LocationID: 2}, // sell order ignored
+		{IsBuyOrder: true, Price: 105, VolumeRemain: 0, LocationID: 3},  // empty ignored
+	}
+	price, stn, ok := bestBuyInRegion(orders)
+	if !ok || price != 110 || stn != 2 {
+		t.Fatalf("bestBuyInRegion = (%v,%v,%v), want (110,2,true)", price, stn, ok)
+	}
+}
+
+func TestBestBuyInRegion_NoBuyOrders(t *testing.T) {
+	orders := []esi.ESIMarketOrder{{IsBuyOrder: false, Price: 200, VolumeRemain: 5, LocationID: 1}}
+	if _, _, ok := bestBuyInRegion(orders); ok {
+		t.Fatalf("expected ok=false when no buy orders")
+	}
+}
+
+func TestBestBuyByStation(t *testing.T) {
+	orders := []esi.ESIMarketOrder{
+		{IsBuyOrder: true, Price: 90, VolumeRemain: 10, LocationID: 1},
+		{IsBuyOrder: true, Price: 95, VolumeRemain: 10, LocationID: 1}, // higher at stn 1
+		{IsBuyOrder: true, Price: 80, VolumeRemain: 10, LocationID: 2},
+		{IsBuyOrder: false, Price: 200, VolumeRemain: 5, LocationID: 1}, // sell ignored
+	}
+	got := bestBuyByStation(orders)
+	if got[1] != 95 || got[2] != 80 || len(got) != 2 {
+		t.Fatalf("bestBuyByStation = %v, want {1:95, 2:80}", got)
+	}
+}
+
+func TestAggregateAssets(t *testing.T) {
+	raw := []RawAsset{
+		{TypeID: 34, LocationID: 60003760, Quantity: 100},
+		{TypeID: 34, LocationID: 60003760, Quantity: 50}, // same type+loc -> summed
+		{TypeID: 34, LocationID: 60008494, Quantity: 10}, // different loc -> separate
+		{TypeID: 35, LocationID: 60003760, Quantity: 7},
+	}
+	got := aggregateAssets(raw)
+	find := func(typeID int, loc int64) int {
+		for _, a := range got {
+			if a.typeID == typeID && a.locationID == loc {
+				return a.quantity
+			}
+		}
+		return -1
+	}
+	if find(34, 60003760) != 150 {
+		t.Fatalf("type 34 @ 60003760 = %d, want 150", find(34, 60003760))
+	}
+	if find(34, 60008494) != 10 || find(35, 60003760) != 7 {
+		t.Fatalf("unexpected aggregation: %+v", got)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 aggregated stacks, got %d", len(got))
+	}
+}

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -1,10 +1,74 @@
 package services
 
 import (
+	"context"
+	"database/sql"
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+	applogger "github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
 )
+
+// --- fakes for the service test ---
+
+type fakeAssetFetcher struct{ assets []RawAsset }
+
+func (f fakeAssetFetcher) FetchCharacterAssets(_ context.Context, _ int, _ string) ([]RawAsset, error) {
+	return f.assets, nil
+}
+
+type fakeAssetSkills struct{}
+
+func (fakeAssetSkills) GetCharacterSkills(_ context.Context, _ int, _ string) (*TradingSkills, error) {
+	return &TradingSkills{Accounting: 0}, nil
+}
+
+type fakeHubFetcher struct{ ordersByRegion map[int][]esi.ESIMarketOrder }
+
+func (f fakeHubFetcher) FetchMarketOrdersForType(_ context.Context, regionID, _ int) ([]esi.ESIMarketOrder, error) {
+	return f.ordersByRegion[regionID], nil
+}
+
+type fakeTypeNamer struct {
+	name       string
+	marketable bool
+}
+
+func (f fakeTypeNamer) GetTypeInfo(_ context.Context, _ int) (*database.TypeInfo, error) {
+	ti := &database.TypeInfo{Name: f.name}
+	if f.marketable {
+		mg := 1234
+		ti.MarketGroup = &mg
+	}
+	return ti, nil
+}
+
+// newAssetTestSDE builds an in-memory SDE matching the columns SDERepository queries.
+func newAssetTestSDE(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`
+		CREATE TABLE mapSolarSystems (_key INTEGER PRIMARY KEY, constellationID INTEGER, regionID INTEGER, securityStatus REAL, name TEXT);
+		CREATE TABLE mapConstellations (_key INTEGER PRIMARY KEY, regionID INTEGER);
+		CREATE TABLE npcStations (_key INTEGER PRIMARY KEY, solarSystemID INTEGER, typeID INTEGER);
+		CREATE TABLE types (_key INTEGER PRIMARY KEY, name TEXT);
+		INSERT INTO mapConstellations VALUES (20000020, 10000002);
+		INSERT INTO mapSolarSystems VALUES (30000142, 20000020, 10000002, 0.9, '{"en":"Jita"}');
+		INSERT INTO types VALUES (54, '{"en":"Jita IV - Moon 4 - CNAP"}');
+		INSERT INTO npcStations VALUES (60003760, 30000142, 54);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
 
 func TestTakerUnitNet(t *testing.T) {
 	// 100 ISK buy order, 2.5% sales tax -> 97.5 net, no broker fee.
@@ -71,5 +135,69 @@ func TestAggregateAssets(t *testing.T) {
 	}
 	if len(got) != 3 {
 		t.Fatalf("expected 3 aggregated stacks, got %d", len(got))
+	}
+}
+
+func TestAssetSaleService_ListAssets_Aggregates(t *testing.T) {
+	sde := newAssetTestSDE(t)
+	defer sde.Close()
+	repo := database.NewSDERepository(sde)
+	svc := NewAssetSaleService(
+		fakeAssetSkills{},
+		fakeHubFetcher{},
+		fakeTypeNamer{name: "Tritanium", marketable: true},
+		fakeAssetFetcher{assets: []RawAsset{
+			{TypeID: 34, LocationID: 60003760, Quantity: 100, LocationFlag: "Hangar"},
+			{TypeID: 34, LocationID: 60003760, Quantity: 50, LocationFlag: "Hangar"},
+		}},
+		repo, sde, applogger.New(),
+	)
+	res, err := svc.ListAssets(context.Background(), 1, "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Count != 1 || res.Assets[0].Quantity != 150 || !res.Assets[0].Marketable {
+		t.Fatalf("unexpected: %+v", res)
+	}
+	if res.Assets[0].SystemID != 30000142 || res.Assets[0].RegionID != 10000002 {
+		t.Fatalf("location not resolved: %+v", res.Assets[0])
+	}
+}
+
+func TestAssetSaleService_SellOptions_RanksTakerNet(t *testing.T) {
+	sde := newAssetTestSDE(t)
+	defer sde.Close()
+	repo := database.NewSDERepository(sde)
+	// Origin = Jita (region 10000002). The Forge hub has a buy order at 5.0 ISK.
+	svc := NewAssetSaleService(
+		fakeAssetSkills{}, // Accounting 0 -> sales tax 5%
+		fakeHubFetcher{ordersByRegion: map[int][]esi.ESIMarketOrder{
+			10000002: {{IsBuyOrder: true, Price: 5.0, VolumeRemain: 1_000_000, LocationID: 60003760}},
+		}},
+		fakeTypeNamer{name: "Tritanium", marketable: true},
+		fakeAssetFetcher{},
+		repo, sde, applogger.New(),
+	)
+	req := &models.SellOptionsRequest{TypeID: 34, LocationID: 60003760, Quantity: 1000, AvoidLowSec: true}
+	res, err := svc.SellOptions(context.Background(), req, 1, "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OriginSystemID != 30000142 {
+		t.Fatalf("origin system = %d, want 30000142", res.OriginSystemID)
+	}
+	if res.Best == nil {
+		t.Fatalf("expected a best option")
+	}
+	// taker net = 5.0 * (1 - 0.05) = 4.75 per unit; total = 4750.
+	if res.Best.UnitNet < 4.74 || res.Best.UnitNet > 4.76 {
+		t.Fatalf("unit_net = %v, want ~4.75", res.Best.UnitNet)
+	}
+	if res.Best.TotalNet < 4749 || res.Best.TotalNet > 4751 {
+		t.Fatalf("total_net = %v, want ~4750", res.Best.TotalNet)
+	}
+	// Jita hub == origin system -> 0 jumps, safe.
+	if res.Best.Jumps != 0 || res.Best.SecurityRisk != "safe" {
+		t.Fatalf("expected 0 jumps / safe, got %d / %s", res.Best.Jumps, res.Best.SecurityRisk)
 	}
 }

--- a/docs/superpowers/plans/2026-05-29-sell-from-assets.md
+++ b/docs/superpowers/plans/2026-05-29-sell-from-assets.md
@@ -1,0 +1,1057 @@
+# Sell-from-Assets Implementation Plan (Issue #107)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a character pick an owned item and get a ranked list of where to sell it for the most net ISK (taker, instant-sell to buy orders) plus the route there, across the 5 major hubs and every station in the item's current region.
+
+**Architecture:** New `AssetSaleService` behind two endpoints — `GET /api/v1/trading/assets` (list owned items) and `POST /api/v1/trading/assets/sell-options` (rank sell locations for one item). Heavy hub-price + route computation runs only for the selected item. Reuses `MajorHubs`, the `hubOrderFetcher` interface (`FetchMarketOrdersForType`), `SkillsServicer`, fee helpers, SDE navigation, and the `securityRisk` helper (all in package `services`).
+
+**Tech Stack:** Go 1.24 / Fiber backend, pgx + SQLite SDE, ESI client; Next.js 16 web; Flutter web. TDD with `go test`.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-sell-from-assets-design.md`
+
+---
+
+## File Structure
+
+**Backend (built here, TDD):**
+- `internal/models/assets.go` — `AssetItem`, `SellOption`, `SellOptionsResponse`, `SellOptionsRequest` (reuse existing `models.SkillsApplied`).
+- `internal/services/asset_sale_service.go` — `AssetSaleService` + pure helpers (`takerUnitNet`, `bestBuyInRegion`, `bestBuyByStation`, `aggregateAssets`, `minRouteSecurityStatus`).
+- `internal/services/asset_sale_service_test.go` — unit tests for the pure helpers + service via fakes.
+- `internal/services/asset_fetcher.go` — concrete paginated ESI assets fetcher (`ESIAssetFetcher`) + `RawAsset` type + `assetFetcher` interface.
+- `internal/services/asset_fetcher_test.go` — pagination/parse test via `httptest`.
+- `internal/handlers/assets.go` — `AssetsHandler` (`ListAssets`, `SellOptions`).
+- `internal/handlers/assets_test.go` — handler validation tests (400/401).
+- `cmd/api/container.go`, `cmd/api/main.go` — wire handler + register routes.
+- `CHANGELOG.md` — `[Unreleased] ### Added` entry.
+
+**Frontends (parallel subagents, against the locked contract):**
+- Web `/sell-assets` page + asset picker + result + tests.
+- Flutter `/sell-assets` screen + models + providers + tests.
+
+---
+
+## Task 1: Models
+
+**Files:**
+- Create: `backend/internal/models/assets.go`
+
+- [ ] **Step 1: Create the models file**
+
+```go
+package models
+
+// AssetItem is one aggregated owned stack: a type at a location with a summed quantity.
+type AssetItem struct {
+	TypeID       int    `json:"type_id"`
+	Name         string `json:"name"`
+	Quantity     int    `json:"quantity"`
+	LocationID   int64  `json:"location_id"`
+	LocationName string `json:"location_name"`
+	SystemID     int    `json:"system_id"`
+	RegionID     int    `json:"region_id"`
+	Marketable   bool   `json:"marketable"`
+}
+
+// AssetsResponse is the GET /trading/assets payload.
+type AssetsResponse struct {
+	Assets []AssetItem `json:"assets"`
+	Count  int         `json:"count"`
+}
+
+// SellOptionsRequest is the POST /trading/assets/sell-options body.
+type SellOptionsRequest struct {
+	TypeID      int   `json:"type_id"`
+	LocationID  int64 `json:"location_id"`
+	Quantity    int   `json:"quantity"`
+	AvoidLowSec bool  `json:"avoid_low_sec"`
+}
+
+// SellOption is one ranked place to sell the item (taker / sell into a buy order).
+type SellOption struct {
+	Scope         string  `json:"scope"` // "hub" | "current_region"
+	RegionID      int     `json:"region_id"`
+	RegionName    string  `json:"region_name"`
+	StationID     int64   `json:"station_id"`
+	StationName   string  `json:"station_name"`
+	SystemName    string  `json:"system_name"`
+	BuyPrice      float64 `json:"buy_price"`
+	UnitNet       float64 `json:"unit_net"`
+	TotalNet      float64 `json:"total_net"`
+	Jumps         int     `json:"jumps"`
+	TravelTimeMin float64 `json:"travel_time_min"`
+	SecurityRisk  string  `json:"security_risk"` // "safe" | "caution" | "danger"
+	HasData       bool    `json:"has_data"`
+}
+
+// SellOptionsResponse is the ranked result for one selected item.
+type SellOptionsResponse struct {
+	TypeID         int           `json:"type_id"`
+	Name           string        `json:"name"`
+	Quantity       int           `json:"quantity"`
+	OriginSystemID int           `json:"origin_system_id"`
+	Best           *SellOption   `json:"best"`
+	Options        []SellOption  `json:"options"`
+	SkillsApplied  SkillsApplied `json:"skills_applied"`
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `cd backend && go build ./internal/models/`
+Expected: no output (success).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd backend && git add internal/models/assets.go
+git commit -m "feat(assets): models for sell-from-assets (#107)"
+```
+
+---
+
+## Task 2: Pure pricing + ranking helpers
+
+**Files:**
+- Create: `backend/internal/services/asset_sale_service.go` (helpers only this task)
+- Test: `backend/internal/services/asset_sale_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package services
+
+import (
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+)
+
+func TestTakerUnitNet(t *testing.T) {
+	// 100 ISK buy order, 2.5% sales tax -> 97.5 net, no broker fee.
+	got := takerUnitNet(100.0, 0.025)
+	if got != 97.5 {
+		t.Fatalf("takerUnitNet = %v, want 97.5", got)
+	}
+}
+
+func TestBestBuyInRegion(t *testing.T) {
+	orders := []esi.ESIMarketOrder{
+		{IsBuyOrder: true, Price: 90, VolumeRemain: 10, LocationID: 1},
+		{IsBuyOrder: true, Price: 110, VolumeRemain: 5, LocationID: 2},
+		{IsBuyOrder: false, Price: 200, VolumeRemain: 5, LocationID: 2}, // sell order ignored
+		{IsBuyOrder: true, Price: 105, VolumeRemain: 0, LocationID: 3},  // empty ignored
+	}
+	price, stn, ok := bestBuyInRegion(orders)
+	if !ok || price != 110 || stn != 2 {
+		t.Fatalf("bestBuyInRegion = (%v,%v,%v), want (110,2,true)", price, stn, ok)
+	}
+}
+
+func TestBestBuyInRegion_NoBuyOrders(t *testing.T) {
+	orders := []esi.ESIMarketOrder{{IsBuyOrder: false, Price: 200, VolumeRemain: 5, LocationID: 1}}
+	if _, _, ok := bestBuyInRegion(orders); ok {
+		t.Fatalf("expected ok=false when no buy orders")
+	}
+}
+
+func TestBestBuyByStation(t *testing.T) {
+	orders := []esi.ESIMarketOrder{
+		{IsBuyOrder: true, Price: 90, VolumeRemain: 10, LocationID: 1},
+		{IsBuyOrder: true, Price: 95, VolumeRemain: 10, LocationID: 1}, // higher at stn 1
+		{IsBuyOrder: true, Price: 80, VolumeRemain: 10, LocationID: 2},
+		{IsBuyOrder: false, Price: 200, VolumeRemain: 5, LocationID: 1}, // sell ignored
+	}
+	got := bestBuyByStation(orders)
+	if got[1] != 95 || got[2] != 80 || len(got) != 2 {
+		t.Fatalf("bestBuyByStation = %v, want {1:95, 2:80}", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/services/ -run 'TestTakerUnitNet|TestBestBuy' -v`
+Expected: FAIL — `undefined: takerUnitNet` etc.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `backend/internal/services/asset_sale_service.go`:
+
+```go
+package services
+
+import (
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+)
+
+// takerUnitNet is the per-unit proceeds when selling instantly into a buy order:
+// buy price minus sales tax. No broker fee (that applies only to placed orders).
+func takerUnitNet(buyPrice, salesTaxRate float64) float64 {
+	return buyPrice * (1 - salesTaxRate)
+}
+
+// bestBuyInRegion returns the highest active buy-order price across all stations in a
+// region, plus the station it sits at.
+func bestBuyInRegion(orders []esi.ESIMarketOrder) (price float64, stationID int64, ok bool) {
+	for _, o := range orders {
+		if !o.IsBuyOrder || o.VolumeRemain <= 0 {
+			continue
+		}
+		if !ok || o.Price > price {
+			price, stationID, ok = o.Price, o.LocationID, true
+		}
+	}
+	return price, stationID, ok
+}
+
+// bestBuyByStation returns the highest active buy-order price per station.
+func bestBuyByStation(orders []esi.ESIMarketOrder) map[int64]float64 {
+	best := map[int64]float64{}
+	for _, o := range orders {
+		if !o.IsBuyOrder || o.VolumeRemain <= 0 {
+			continue
+		}
+		if cur, seen := best[o.LocationID]; !seen || o.Price > cur {
+			best[o.LocationID] = o.Price
+		}
+	}
+	return best
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/services/ -run 'TestTakerUnitNet|TestBestBuy' -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add internal/services/asset_sale_service.go internal/services/asset_sale_service_test.go
+git commit -m "feat(assets): taker net + best-buy helpers (#107)"
+```
+
+---
+
+## Task 3: Asset aggregation helper
+
+**Files:**
+- Create: `backend/internal/services/asset_fetcher.go` (RawAsset type only this task)
+- Modify: `backend/internal/services/asset_sale_service.go` (add `aggregateAssets`)
+- Test: `backend/internal/services/asset_sale_service_test.go` (add)
+
+- [ ] **Step 1: Write the failing test (append to asset_sale_service_test.go)**
+
+```go
+func TestAggregateAssets(t *testing.T) {
+	raw := []RawAsset{
+		{TypeID: 34, LocationID: 60003760, Quantity: 100},
+		{TypeID: 34, LocationID: 60003760, Quantity: 50},  // same type+loc -> summed
+		{TypeID: 34, LocationID: 60008494, Quantity: 10},  // different loc -> separate
+		{TypeID: 35, LocationID: 60003760, Quantity: 7},
+	}
+	got := aggregateAssets(raw)
+	// key (type,loc)
+	find := func(typeID int, loc int64) int {
+		for _, a := range got {
+			if a.typeID == typeID && a.locationID == loc {
+				return a.quantity
+			}
+		}
+		return -1
+	}
+	if find(34, 60003760) != 150 {
+		t.Fatalf("type 34 @ 60003760 = %d, want 150", find(34, 60003760))
+	}
+	if find(34, 60008494) != 10 || find(35, 60003760) != 7 {
+		t.Fatalf("unexpected aggregation: %+v", got)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 aggregated stacks, got %d", len(got))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/services/ -run TestAggregateAssets -v`
+Expected: FAIL — `undefined: RawAsset` / `aggregateAssets`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `backend/internal/services/asset_fetcher.go`:
+
+```go
+package services
+
+// RawAsset is the minimal ESI asset shape the aggregator needs.
+type RawAsset struct {
+	TypeID       int
+	LocationID   int64
+	Quantity     int
+	LocationFlag string
+}
+```
+
+Append to `backend/internal/services/asset_sale_service.go`:
+
+```go
+// aggStack is an aggregated (type, location) quantity, pre-enrichment.
+type aggStack struct {
+	typeID     int
+	locationID int64
+	quantity   int
+}
+
+// aggregateAssets sums quantities for identical (type, location) pairs.
+func aggregateAssets(raw []RawAsset) []aggStack {
+	idx := map[[2]int64]int{} // (typeID, locationID) -> index in out
+	var out []aggStack
+	for _, r := range raw {
+		key := [2]int64{int64(r.TypeID), r.LocationID}
+		if i, ok := idx[key]; ok {
+			out[i].quantity += r.Quantity
+			continue
+		}
+		idx[key] = len(out)
+		out = append(out, aggStack{typeID: r.TypeID, locationID: r.LocationID, quantity: r.Quantity})
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/services/ -run TestAggregateAssets -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add internal/services/asset_fetcher.go internal/services/asset_sale_service.go internal/services/asset_sale_service_test.go
+git commit -m "feat(assets): asset aggregation by type+location (#107)"
+```
+
+---
+
+## Task 4: Paginated ESI assets fetcher
+
+**Files:**
+- Modify: `backend/internal/services/asset_fetcher.go`
+- Test: `backend/internal/services/asset_fetcher_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package services
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestESIAssetFetcher_Paginates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Pages", "2")
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			fmt.Fprint(w, `[{"type_id":34,"location_id":60003760,"quantity":100,"location_flag":"Hangar"}]`)
+		case "2":
+			fmt.Fprint(w, `[{"type_id":35,"location_id":60003760,"quantity":7,"location_flag":"Hangar"}]`)
+		}
+	}))
+	defer srv.Close()
+
+	f := &ESIAssetFetcher{baseURL: srv.URL, client: srv.Client()}
+	got, err := f.FetchCharacterAssets(context.Background(), 123, "token")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 2 || got[0].TypeID != 34 || got[0].Quantity != 100 || got[1].TypeID != 35 {
+		t.Fatalf("unexpected assets: %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/services/ -run TestESIAssetFetcher -v`
+Expected: FAIL — `undefined: ESIAssetFetcher`.
+
+- [ ] **Step 3: Write minimal implementation (append to asset_fetcher.go)**
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// assetFetcher fetches a character's full asset list (keeps AssetSaleService testable).
+type assetFetcher interface {
+	FetchCharacterAssets(ctx context.Context, characterID int, accessToken string) ([]RawAsset, error)
+}
+
+// ESIAssetFetcher calls /characters/{id}/assets/ with pagination (X-Pages).
+type ESIAssetFetcher struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewESIAssetFetcher creates a fetcher against the live ESI base URL.
+func NewESIAssetFetcher() *ESIAssetFetcher {
+	return &ESIAssetFetcher{
+		baseURL: "https://esi.evetech.net",
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+type esiAsset struct {
+	TypeID       int    `json:"type_id"`
+	LocationID   int64  `json:"location_id"`
+	Quantity     int    `json:"quantity"`
+	LocationFlag string `json:"location_flag"`
+}
+
+func (f *ESIAssetFetcher) FetchCharacterAssets(ctx context.Context, characterID int, accessToken string) ([]RawAsset, error) {
+	base := fmt.Sprintf("%s/latest/characters/%d/assets/", f.baseURL, characterID)
+	first, pages, err := f.page(ctx, base, accessToken, 1)
+	if err != nil {
+		return nil, err
+	}
+	all := first
+	for p := 2; p <= pages; p++ {
+		more, _, err := f.page(ctx, base, accessToken, p)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, more...)
+	}
+	return all, nil
+}
+
+func (f *ESIAssetFetcher) page(ctx context.Context, base, token string, page int) ([]RawAsset, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"?page="+strconv.Itoa(page), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, 0, fmt.Errorf("unauthorized")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, fmt.Errorf("ESI assets status %d", resp.StatusCode)
+	}
+	pages := 1
+	if x := resp.Header.Get("X-Pages"); x != "" {
+		if v, err := strconv.Atoi(x); err == nil {
+			pages = v
+		}
+	}
+	var raw []esiAsset
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, 0, err
+	}
+	out := make([]RawAsset, 0, len(raw))
+	for _, a := range raw {
+		out = append(out, RawAsset{TypeID: a.TypeID, LocationID: a.LocationID, Quantity: a.Quantity, LocationFlag: a.LocationFlag})
+	}
+	return out, pages, nil
+}
+```
+
+Note: keep the existing `RawAsset` struct from Task 3 at the top of the file; add these imports and code below it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/services/ -run TestESIAssetFetcher -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add internal/services/asset_fetcher.go internal/services/asset_fetcher_test.go
+git commit -m "feat(assets): paginated ESI assets fetcher (#107)"
+```
+
+---
+
+## Task 5: AssetSaleService (ListAssets + SellOptions)
+
+**Files:**
+- Modify: `backend/internal/services/asset_sale_service.go`
+- Test: `backend/internal/services/asset_sale_service_test.go` (add service test with fakes)
+
+- [ ] **Step 1: Write the failing test (append)**
+
+```go
+import (
+	"context"
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	applogger "github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+)
+
+// fakeAssetFetcher / fakeSkills / fakeHubFetcher / fakeTypeNamer for the service test.
+type fakeAssetFetcher struct{ assets []RawAsset }
+
+func (f fakeAssetFetcher) FetchCharacterAssets(_ context.Context, _ int, _ string) ([]RawAsset, error) {
+	return f.assets, nil
+}
+
+type fakeSkills2 struct{}
+
+func (fakeSkills2) GetCharacterSkills(_ context.Context, _ int, _ string) (*TradingSkills, error) {
+	return &TradingSkills{Accounting: 0}, nil // sales tax = 8% (Accounting 0)
+}
+
+// newTestSDE builds an in-memory SDE with the columns the service queries.
+func newAssetTestSDE(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.Exec(`
+		CREATE TABLE mapSolarSystems (_key INTEGER PRIMARY KEY, regionID INTEGER, securityStatus REAL, name TEXT);
+		CREATE TABLE staStations (stationID INTEGER PRIMARY KEY, solarSystemID INTEGER, regionID INTEGER, stationName TEXT);
+		INSERT INTO mapSolarSystems VALUES (30000142, 10000002, 0.9, 'Jita');
+		INSERT INTO staStations VALUES (60003760, 30000142, 10000002, 'Jita IV - Moon 4 - CNAP');
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+```
+
+NOTE for the implementer: the exact SDE schema (`mapSolarSystems._key`, `staStations`) must match what `SDERepository.GetSystemIDForLocation` / `GetStationName` / `GetSystemName` / `GetRegionIDForSystem` query. Before writing this test, open `internal/database/sde.go` lines 134-230 and copy the real column/table names into the `CREATE TABLE` statements. Then assert:
+
+```go
+func TestAssetSaleService_ListAssets_Aggregates(t *testing.T) {
+	sde := newAssetTestSDE(t)
+	defer sde.Close()
+	repo := database.NewSDERepository(sde)
+	svc := NewAssetSaleService(
+		fakeSkills2{},
+		fakeHubFetcher{},          // reuse the multi_hub fakeMarket pattern; returns no orders here
+		fakeTypeNamer{name: "Tritanium", marketable: true},
+		fakeAssetFetcher{assets: []RawAsset{
+			{TypeID: 34, LocationID: 60003760, Quantity: 100, LocationFlag: "Hangar"},
+			{TypeID: 34, LocationID: 60003760, Quantity: 50, LocationFlag: "Hangar"},
+		}},
+		repo, sde, applogger.New(),
+	)
+	res, err := svc.ListAssets(context.Background(), 1, "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Count != 1 || res.Assets[0].Quantity != 150 || !res.Assets[0].Marketable {
+		t.Fatalf("unexpected: %+v", res)
+	}
+}
+```
+
+Define `fakeHubFetcher` and `fakeTypeNamer` in the test file:
+
+```go
+type fakeHubFetcher struct{ ordersByRegion map[int][]esi.ESIMarketOrder }
+
+func (f fakeHubFetcher) FetchMarketOrdersForType(_ context.Context, regionID, _ int) ([]esi.ESIMarketOrder, error) {
+	return f.ordersByRegion[regionID], nil
+}
+
+type fakeTypeNamer struct {
+	name       string
+	marketable bool
+}
+
+func (f fakeTypeNamer) GetTypeInfo(_ context.Context, _ int) (*database.TypeInfo, error) {
+	ti := &database.TypeInfo{Name: f.name}
+	if f.marketable {
+		mg := 1234
+		ti.MarketGroup = &mg
+	}
+	return ti, nil
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/services/ -run TestAssetSaleService -v`
+Expected: FAIL — `undefined: NewAssetSaleService`.
+
+- [ ] **Step 3: Write the implementation (append to asset_sale_service.go)**
+
+```go
+import (
+	"context"
+	"database/sql"
+	"sort"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/navigation"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+)
+
+// AssetSaleService lists owned items and ranks taker sell locations (Issue #107).
+type AssetSaleService struct {
+	skills  SkillsServicer
+	market  hubOrderFetcher
+	types   typeNamer
+	assets  assetFetcher
+	sdeRepo *database.SDERepository
+	sdeDB   *sql.DB
+	logger  *logger.Logger
+}
+
+// NewAssetSaleService creates a new service.
+func NewAssetSaleService(
+	skills SkillsServicer,
+	market hubOrderFetcher,
+	types typeNamer,
+	assets assetFetcher,
+	sdeRepo *database.SDERepository,
+	sdeDB *sql.DB,
+	logger *logger.Logger,
+) *AssetSaleService {
+	return &AssetSaleService{skills: skills, market: market, types: types, assets: assets, sdeRepo: sdeRepo, sdeDB: sdeDB, logger: logger}
+}
+
+// ListAssets returns the character's owned items aggregated by (type, location).
+func (s *AssetSaleService) ListAssets(ctx context.Context, characterID int, accessToken string) (*models.AssetsResponse, error) {
+	raw, err := s.assets.FetchCharacterAssets(ctx, characterID, accessToken)
+	if err != nil {
+		return nil, err
+	}
+	stacks := aggregateAssets(raw)
+	items := make([]models.AssetItem, 0, len(stacks))
+	for _, st := range stacks {
+		item := models.AssetItem{TypeID: st.typeID, Quantity: st.quantity, LocationID: st.locationID}
+		if info, err := s.types.GetTypeInfo(ctx, st.typeID); err == nil && info != nil {
+			item.Name = info.Name
+			item.Marketable = info.MarketGroup != nil
+		}
+		if sysID, err := s.sdeRepo.GetSystemIDForLocation(ctx, st.locationID); err == nil {
+			item.SystemID = int(sysID)
+			if rid, err := s.sdeRepo.GetRegionIDForSystem(ctx, sysID); err == nil {
+				item.RegionID = rid
+			}
+		}
+		if name, err := s.sdeRepo.GetStationName(ctx, st.locationID); err == nil {
+			item.LocationName = name
+		}
+		items = append(items, item)
+	}
+	return &models.AssetsResponse{Assets: items, Count: len(items)}, nil
+}
+
+// SellOptions ranks taker sell locations for one owned item.
+func (s *AssetSaleService) SellOptions(ctx context.Context, req *models.SellOptionsRequest, characterID int, accessToken string) (*models.SellOptionsResponse, error) {
+	skills, serr := s.skills.GetCharacterSkills(ctx, characterID, accessToken)
+	if serr != nil || skills == nil {
+		skills = &TradingSkills{}
+	}
+	salesTaxRate := SalesTaxRate(skills.Accounting)
+
+	name := ""
+	if info, err := s.types.GetTypeInfo(ctx, req.TypeID); err == nil && info != nil {
+		name = info.Name
+	}
+
+	originSys, err := s.sdeRepo.GetSystemIDForLocation(ctx, req.LocationID)
+	resp := &models.SellOptionsResponse{
+		TypeID: req.TypeID, Name: name, Quantity: req.Quantity,
+		SkillsApplied: models.SkillsApplied{
+			Applied: serr == nil, Accounting: skills.Accounting, BrokerRelations: skills.BrokerRelations,
+			SalesTaxRate: salesTaxRate,
+			BrokerFeeRate: BrokerFeeRate(skills.BrokerRelations, skills.AdvancedBrokerRelations, skills.FactionStanding, skills.CorpStanding),
+		},
+	}
+	if err != nil {
+		return resp, nil // origin unresolvable -> empty options
+	}
+	resp.OriginSystemID = int(originSys)
+	currentRegion, _ := s.sdeRepo.GetRegionIDForSystem(ctx, originSys)
+
+	var options []models.SellOption
+
+	// 5 major hubs: region-best buy order, route to hub system.
+	for _, hub := range MajorHubs {
+		orders, err := s.market.FetchMarketOrdersForType(ctx, hub.RegionID, req.TypeID)
+		if err != nil {
+			s.logger.Warn("sell-options: hub fetch failed", "error", err, "region", hub.RegionID)
+			options = append(options, models.SellOption{Scope: "hub", RegionID: hub.RegionID, RegionName: hub.RegionName, SystemName: hub.Name, HasData: false})
+			continue
+		}
+		price, stationID, ok := bestBuyInRegion(orders)
+		opt := s.buildOption(ctx, "hub", hub.RegionID, hub.RegionName, stationID, int64(hub.SystemID), originSys, price, ok, req, salesTaxRate)
+		if opt.SystemName == "" {
+			opt.SystemName = hub.Name
+		}
+		options = append(options, opt)
+	}
+
+	// Current region: per-station best buy, route to each station's system.
+	if currentRegion != 0 {
+		orders, err := s.market.FetchMarketOrdersForType(ctx, currentRegion, req.TypeID)
+		if err == nil {
+			for stationID, price := range bestBuyByStation(orders) {
+				sysID, err := s.sdeRepo.GetSystemIDForLocation(ctx, stationID)
+				if err != nil {
+					continue // unresolvable (player structure) -> skip
+				}
+				opt := s.buildOption(ctx, "current_region", currentRegion, "", stationID, sysID, originSys, price, true, req, salesTaxRate)
+				options = append(options, opt)
+			}
+		}
+	}
+
+	sort.SliceStable(options, func(i, j int) bool { return options[i].TotalNet > options[j].TotalNet })
+	resp.Options = options
+	for i := range options {
+		if options[i].HasData && options[i].TotalNet > 0 {
+			best := options[i]
+			resp.Best = &best
+			break
+		}
+	}
+	return resp, nil
+}
+
+// buildOption computes net + route for one sell location. destSys is the system to route
+// to; stationID is the buy-order station (for the waypoint + name).
+func (s *AssetSaleService) buildOption(ctx context.Context, scope string, regionID int, regionName string, stationID, destSys, originSys int64, buyPrice float64, hasData bool, req *models.SellOptionsRequest, salesTaxRate float64) models.SellOption {
+	opt := models.SellOption{Scope: scope, RegionID: regionID, RegionName: regionName, StationID: stationID, HasData: hasData}
+	if name, err := s.sdeRepo.GetStationName(ctx, stationID); err == nil {
+		opt.StationName = name
+	}
+	if name, err := s.sdeRepo.GetSystemName(ctx, destSys); err == nil {
+		opt.SystemName = name
+	}
+	if !hasData {
+		return opt
+	}
+	opt.BuyPrice = buyPrice
+	opt.UnitNet = takerUnitNet(buyPrice, salesTaxRate)
+	opt.TotalNet = opt.UnitNet * float64(req.Quantity)
+
+	if destSys == originSys {
+		opt.Jumps = 0
+		opt.TravelTimeMin = 0
+		opt.SecurityRisk = securityRisk(minRouteSecurityStatus(s.sdeDB, []int64{originSys}))
+		return opt
+	}
+	travel, err := navigation.CalculateTravelTime(s.sdeDB, originSys, destSys, &navigation.NavigationParams{AvoidLowSec: req.AvoidLowSec}, false)
+	if err != nil {
+		opt.HasData = false // no route (e.g. high-sec-only filter) -> not actionable
+		return opt
+	}
+	opt.Jumps = travel.Jumps
+	opt.TravelTimeMin = travel.TotalMinutes
+	opt.SecurityRisk = securityRisk(minRouteSecurityStatus(s.sdeDB, travel.Route))
+	return opt
+}
+
+// minRouteSecurityStatus returns the lowest securityStatus along a route (1.0 if empty/unknown).
+func minRouteSecurityStatus(db *sql.DB, route []int64) float64 {
+	if len(route) == 0 {
+		return 1.0
+	}
+	minSec := 1.0
+	for _, sysID := range route {
+		var sec float64
+		if err := db.QueryRowContext(context.Background(), "SELECT securityStatus FROM mapSolarSystems WHERE _key = ?", sysID).Scan(&sec); err != nil {
+			continue
+		}
+		if sec < minSec {
+			minSec = sec
+		}
+	}
+	return minSec
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/services/ -run 'TestAssetSaleService|TestTakerUnitNet|TestBestBuy|TestAggregateAssets' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd backend && git add internal/services/asset_sale_service.go internal/services/asset_sale_service_test.go
+git commit -m "feat(assets): AssetSaleService list + taker sell-options ranking (#107)"
+```
+
+---
+
+## Task 6: Handler + routes + wiring
+
+**Files:**
+- Create: `backend/internal/handlers/assets.go`
+- Test: `backend/internal/handlers/assets_test.go`
+- Modify: `backend/cmd/api/container.go`, `backend/cmd/api/main.go`
+
+- [ ] **Step 1: Write the failing handler validation test**
+
+```go
+package handlers
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestAssetsHandler_SellOptions_BadRequest(t *testing.T) {
+	app := fiber.New()
+	h := &AssetsHandler{} // service nil: validation happens before service call
+	app.Post("/sell", func(c *fiber.Ctx) error {
+		c.Locals("character_id", 1)
+		c.Locals("access_token", "tok")
+		return h.SellOptions(c)
+	})
+	req := httptest.NewRequest("POST", "/sell", strings.NewReader(`{"type_id":0,"location_id":1,"quantity":0}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+	if resp.StatusCode != 400 {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestAssetsHandler_SellOptions_Unauthorized(t *testing.T) {
+	app := fiber.New()
+	h := &AssetsHandler{}
+	app.Post("/sell", h.SellOptions)
+	req := httptest.NewRequest("POST", "/sell", strings.NewReader(`{"type_id":34,"location_id":60003760,"quantity":10}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := app.Test(req)
+	if resp.StatusCode != 401 {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestAssetsHandler -v`
+Expected: FAIL — `undefined: AssetsHandler`.
+
+- [ ] **Step 3: Write the handler (create assets.go)**
+
+```go
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
+)
+
+// AssetsHandler serves the sell-from-assets endpoints (Issue #107).
+type AssetsHandler struct {
+	service *services.AssetSaleService
+}
+
+// NewAssetsHandler creates a new assets handler.
+func NewAssetsHandler(service *services.AssetSaleService) *AssetsHandler {
+	return &AssetsHandler{service: service}
+}
+
+func authCtx(c *fiber.Ctx) (int, string, bool) {
+	cid, ok1 := c.Locals("character_id").(int)
+	tok, ok2 := c.Locals("access_token").(string)
+	return cid, tok, ok1 && ok2
+}
+
+// ListAssets handles GET /api/v1/trading/assets
+//
+// @Summary List owned items aggregated by type and location
+// @Tags Trading
+// @Produce json
+// @Success 200 {object} models.AssetsResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/trading/assets [get]
+func (h *AssetsHandler) ListAssets(c *fiber.Ctx) error {
+	cid, tok, ok := authCtx(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Authentication required"})
+	}
+	res, err := h.service.ListAssets(c.UserContext(), cid, tok)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to list assets"})
+	}
+	return c.JSON(res)
+}
+
+// SellOptions handles POST /api/v1/trading/assets/sell-options
+//
+// @Summary Rank taker sell locations for one owned item
+// @Tags Trading
+// @Accept json
+// @Produce json
+// @Param request body models.SellOptionsRequest true "Selected item"
+// @Success 200 {object} models.SellOptionsResponse
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/trading/assets/sell-options [post]
+func (h *AssetsHandler) SellOptions(c *fiber.Ctx) error {
+	var req models.SellOptionsRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+	if req.TypeID <= 0 || req.Quantity <= 0 || req.LocationID <= 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "type_id, location_id and quantity are required"})
+	}
+	cid, tok, ok := authCtx(c)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Authentication required"})
+	}
+	res, err := h.service.SellOptions(c.UserContext(), &req, cid, tok)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to compute sell options"})
+	}
+	return c.JSON(res)
+}
+```
+
+Note: the `TestAssetsHandler_SellOptions_BadRequest` test validates *before* auth (validation runs first in `SellOptions`), so the `400` path is reached even though `character_id` is set. The `Unauthorized` test omits Locals so `authCtx` returns false after validation passes — both match the handler order above (validation → auth).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && go test ./internal/handlers/ -run TestAssetsHandler -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire into the container**
+
+In `backend/cmd/api/container.go`, add field to `AppContainer`:
+```go
+	AssetsHandler      *handlers.AssetsHandler
+```
+And after the hauling wiring block (around line 164), add:
+```go
+	// Sell-from-assets (#107) — reuses hub price fetch + skills + navigation.
+	assetSaleService := services.NewAssetSaleService(skillsService, c.ESIClient, c.SDERepo, services.NewESIAssetFetcher(), c.SDERepo, c.DB.SDE, c.AppLogger)
+	c.AssetsHandler = handlers.NewAssetsHandler(assetSaleService)
+```
+NOTE: confirm `c.ESIClient` satisfies `hubOrderFetcher` (it has `FetchMarketOrdersForType`; `competition_collector.go:67` calls it on the ESI client). If the method lives on a sub-client, mirror exactly how `multiHubService` is constructed at container.go:154 (it passes the same fetcher the multi-hub service uses). Use that identical argument.
+
+- [ ] **Step 6: Register routes in main.go**
+
+In `backend/cmd/api/main.go`, after the hauling route (line 157), add:
+```go
+	api.Get("/trading/assets", evesso.NewAuthMiddleware(c.TokenValidator), c.AssetsHandler.ListAssets)
+	api.Post("/trading/assets/sell-options", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.AssetsHandler.SellOptions)
+```
+
+- [ ] **Step 7: Build + vet + full short test**
+
+Run: `cd backend && gofmt -l . && go build ./... && go vet ./... && go test -short ./internal/... ./cmd/...`
+Expected: gofmt prints nothing; build/vet clean; tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd backend && git add internal/handlers/assets.go internal/handlers/assets_test.go cmd/api/container.go cmd/api/main.go
+git commit -m "feat(assets): handler + routes + wiring (#107)"
+```
+
+---
+
+## Task 7: CHANGELOG + backend gate
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add an Unreleased entry**
+
+Under `## [Unreleased]` add:
+```markdown
+### Added
+
+- **Sell-from-Assets (#107):** `GET /api/v1/trading/assets` (owned items aggregated by type + location) and `POST /api/v1/trading/assets/sell-options` — for a selected item, ranks taker sell locations (instant sell into a buy order, net of sales tax) across the 5 major hubs + every station in the item's current region, each with route (jumps, travel time, security risk). Ranked by total net proceeds.
+```
+
+- [ ] **Step 2: Run the release-check + full backend gate**
+
+Run: `cd backend && make test` (or from repo root `make pr-check` if Docker is available)
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md && git commit -m "docs(changelog): sell-from-assets endpoints (#107)"
+```
+
+---
+
+## Task 8: Web frontend (subagent)
+
+Dispatch a subagent with the locked contract (spec §"API Contract"). Brief:
+
+- **Page** `frontend/src/app/sell-assets/page.tsx` (NEW route, auth-gated, ErrorBoundary) — follow `src/app/roi-calculator/page.tsx` / `multi-hub/page.tsx`.
+- **API** `src/lib/api-client.ts`: add `listAssets()` (GET) and `findSellOptions(req)` (POST), both authed `credentials:"include"`. Reuse existing `setWaypoint`.
+- **Types** in `src/types/trading.ts`: `AssetItem`, `AssetsResponse`, `SellOptionsRequest`, `SellOption`, `SellOptionsResponse` (reuse `SkillsApplied`).
+- **Components:**
+  - `AssetPicker.tsx` — searchable/filterable list (by name / quantity / location); non-marketable rows visually disabled; selecting one + entering quantity (default = stack quantity) + avoid-low-sec checkbox fires `findSellOptions`.
+  - `SellOptionsResult.tsx` — `best` highlighted; option list (system, station, scope badge hub/region, buy price, unit net, **total net**, jumps, travel min, security badge safe/caution/danger); "Route an EVE übertragen" button → `setWaypoint(station_id, {clearOtherWaypoints:true})`. Empty/`has_data:false` rows shown muted ("kein Marktpreis").
+- **Nav:** add `/sell-assets` entry in `src/components/navigation.tsx` (desktop + mobile), consistent with the others.
+- **Tests:** Vitest `tests/components/SellOptionsResult.test.tsx` (option fields, security badge color, best highlight, waypoint call); authed Playwright `tests/e2e/auth/sell-assets.spec.ts` mirroring `roi-calculator.spec.ts`.
+- **Verify:** `npm run test` + `npm run lint` + `tsc --noEmit` clean for touched files.
+
+After it returns: verify (`npx vitest run tests/components/SellOptionsResult.test.tsx`, eslint touched files), then commit `feat(web): sell-from-assets page + asset picker + sell options (#107)`.
+
+---
+
+## Task 9: Flutter frontend (subagent)
+
+Dispatch a subagent with the same locked contract. Brief:
+
+- **Models** `lib/api/asset_models.dart`: `AssetItem`, `AssetsResponse`, `SellOptionsRequest`, `SellOption`, `SellOptionsResponse` (reuse `SkillsApplied`), null/float-robust `fromJson`.
+- **Service** `lib/api/trading_api.dart`: add `listAssets()` and `findSellOptions(req)` (token via existing dio interceptor).
+- **Providers** `lib/features/trading/sell_assets_providers.dart`: assets `FutureProvider`, sell-options `AsyncNotifier` (match ROI/Hub shape).
+- **Screen** `lib/features/trading/sell_assets_screen.dart`: adaptive `isTwoPane(840)`; left = asset picker (search field + list, non-marketable disabled), tapping one opens quantity + avoid-low-sec + "Verkaufsorte suchen"; right/result = best highlighted + option list with security chip (safe=green/caution=amber/danger=red), scope badge, total net, jumps, travel; tap option → detail with "Route an EVE übertragen" (waypoint to `station_id`). Empty state "Keine Verkaufsorte gefunden".
+- **Router** `lib/core/router.dart`: register `/sell-assets` + nav destination (e.g. sell/tag icon), consistent indexing.
+- **Tests:** widget test (option list, security chip colors, tap→detail, waypoint) + `fromJson` model test.
+- **Verify:** `flutter analyze` clean; `flutter test` passes. Do NOT build/run on device.
+
+After it returns: verify (`flutter analyze` touched files, `flutter test` new tests), then commit `feat(app): sell-from-assets screen + asset picker + sell options (#107)`.
+
+---
+
+## Task 10: Ship
+
+- [ ] PR `feat/sell-from-assets` → CI (lint/test/vuln) green → squash-merge (`Closes #107`).
+- [ ] `make release VERSION=0.12.0` → commit CHANGELOG transform → tag `v0.12.0` → push → watch deploy.
+- [ ] Prod verify: `GET /sell-assets` → 200; `POST /api/v1/trading/assets/sell-options` without auth → 401; `GET /api/v1/version` → `v0.12.0`.
+- [ ] Rebuild APK with `--dart-define=API_BASE_URL=https://eveonline.sternrassler.de --dart-define=EVE_CLIENT_ID=<mobile client id from deployments/.env>`, install on device, on-device smoke (login → Sell-Assets → pick item → options).
+- [ ] Comment + close #107.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** assets endpoint (Task 1/4/5/6) ✓; per-item taker hub ranking (Task 2/5) ✓; current-region per-station (Task 5) ✓; route + security (Task 5 buildOption) ✓; UI picker + result + waypoint (Task 8/9) ✓; structures/low-null graceful (Task 5: unresolvable skip, no-route → has_data:false; origin unresolvable → empty options) ✓; "everything" assets + marketable flag (Task 5 ListAssets) ✓.
+- **Type consistency:** `RawAsset` (Task 3) reused in Task 4/5; `bestBuyInRegion`/`bestBuyByStation`/`takerUnitNet` (Task 2) used in Task 5; `hubOrderFetcher`/`typeNamer`/`SkillsServicer` reused from `multi_hub_service.go`; `securityRisk` reused from `hauling_service.go`; `minRouteSecurityStatus` defined in Task 5.
+- **Known implementer check-points (flagged inline, not placeholders):** (a) Task 5 test SDE schema must mirror the real `sde.go` queries — copy column names; (b) Task 6 container wiring must pass the *same* `FetchMarketOrdersForType` provider the multi-hub service uses (confirm at container.go:154).

--- a/docs/superpowers/specs/2026-05-29-sell-from-assets-design.md
+++ b/docs/superpowers/specs/2026-05-29-sell-from-assets-design.md
@@ -1,0 +1,125 @@
+# Sell-from-Assets — Design Spec (Issue #107)
+
+**Date:** 2026-05-29
+**Status:** Approved (design), pending implementation plan
+
+## Goal
+
+Let a character pick an item they already own and get a ranked answer to *"where do I sell this for the most ISK, and how do I get there?"* — net proceeds after fees/skills, plus the route (jumps, travel time, security risk) from the item's current location to each sell location.
+
+This is a **liquidation** flow (selling owned inventory), distinct from #45 hauling (buy-to-resell arbitrage) and #43 multi-hub (station-trading spread).
+
+## Scope Decisions (locked)
+
+1. **Sell model = Taker (instant sell to a buy order).** Net proceeds per unit = `best_buy_order_price × (1 − sales_tax_rate)`. **No broker fee** (broker fee applies only when placing an order; selling directly into an existing buy order incurs sales tax only). Placing one's own sell order (maker) is out of scope.
+2. **Asset scope = everything.** No market-group filter. All assets are listed (aggregated by type + location, with quantity). Non-marketable items (no buy order anywhere) surface as `has_data:false` ("kein Marktpreis"), not hidden.
+3. **Comparison set = 5 major hubs + all stations in the item's current region.**
+   - Hubs: best buy order in the hub's region; route to the hub system.
+   - Current region: best buy order per station; route to that station's system (often 0 jumps).
+4. **Ranking = total net proceeds** (`unit_net × quantity`), descending. Jumps / travel time / security risk are shown alongside so the user weighs value vs. effort (not used as the sort key).
+5. **Frontends = Web + Flutter** (parallel subagents against the locked API contract, as in #43/#44/#45).
+
+## Architecture
+
+New `AssetSaleService` with two responsibilities behind two endpoints:
+
+```
+[Web/Flutter picker]
+   └─ GET /api/v1/trading/assets ──────────────► list owned items (cheap)
+[user selects an item]
+   └─ POST /api/v1/trading/assets/sell-options ─► rank sell locations (expensive)
+```
+
+Keeping listing and ranking separate avoids the N-items × hubs × routes blow-up: the heavy hub-price + route computation runs only for the one selected item.
+
+### Reuse (no re-implementation)
+
+- **Hub set + best prices + fees + skills:** `services.MajorHubs`, `bestPrices`, `MarketRepository.FetchMarketOrdersForType`, `SalesTaxRate`, `GetCharacterSkills`, `models.SkillsApplied` — the `MultiHubComparisonService` is the template.
+- **Region order fetch (current region):** `RouteFinder.fetchMarketOrders(ctx, region)` (region-wide, paginated) — same as #45.
+- **Navigation:** `SDERepository.GetSystemIDForLocation`, `navigation.CalculateTravelTime(db, from, to, &NavigationParams{AvoidLowSec}, false)`, security via `mapSolarSystems.securityStatus` (the `securityRisk(minSec)` helper pattern from #45: safe ≥0.5 / caution >0 / danger ≤0).
+- **Names:** `SDERepository.GetStationName`, `GetSystemName`, `GetTypeInfo`.
+- **Assets fetch:** generalize the existing `/characters/{id}/assets/` call in `handlers/trading.go` (currently ship-only, no quantity, single page) into a paginated, general fetch.
+
+### New
+
+- **General assets fetch** — paginated (ESI `X-Pages`), captures `quantity`, aggregates by `(type_id, location_id)` summing quantity, resolves name/system/region, flags `marketable` (has a market group via SDE).
+- **`AssetSaleService`** — `ListAssets` and `SellOptions`.
+- **`AssetsHandler`** — two endpoints + wiring.
+
+## Data Flow — sell-options
+
+1. Resolve `origin_system_id` from `location_id` (`GetSystemIDForLocation`); resolve current `region_id`.
+2. Skills once → `sales_tax_rate`.
+3. Build comparison entries:
+   - For each of the 5 `MajorHubs`: fetch region orders for the type, `bestPrices` → best buy; `unit_net = best_buy × (1 − tax)`; route origin→hub system; `scope:"hub"`.
+   - For the current region: fetch region orders for the type, group buy orders by `location_id`, best buy per station; route origin→station system; `scope:"current_region"`.
+4. For each entry compute `total_net = unit_net × quantity`, `jumps`, `travel_time_min`, `security_risk`. Entries whose station/system can't be resolved (player structures, unknown IDs) are skipped; entries with no buy order get `has_data:false`.
+5. Sort by `total_net` desc. `best` = first entry with `has_data && total_net > 0` (or `null` if none).
+
+## API Contract (locked)
+
+```
+GET /api/v1/trading/assets        (auth)
+→ 200 { "assets": [ {
+        "type_id": int, "name": string, "quantity": int,
+        "location_id": int64, "location_name": string,
+        "system_id": int, "region_id": int, "marketable": bool
+      } ], "count": int }
+   401 if unauthenticated
+
+POST /api/v1/trading/assets/sell-options   (auth)
+  body { "type_id": int, "location_id": int64, "quantity": int, "avoid_low_sec": bool }
+→ 200 {
+    "type_id": int, "name": string, "quantity": int,
+    "origin_system_id": int,
+    "best": <option|null>,
+    "options": [ {
+       "scope": "hub" | "current_region",
+       "region_id": int, "region_name": string,
+       "station_id": int64, "station_name": string, "system_name": string,
+       "buy_price": float, "unit_net": float, "total_net": float,
+       "jumps": int, "travel_time_min": float,
+       "security_risk": "safe"|"caution"|"danger", "has_data": bool
+    } ],
+    "skills_applied": { "applied": bool, "accounting": int, "broker_relations": int,
+                        "sales_tax_rate": float, "broker_fee_rate": float }
+  }
+   400 if type_id<=0 || quantity<=0 || location_id<=0
+   401 if unauthenticated
+```
+
+`options` is pre-sorted by `total_net` desc. `broker_fee_rate` is reported for transparency but **not** applied to taker proceeds.
+
+## Error Handling
+
+- ESI assets 401 → propagate 401.
+- Per-hub / per-region order-fetch failure → log + skip that entry (don't fail the whole request).
+- Unresolvable `location_id` (player structures, citadels) → skip the entry; for the *origin* item location, if unresolvable, return 200 with `options:[]` and `best:null` (can't compute routes) rather than erroring.
+- Items with no buy orders anywhere → `options` entries all `has_data:false`, `best:null`.
+
+## Testing
+
+- **Backend unit:** taker net math (`unit_net = buy × (1−tax)`, no broker fee); ranking by total_net; current-region per-station grouping (best buy per station); asset aggregation (sum quantity by type+location); `marketable` flag. Use in-memory/fake market like `multi_hub_service_test.go`.
+- **Backend handler:** 400 (missing/invalid fields), 401 (no auth), 200 happy path.
+- **Web:** Vitest for the result component (option fields, security badge color, best-option highlight, waypoint button → `setWaypoint(station_id)`), plus an authed Playwright spec mirroring the existing ones.
+- **Flutter:** widget test (option list, security chip colors, tap→detail, waypoint) + model fromJson test.
+
+## Components / Files
+
+**Backend**
+- `internal/services/asset_sale_service.go` — `AssetSaleService`, `ListAssets`, `SellOptions` (+ taker net + ranking helpers).
+- `internal/services/asset_sale_service_test.go`.
+- `internal/handlers/assets.go` — `AssetsHandler` (`ListAssets`, `SellOptions`).
+- `internal/models/` — `AssetItem`, `SellOption`, `SellOptionsResponse` (reuse `SkillsApplied`).
+- `cmd/api/container.go` + `main.go` — wire handler, register `GET /trading/assets` and `POST /trading/assets/sell-options`.
+- General paginated assets fetch (shared helper or in the service).
+
+**Web** (`/sell-assets`): API helpers `listAssets()` + `findSellOptions(req)`, `AssetPicker` (search/filter by name/qty/location), `SellOptionsResult` (best highlight, option list, security badge, route, "Route an EVE übertragen" via existing `setWaypoint`), nav entry.
+
+**Flutter** (`/sell-assets`): models, dio methods, providers (AsyncNotifier), adaptive screen (picker → result), security chips, waypoint button, router + nav entry.
+
+## Out of Scope
+
+- Maker / sell-order placement (broker fee, order competition) — possible future issue.
+- Buy-order *range* semantics (station vs region range) — hubs use region-best routed to hub system; current region uses per-station best. Good-enough approximation; documented here.
+- Multi-item batch optimization / "liquidate my whole hangar" planning.

--- a/frontend/src/app/sell-assets/page.tsx
+++ b/frontend/src/app/sell-assets/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { useAuth } from "@/lib/auth-context";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { AssetPicker } from "@/components/trading/AssetPicker";
+import { SellOptionsResult } from "@/components/trading/SellOptionsResult";
+import { SkillsAppliedPanel } from "@/components/trading/SkillsAppliedPanel";
+import { findSellOptions } from "@/lib/api-client";
+import { SellOptionsRequest } from "@/types/trading";
+import { Loader2 } from "lucide-react";
+
+function SellAssetsPageContent() {
+  const { isAuthenticated } = useAuth();
+
+  const sellMutation = useMutation({
+    mutationFn: (req: SellOptionsRequest) => findSellOptions(req),
+  });
+
+  const apiError = sellMutation.isError
+    ? sellMutation.error instanceof Error
+      ? sellMutation.error.message
+      : "Unbekannter Fehler"
+    : undefined;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold">Sell from Assets</h1>
+        <p className="text-muted-foreground">
+          Wähle ein Item aus deinem Besitz und finde heraus, wo du es für das
+          meiste Netto-ISK verkaufst — inkl. Route, Sprüngen und Sicherheits-Risiko.
+        </p>
+      </div>
+
+      {!isAuthenticated && (
+        <Alert className="mb-6">
+          <AlertTitle>Login erforderlich</AlertTitle>
+          <AlertDescription>
+            Melde dich per EVE SSO an, um deine Assets zu laden und die besten
+            Verkaufsorte zu finden.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
+        {/* Asset picker + sell form */}
+        <AssetPicker
+          authenticated={isAuthenticated}
+          searching={sellMutation.isPending}
+          onSearch={(req) => sellMutation.mutate(req)}
+        />
+
+        {/* Results */}
+        <div className="space-y-6">
+          {sellMutation.isPending && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Suche beste Verkaufsorte...
+            </div>
+          )}
+
+          {apiError && (
+            <Alert variant="destructive">
+              <AlertTitle>Fehler</AlertTitle>
+              <AlertDescription className="flex items-center justify-between gap-4">
+                <span>{apiError}</span>
+                {sellMutation.variables && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => sellMutation.mutate(sellMutation.variables!)}
+                  >
+                    Erneut versuchen
+                  </Button>
+                )}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {sellMutation.isSuccess && sellMutation.data && (
+            <div className="space-y-6">
+              <SellOptionsResult
+                best={sellMutation.data.best}
+                options={sellMutation.data.options}
+              />
+              <SkillsAppliedPanel skills={sellMutation.data.skills_applied} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function SellAssetsPage() {
+  return (
+    <ErrorBoundary>
+      <SellAssetsPageContent />
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/components/navigation.tsx
+++ b/frontend/src/components/navigation.tsx
@@ -17,6 +17,7 @@ const navItems = [
   { href: "/multi-hub", label: "Multi-Hub", badge: "Phase 2" },
   { href: "/roi-calculator", label: "ROI Calculator", badge: "Phase 2" },
   { href: "/hauling", label: "Hauling", badge: "Phase 2" },
+  { href: "/sell-assets", label: "Sell Assets", badge: "Phase 2" },
   { href: "/trends", label: "Trends", badge: "Phase 3" },
   { href: "/watchlist", label: "Watchlist", badge: "Phase 3" },
 ];

--- a/frontend/src/components/trading/AssetPicker.tsx
+++ b/frontend/src/components/trading/AssetPicker.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, Search } from "lucide-react";
+import { AssetItem, SellOptionsRequest } from "@/types/trading";
+import { listAssets } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+
+interface AssetPickerProps {
+  authenticated: boolean;
+  /** Disable while a sell-options search is in flight. */
+  searching?: boolean;
+  /** Fired with the assembled sell-options request when the user searches. */
+  onSearch: (req: SellOptionsRequest) => void;
+}
+
+/**
+ * Picker for the character's marketable assets. Fetches the asset list, lets
+ * the user filter by name and pick a stack, then choose a quantity + low-sec
+ * preference and fire a sell-options search. Non-marketable assets are shown
+ * but disabled (no market group).
+ */
+export function AssetPicker({
+  authenticated,
+  searching = false,
+  onSearch,
+}: AssetPickerProps) {
+  const [filter, setFilter] = useState("");
+  const [selected, setSelected] = useState<AssetItem | null>(null);
+  const [quantity, setQuantity] = useState<number>(0);
+  const [avoidLowSec, setAvoidLowSec] = useState(true);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ["assets"],
+    queryFn: listAssets,
+    enabled: authenticated,
+  });
+
+  const filtered = useMemo(() => {
+    const assets = data?.assets ?? [];
+    const q = filter.trim().toLowerCase();
+    if (!q) return assets;
+    return assets.filter((a) => a.name.toLowerCase().includes(q));
+  }, [data, filter]);
+
+  const handleSelect = (asset: AssetItem) => {
+    if (!asset.marketable) return;
+    setSelected(asset);
+    setQuantity(asset.quantity);
+  };
+
+  const handleSubmit = () => {
+    if (!selected) return;
+    onSearch({
+      type_id: selected.type_id,
+      location_id: selected.location_id,
+      quantity,
+      avoid_low_sec: avoidLowSec,
+    });
+  };
+
+  if (!authenticated) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border p-4" data-testid="asset-picker">
+      <div className="space-y-2">
+        <Label htmlFor="asset-filter">Asset suchen</Label>
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
+          <Input
+            id="asset-filter"
+            placeholder="Nach Name filtern..."
+            value={filter}
+            disabled={isLoading}
+            className="pl-8"
+            onChange={(e) => setFilter(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" />
+          Lade Assets...
+        </div>
+      )}
+
+      {isError && (
+        <Alert variant="destructive">
+          <AlertTitle>Fehler</AlertTitle>
+          <AlertDescription className="flex items-center justify-between gap-4">
+            <span>
+              {error instanceof Error ? error.message : "Unbekannter Fehler"}
+            </span>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              Erneut versuchen
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {!isLoading && !isError && filtered.length === 0 && (
+        <div
+          data-testid="asset-picker-empty"
+          className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
+        >
+          Keine Assets gefunden
+        </div>
+      )}
+
+      {filtered.length > 0 && (
+        <ul
+          className="max-h-72 space-y-1 overflow-y-auto"
+          data-testid="asset-list"
+        >
+          {filtered.map((asset) => {
+            const isSelected =
+              selected?.type_id === asset.type_id &&
+              selected?.location_id === asset.location_id;
+            const disabled = !asset.marketable;
+            return (
+              <li key={`${asset.type_id}-${asset.location_id}`}>
+                <button
+                  type="button"
+                  data-testid="asset-row"
+                  data-type-id={asset.type_id}
+                  data-marketable={asset.marketable}
+                  disabled={disabled}
+                  onClick={() => handleSelect(asset)}
+                  className={cn(
+                    "w-full rounded-md border px-3 py-2 text-left text-sm transition-colors",
+                    isSelected
+                      ? "border-primary bg-primary/10"
+                      : "border-transparent hover:bg-muted/60",
+                    disabled && "cursor-not-allowed opacity-50"
+                  )}
+                  title={
+                    disabled ? "Nicht handelbar (keine Marktgruppe)" : undefined
+                  }
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{asset.name}</span>
+                    <span className="text-muted-foreground">
+                      {asset.quantity.toLocaleString("de-DE")}
+                    </span>
+                  </div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {asset.location_name}
+                    {disabled && " · nicht handelbar"}
+                  </div>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {selected && (
+        <div className="space-y-4 border-t pt-4" data-testid="asset-sell-form">
+          <div className="space-y-2">
+            <Label htmlFor="sell-quantity">Menge</Label>
+            <Input
+              id="sell-quantity"
+              type="number"
+              min={1}
+              max={selected.quantity}
+              value={quantity}
+              disabled={searching}
+              onChange={(e) => setQuantity(Number(e.target.value))}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="avoid-low-sec"
+              checked={avoidLowSec}
+              disabled={searching}
+              onCheckedChange={(c) => setAvoidLowSec(c === true)}
+            />
+            <Label htmlFor="avoid-low-sec" className="font-normal">
+              Low-Sec meiden
+            </Label>
+          </div>
+
+          <Button
+            type="button"
+            className="w-full"
+            onClick={handleSubmit}
+            disabled={searching || quantity < 1}
+          >
+            {searching && <Loader2 className="mr-2 size-4 animate-spin" />}
+            {searching ? "Suche Verkaufsorte..." : "Verkaufsorte suchen"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/trading/SellOptionsResult.tsx
+++ b/frontend/src/components/trading/SellOptionsResult.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Navigation, Trophy } from "lucide-react";
+import { SellOption, SellOptionScope, SecurityRisk } from "@/types/trading";
+import { cn, formatISKWithSeparators } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/lib/auth-context";
+import { setWaypoint } from "@/lib/api-client";
+
+interface SellOptionsResultProps {
+  best: SellOption | null;
+  options: SellOption[];
+}
+
+const SECURITY_BADGE: Record<
+  SecurityRisk,
+  { label: string; className: string }
+> = {
+  safe: {
+    label: "Sicher",
+    className:
+      "border-green-300 bg-green-50 text-green-700 dark:border-green-700 dark:bg-green-900/20 dark:text-green-300",
+  },
+  caution: {
+    label: "Vorsicht",
+    className:
+      "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-300",
+  },
+  danger: {
+    label: "Gefahr",
+    className:
+      "border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-900/20 dark:text-red-300",
+  },
+};
+
+function SecurityBadge({ risk }: { risk: SecurityRisk }) {
+  const cfg = SECURITY_BADGE[risk] ?? SECURITY_BADGE.caution;
+  return (
+    <span
+      data-testid="security-badge"
+      data-risk={risk}
+      className={cn(
+        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold",
+        cfg.className
+      )}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+function ScopeBadge({ scope }: { scope: SellOptionScope }) {
+  return (
+    <Badge variant="outline" className="text-xs" data-testid="scope-badge">
+      {scope === "hub" ? "Hub" : "Region"}
+    </Badge>
+  );
+}
+
+/**
+ * Ranked sell locations for an owned item (taker model, net of sales tax). The
+ * best actionable option is highlighted at the top, followed by the full list
+ * pre-sorted by total_net. Each option can be pushed to the in-game autopilot.
+ * Options without market data render muted. An empty list shows a hint.
+ */
+export function SellOptionsResult({ best, options }: SellOptionsResultProps) {
+  if (options.length === 0) {
+    return (
+      <div
+        data-testid="sell-options-empty"
+        className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
+      >
+        Keine Verkaufsorte gefunden
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4" data-testid="sell-options-result">
+      {best && (
+        <SellOptionCard
+          key={`best-${best.station_id}`}
+          option={best}
+          highlighted
+        />
+      )}
+      <div className="space-y-3" data-testid="sell-options-list">
+        {options.map((option, idx) => (
+          <SellOptionCard
+            key={`${option.station_id}-${idx}`}
+            option={option}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SellOptionCard({
+  option,
+  highlighted,
+}: {
+  option: SellOption;
+  highlighted?: boolean;
+}) {
+  const { isAuthenticated } = useAuth();
+  const { toast } = useToast();
+  const [isSettingRoute, setIsSettingRoute] = useState(false);
+
+  const handleSetWaypoint = async () => {
+    if (!isAuthenticated) {
+      toast({
+        title: "Nicht eingeloggt",
+        description: "EVE SSO Login erforderlich",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSettingRoute(true);
+    try {
+      await setWaypoint(option.station_id, { clearOtherWaypoints: true });
+      toast({
+        title: "Route gesetzt",
+        description: `Waypoint in EVE gesetzt: ${option.station_name}`,
+      });
+    } catch (err) {
+      toast({
+        title: "Fehler",
+        description: err instanceof Error ? err.message : "Unbekannter Fehler",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSettingRoute(false);
+    }
+  };
+
+  return (
+    <Card
+      data-testid="sell-option"
+      data-has-data={option.has_data}
+      data-highlighted={highlighted ? "true" : undefined}
+      className={cn(
+        highlighted && "border-primary ring-1 ring-primary",
+        !option.has_data && "opacity-60"
+      )}
+    >
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <CardTitle
+              className="flex items-center gap-2 text-lg"
+              title={option.station_name}
+            >
+              {highlighted && (
+                <Trophy
+                  className="size-4 text-amber-500"
+                  aria-label="Beste Option"
+                />
+              )}
+              {option.system_name}
+            </CardTitle>
+            <div className="text-sm text-muted-foreground">
+              {option.station_name}
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <ScopeBadge scope={option.scope} />
+              <SecurityBadge risk={option.security_risk} />
+              <span>{option.jumps} Sprünge</span>
+              <span aria-hidden>·</span>
+              <span>{option.travel_time_min.toFixed(1)} Min</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSetWaypoint}
+              disabled={isSettingRoute || !option.has_data}
+              title="Route an EVE übertragen"
+              aria-label="Route an EVE übertragen"
+            >
+              {isSettingRoute ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Navigation className="size-4" />
+              )}
+              <span className="ml-2 hidden sm:inline">
+                Route an EVE übertragen
+              </span>
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {option.has_data ? (
+          <div className="grid grid-cols-3 gap-4">
+            <Metric
+              label="Kaufpreis"
+              value={formatISKWithSeparators(option.buy_price)}
+            />
+            <Metric
+              label="Netto/Stück"
+              value={formatISKWithSeparators(option.unit_net)}
+            />
+            <Metric
+              label="Netto gesamt"
+              value={formatISKWithSeparators(option.total_net)}
+              positive
+            />
+          </div>
+        ) : (
+          <div
+            data-testid="sell-option-no-data"
+            className="text-sm text-muted-foreground"
+          >
+            kein Marktpreis
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  positive,
+}: {
+  label: string;
+  value: string;
+  positive?: boolean;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div
+        className={cn(
+          "font-semibold",
+          positive && "text-green-600 dark:text-green-400"
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -13,6 +13,9 @@ import {
   PortfolioResult,
   HaulingRequest,
   HaulingResponse,
+  AssetsResponse,
+  SellOptionsRequest,
+  SellOptionsResponse,
 } from "@/types/trading";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:9001";
@@ -221,6 +224,53 @@ export async function findHaulingRoutes(
 
   if (!response.ok) {
     throw new Error(`Failed to find hauling routes: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * List the authenticated character's marketable assets (requires
+ * authentication). Each asset carries its current location/system/region so the
+ * sell-options lookup can scope to the item's current region. Assets with
+ * marketable=false have no market group and cannot be sold via market orders.
+ */
+export async function listAssets(): Promise<AssetsResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/trading/assets`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to list assets: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Find the best sell locations for an owned item using a taker model (instant
+ * sell into a buy order, net of sales tax), compared across the major hubs plus
+ * every station in the item's current region (requires authentication).
+ * Options are returned pre-sorted by total_net descending; `best` is the top
+ * actionable option or null. Options with has_data=false have no buy order /
+ * route. An empty options array means no sell locations were found.
+ * @param req - sell options parameters (item, current location, quantity)
+ */
+export async function findSellOptions(
+  req: SellOptionsRequest
+): Promise<SellOptionsResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/trading/assets/sell-options`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(req),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to find sell options: ${response.statusText}`);
   }
 
   return response.json();

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -257,3 +257,56 @@ export interface InventorySellRoute {
   route_system_ids: number[];
   min_route_security_status: number;
 }
+
+// Sell-from-Assets (Issue #107)
+
+export interface AssetItem {
+  type_id: number;
+  name: string;
+  quantity: number;
+  location_id: number;
+  location_name: string;
+  system_id: number;
+  region_id: number;
+  marketable: boolean;
+}
+
+export interface AssetsResponse {
+  assets: AssetItem[];
+  count: number;
+}
+
+export interface SellOptionsRequest {
+  type_id: number;
+  location_id: number;
+  quantity: number;
+  avoid_low_sec: boolean;
+}
+
+export type SellOptionScope = "hub" | "current_region";
+
+export interface SellOption {
+  scope: SellOptionScope;
+  region_id: number;
+  region_name: string;
+  station_id: number;
+  station_name: string;
+  system_name: string;
+  buy_price: number;
+  unit_net: number;
+  total_net: number;
+  jumps: number;
+  travel_time_min: number;
+  security_risk: SecurityRisk;
+  has_data: boolean;
+}
+
+export interface SellOptionsResponse {
+  type_id: number;
+  name: string;
+  quantity: number;
+  origin_system_id: number;
+  best: SellOption | null;
+  options: SellOption[]; // pre-sorted by total_net desc
+  skills_applied: SkillsApplied;
+}

--- a/frontend/tests/components/SellOptionsResult.test.tsx
+++ b/frontend/tests/components/SellOptionsResult.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within, fireEvent, act } from "@testing-library/react";
+import { SellOptionsResult } from "@/components/trading/SellOptionsResult";
+import { SellOption } from "@/types/trading";
+import { setWaypoint } from "@/lib/api-client";
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+  }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  setWaypoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+const setWaypointMock = vi.mocked(setWaypoint);
+
+beforeEach(() => {
+  setWaypointMock.mockClear();
+});
+
+function makeOption(overrides: Partial<SellOption> = {}): SellOption {
+  return {
+    scope: "hub",
+    region_id: 10000002,
+    region_name: "The Forge",
+    station_id: 60003760,
+    station_name: "Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+    system_name: "Jita",
+    buy_price: 5.5,
+    unit_net: 5.36,
+    total_net: 643200,
+    jumps: 0,
+    travel_time_min: 0,
+    security_risk: "safe",
+    has_data: true,
+    ...overrides,
+  };
+}
+
+describe("SellOptionsResult", () => {
+  it("renders an option card with system, station, scope and the money fields", () => {
+    render(<SellOptionsResult best={null} options={[makeOption()]} />);
+
+    const card = screen.getAllByTestId("sell-option")[0];
+    expect(within(card).getByText("Jita")).toBeInTheDocument();
+    expect(
+      within(card).getByText(
+        "Jita IV - Moon 4 - Caldari Navy Assembly Plant"
+      )
+    ).toBeInTheDocument();
+    expect(within(card).getByTestId("scope-badge")).toHaveTextContent("Hub");
+    // total_net 643200
+    expect(within(card).getByText("643.200,00 ISK")).toBeInTheDocument();
+    expect(within(card).getByText("0 Sprünge")).toBeInTheDocument();
+  });
+
+  it("renders a Region scope badge for current_region options", () => {
+    render(
+      <SellOptionsResult
+        best={null}
+        options={[makeOption({ scope: "current_region" })]}
+      />
+    );
+    expect(screen.getByTestId("scope-badge")).toHaveTextContent("Region");
+  });
+
+  it("renders a security badge with the correct color per risk level", () => {
+    const { rerender } = render(
+      <SellOptionsResult
+        best={null}
+        options={[makeOption({ security_risk: "safe" })]}
+      />
+    );
+    let badge = screen.getByTestId("security-badge");
+    expect(badge).toHaveAttribute("data-risk", "safe");
+    expect(badge.className).toContain("green");
+
+    rerender(
+      <SellOptionsResult
+        best={null}
+        options={[makeOption({ security_risk: "caution" })]}
+      />
+    );
+    badge = screen.getByTestId("security-badge");
+    expect(badge).toHaveAttribute("data-risk", "caution");
+    expect(badge.className).toContain("amber");
+
+    rerender(
+      <SellOptionsResult
+        best={null}
+        options={[makeOption({ security_risk: "danger" })]}
+      />
+    );
+    badge = screen.getByTestId("security-badge");
+    expect(badge).toHaveAttribute("data-risk", "danger");
+    expect(badge.className).toContain("red");
+  });
+
+  it("highlights the best option above the list", () => {
+    const best = makeOption({ total_net: 700000 });
+    render(<SellOptionsResult best={best} options={[makeOption()]} />);
+
+    const all = screen.getAllByTestId("sell-option");
+    // best card is rendered first, with the highlighted marker
+    expect(all[0]).toHaveAttribute("data-highlighted", "true");
+    expect(all[1]).not.toHaveAttribute("data-highlighted");
+    expect(screen.getByLabelText("Beste Option")).toBeInTheDocument();
+  });
+
+  it("calls setWaypoint with the option's station_id and clearOtherWaypoints", async () => {
+    render(<SellOptionsResult best={null} options={[makeOption()]} />);
+
+    const button = screen.getByRole("button", {
+      name: "Route an EVE übertragen",
+    });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    await vi.waitFor(() => {
+      expect(setWaypointMock).toHaveBeenCalledTimes(1);
+    });
+    expect(setWaypointMock).toHaveBeenCalledWith(60003760, {
+      clearOtherWaypoints: true,
+    });
+  });
+
+  it("renders has_data:false options muted with 'kein Marktpreis' and disabled waypoint", () => {
+    render(
+      <SellOptionsResult
+        best={null}
+        options={[makeOption({ has_data: false })]}
+      />
+    );
+
+    const card = screen.getByTestId("sell-option");
+    expect(card).toHaveAttribute("data-has-data", "false");
+    expect(card.className).toContain("opacity-60");
+    expect(screen.getByTestId("sell-option-no-data")).toHaveTextContent(
+      "kein Marktpreis"
+    );
+    expect(
+      screen.getByRole("button", { name: "Route an EVE übertragen" })
+    ).toBeDisabled();
+  });
+
+  it("renders the empty-state when no options exist", () => {
+    render(<SellOptionsResult best={null} options={[]} />);
+
+    expect(screen.getByTestId("sell-options-empty")).toBeInTheDocument();
+    expect(
+      screen.getByText("Keine Verkaufsorte gefunden")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("sell-option")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/e2e/auth/sell-assets.spec.ts
+++ b/frontend/tests/e2e/auth/sell-assets.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Sell-from-Assets workflow (Issue #107) — only operable when authenticated
+ * (the assets + sell-options endpoints require the session cookie and use the
+ * character's owned assets / current region). The auth project injects the
+ * captured session via storageState, so this spec runs against the real backend.
+ *
+ * Structure assertions only — live market values vary. The sell-options scan
+ * hits a live multi-region market lookup and can be slow, so timeouts are
+ * generous.
+ */
+test.describe('Authenticated sell-from-assets', () => {
+  test('pick an asset, search, see sell options or empty-state', async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    await page.goto('/sell-assets');
+    await expect(page.locator('h1')).toContainText('Sell from Assets');
+
+    // The picker loads the character's assets once authenticated.
+    const picker = page.getByTestId('asset-picker');
+    await expect(picker).toBeVisible({ timeout: 30000 });
+
+    // Either the asset list or the empty-state appears (both valid).
+    const assetList = page.getByTestId('asset-list');
+    const assetEmpty = page.getByTestId('asset-picker-empty');
+    await expect(assetList.or(assetEmpty)).toBeVisible({ timeout: 30000 });
+
+    // Without assets there is nothing to sell — done.
+    if (!(await assetList.isVisible())) {
+      return;
+    }
+
+    // Pick the first marketable asset (selectable rows are enabled).
+    const marketableRow = page
+      .getByTestId('asset-row')
+      .filter({ hasNot: page.locator('[disabled]') })
+      .first();
+    const firstEnabled = page.locator('[data-testid="asset-row"]:not([disabled])').first();
+    await expect(firstEnabled.or(marketableRow)).toBeVisible();
+    await firstEnabled.click();
+
+    // The sell form (quantity + search button) appears after selection.
+    const submit = page.getByRole('button', { name: /Verkaufsorte suchen/i });
+    await expect(submit).toBeEnabled({ timeout: 10000 });
+    await submit.click();
+
+    // Either option cards appear, or the empty-state hint — both are valid.
+    const result = page.getByTestId('sell-options-result');
+    const empty = page.getByTestId('sell-options-empty');
+    await expect(result.or(empty)).toBeVisible({ timeout: 90000 });
+
+    if (await result.isVisible()) {
+      const firstOption = page.getByTestId('sell-option').first();
+      await expect(firstOption).toBeVisible();
+      // Security + scope badges render on the option card.
+      await expect(firstOption.getByTestId('security-badge')).toBeVisible();
+      await expect(firstOption.getByTestId('scope-badge')).toBeVisible();
+    }
+
+    // The skills-applied panel is shown alongside the results.
+    await expect(page.getByText('Skills angewendet')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #107 — pick an item you already own and get a ranked answer to *"where do I sell this for the most net ISK, and how do I get there?"* (taker / liquidation flow).

- **Backend:** `GET /api/v1/trading/assets` (owned items aggregated by type + location, paginated ESI fetch, `marketable` flag) and `POST /api/v1/trading/assets/sell-options`. For a selected item it ranks **taker** sell locations — instant sell into a buy order, net = best buy × (1 − sales tax), **no broker fee** — across the 5 major hubs (region-best, route to hub) + every station in the item's current region (per-station best, often 0 jumps). Each option carries jumps, travel time and security risk (safe/caution/danger). Ranked by total net proceeds. Reuses `MajorHubs`, the hub order fetcher, fee/skills helpers, and SDE navigation.
- **Web (`/sell-assets`):** searchable asset picker (non-marketable disabled) → result with best highlighted + ranked option list + "Route an EVE übertragen".
- **Flutter (`/sell-assets`):** adaptive picker → result, security chips, waypoint button.

Distinct from #45 (buy-to-resell arbitrage); this starts from owned assets. Order-placing (maker) is out of scope.

## Test plan
- [x] Backend: `gofmt`/`vet` clean, `go test -short ./internal/...` pass (taker net, best-buy per region/station, asset aggregation, paginated fetcher, service list + ranking, handler 400/401)
- [x] Web: Vitest 58/58 (incl. 7 new SellOptionsResult: fields, security badge, best highlight, waypoint call, muted no-data, empty); ESLint clean
- [x] Flutter: `flutter analyze` clean; 16 new tests + 20/20 e2e pass
- [ ] CI green
- [ ] Post-deploy: `/sell-assets` 200, sell-options 401 noauth; APK on-device

🤖 Generated with [Claude Code](https://claude.com/claude-code)