### PR TITLE
feat: sortable asset picker + document citadel limitation (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sell-from-Assets:** the asset picker is now sortable by name or quantity (ascending/descending), in both the web and Flutter clients. Client-side only — no API change. Items stored in player structures/citadels remain a documented limitation (no route resolvable → "Keine Verkaufsorte").
+
 ## [0.12.0] - 2026-05-29
 
 ### Added

--- a/app/lib/features/trading/sell_assets_screen.dart
+++ b/app/lib/features/trading/sell_assets_screen.dart
@@ -119,6 +119,8 @@ class _PickerPaneState extends ConsumerState<_PickerPane> {
   final _searchController = TextEditingController();
   final _quantityController = TextEditingController();
   String _query = '';
+  String _sortBy = 'name'; // 'name' | 'quantity'
+  bool _sortAsc = true;
   AssetItem? _selected;
   bool _avoidLowSec = true;
   String? _error;
@@ -190,6 +192,43 @@ class _PickerPaneState extends ConsumerState<_PickerPane> {
           ),
         ),
 
+        // ── Sort control ───────────────────────────────────────────────────
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+          child: Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              ChoiceChip(
+                key: const Key('sell-sort-name'),
+                label: const Text('Name'),
+                visualDensity: VisualDensity.compact,
+                selected: _sortBy == 'name',
+                onSelected: busy ? null : (_) => setState(() => _sortBy = 'name'),
+              ),
+              ChoiceChip(
+                key: const Key('sell-sort-quantity'),
+                label: const Text('Menge'),
+                visualDensity: VisualDensity.compact,
+                selected: _sortBy == 'quantity',
+                onSelected:
+                    busy ? null : (_) => setState(() => _sortBy = 'quantity'),
+              ),
+              IconButton(
+                key: const Key('sell-sort-dir'),
+                visualDensity: VisualDensity.compact,
+                tooltip: _sortAsc ? 'Aufsteigend' : 'Absteigend',
+                icon: Icon(_sortAsc
+                    ? Icons.arrow_upward_rounded
+                    : Icons.arrow_downward_rounded),
+                onPressed:
+                    busy ? null : () => setState(() => _sortAsc = !_sortAsc),
+              ),
+            ],
+          ),
+        ),
+
         // ── Asset list ─────────────────────────────────────────────────────
         Expanded(
           child: assetsAsync.when(
@@ -211,6 +250,12 @@ class _PickerPaneState extends ConsumerState<_PickerPane> {
                   .where((a) =>
                       _query.isEmpty || a.name.toLowerCase().contains(_query))
                   .toList();
+              filtered.sort((a, b) {
+                final cmp = _sortBy == 'name'
+                    ? a.name.toLowerCase().compareTo(b.name.toLowerCase())
+                    : a.quantity.compareTo(b.quantity);
+                return _sortAsc ? cmp : -cmp;
+              });
               if (resp.isEmpty) {
                 return const Center(
                   child: Padding(

--- a/app/test/sell_assets_screen_layout_test.dart
+++ b/app/test/sell_assets_screen_layout_test.dart
@@ -145,6 +145,24 @@ class _FakeTradingApi extends TradingApi {
       _fakeResponse();
 }
 
+class _MultiAssetApi extends TradingApi {
+  _MultiAssetApi() : super(Dio());
+
+  @override
+  Future<AssetsResponse> listAssets() async => const AssetsResponse(
+        count: 3,
+        assets: [
+          AssetItem(typeId: 1, name: 'Tritanium', quantity: 5, locationId: 60000001, locationName: 'A', systemId: 1, regionId: 1, marketable: true),
+          AssetItem(typeId: 2, name: 'Arkonor', quantity: 100, locationId: 60000001, locationName: 'A', systemId: 1, regionId: 1, marketable: true),
+          AssetItem(typeId: 3, name: 'Mexallon', quantity: 50, locationId: 60000001, locationName: 'A', systemId: 1, regionId: 1, marketable: true),
+        ],
+      );
+
+  @override
+  Future<SellOptionsResponse> findSellOptions(SellOptionsRequest request) async =>
+      _emptyResponse();
+}
+
 class _StubNotifier extends SellOptionsNotifier {
   @override
   Future<SellOptionsResponse?> build() async => _fakeResponse();
@@ -165,6 +183,7 @@ Future<void> _pumpScreen(
   double width, {
   double height = 1400,
   SellOptionsNotifier Function() notifier = _StubNotifier.new,
+  TradingApi Function() api = _FakeTradingApi.new,
 }) async {
   tester.view.physicalSize = Size(width, height);
   tester.view.devicePixelRatio = 1.0;
@@ -174,7 +193,7 @@ Future<void> _pumpScreen(
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
-        tradingApiProvider.overrideWithValue(_FakeTradingApi()),
+        tradingApiProvider.overrideWithValue(api()),
         sellOptionsProvider.overrideWith(notifier),
       ],
       child: MaterialApp(
@@ -286,5 +305,30 @@ void main() {
 
     expect(find.text('Item wählen und Verkaufsorte suchen'), findsOneWidget);
     expect(find.byKey(const Key('sell-option-list')), findsNothing);
+  });
+
+  testWidgets('Asset list sorts by name (default) then by quantity',
+      (tester) async {
+    await _pumpScreen(tester, 1280,
+        notifier: _IdleNotifier.new, api: _MultiAssetApi.new);
+
+    double dy(String name) => tester.getTopLeft(find.text(name)).dy;
+
+    // Default: name ascending → Arkonor, Mexallon, Tritanium.
+    expect(dy('Arkonor') < dy('Mexallon'), isTrue);
+    expect(dy('Mexallon') < dy('Tritanium'), isTrue);
+
+    // Toggle direction → name descending.
+    await tester.tap(find.byKey(const Key('sell-sort-dir')));
+    await tester.pumpAndSettle();
+    expect(dy('Tritanium') < dy('Mexallon'), isTrue);
+    expect(dy('Mexallon') < dy('Arkonor'), isTrue);
+
+    // Sort by quantity ascending (5 Tritanium, 50 Mexallon, 100 Arkonor).
+    await tester.tap(find.byKey(const Key('sell-sort-quantity')));
+    await tester.tap(find.byKey(const Key('sell-sort-dir'))); // back to asc
+    await tester.pumpAndSettle();
+    expect(dy('Tritanium') < dy('Mexallon'), isTrue);
+    expect(dy('Mexallon') < dy('Arkonor'), isTrue);
   });
 }

--- a/docs/superpowers/specs/2026-05-29-sell-from-assets-design.md
+++ b/docs/superpowers/specs/2026-05-29-sell-from-assets-design.md
@@ -123,3 +123,11 @@ POST /api/v1/trading/assets/sell-options   (auth)
 - Maker / sell-order placement (broker fee, order competition) — possible future issue.
 - Buy-order *range* semantics (station vs region range) — hubs use region-best routed to hub system; current region uses per-station best. Good-enough approximation; documented here.
 - Multi-item batch optimization / "liquidate my whole hangar" planning.
+
+## Known Limitations
+
+- **Items in player structures / citadels (accepted, not fixed).** The route is computed from the item's current location. The SDE only knows NPC stations, so an item whose `location_id` is a player-owned structure (Upwell citadel/engineering complex, `location_id` outside the NPC-station/system ranges) cannot be resolved to a system. For such items the service returns 200 with `best:null` / empty `options`, and the UI shows "Keine Verkaufsorte". This is an accepted limitation (decided 2026-05-29) — we explicitly do **not** resolve structure locations. A possible future enhancement would be to still show hub net proceeds *without* a route when the origin is an unresolvable structure.
+
+## Follow-up (shipped 2026-05-29, v0.12.1)
+
+- Asset picker is **sortable by name or quantity**, ascending/descending (web + Flutter). Client-side only; no API change.

--- a/frontend/src/components/trading/AssetPicker.tsx
+++ b/frontend/src/components/trading/AssetPicker.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Loader2, Search } from "lucide-react";
+import { ArrowDownAZ, ArrowUpAZ, Loader2, Search } from "lucide-react";
 import { AssetItem, SellOptionsRequest } from "@/types/trading";
 import { listAssets } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
@@ -32,6 +32,8 @@ export function AssetPicker({
   onSearch,
 }: AssetPickerProps) {
   const [filter, setFilter] = useState("");
+  const [sortBy, setSortBy] = useState<"name" | "quantity">("name");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
   const [selected, setSelected] = useState<AssetItem | null>(null);
   const [quantity, setQuantity] = useState<number>(0);
   const [avoidLowSec, setAvoidLowSec] = useState(true);
@@ -51,9 +53,19 @@ export function AssetPicker({
   const filtered = useMemo(() => {
     const assets = data?.assets ?? [];
     const q = filter.trim().toLowerCase();
-    if (!q) return assets;
-    return assets.filter((a) => a.name.toLowerCase().includes(q));
-  }, [data, filter]);
+    const matched = q
+      ? assets.filter((a) => a.name.toLowerCase().includes(q))
+      : [...assets];
+    const dir = sortDir === "asc" ? 1 : -1;
+    matched.sort((a, b) => {
+      const cmp =
+        sortBy === "name"
+          ? a.name.localeCompare(b.name, "de")
+          : a.quantity - b.quantity;
+      return cmp * dir;
+    });
+    return matched;
+  }, [data, filter, sortBy, sortDir]);
 
   const handleSelect = (asset: AssetItem) => {
     if (!asset.marketable) return;
@@ -91,6 +103,44 @@ export function AssetPicker({
           />
         </div>
       </div>
+
+      {!isLoading && !isError && (data?.assets?.length ?? 0) > 0 && (
+        <div className="flex items-center gap-2" data-testid="asset-sort">
+          <span className="text-xs text-muted-foreground">Sortieren:</span>
+          <Button
+            type="button"
+            variant={sortBy === "name" ? "secondary" : "ghost"}
+            size="sm"
+            data-testid="sort-name"
+            onClick={() => setSortBy("name")}
+          >
+            Name
+          </Button>
+          <Button
+            type="button"
+            variant={sortBy === "quantity" ? "secondary" : "ghost"}
+            size="sm"
+            data-testid="sort-quantity"
+            onClick={() => setSortBy("quantity")}
+          >
+            Menge
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            data-testid="sort-dir"
+            aria-label={sortDir === "asc" ? "Aufsteigend" : "Absteigend"}
+            onClick={() => setSortDir((d) => (d === "asc" ? "desc" : "asc"))}
+          >
+            {sortDir === "asc" ? (
+              <ArrowDownAZ className="size-4" />
+            ) : (
+              <ArrowUpAZ className="size-4" />
+            )}
+          </Button>
+        </div>
+      )}
 
       {isLoading && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/frontend/tests/components/AssetPicker.test.tsx
+++ b/frontend/tests/components/AssetPicker.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AssetPicker } from "@/components/trading/AssetPicker";
+import { listAssets } from "@/lib/api-client";
+
+vi.mock("@/lib/api-client", () => ({
+  listAssets: vi.fn(),
+}));
+
+const listAssetsMock = vi.mocked(listAssets);
+
+const assets = [
+  { type_id: 1, name: "Tritanium", quantity: 5, location_id: 60000001, location_name: "A", system_id: 1, region_id: 1, marketable: true },
+  { type_id: 2, name: "Pyerite", quantity: 100, location_id: 60000001, location_name: "A", system_id: 1, region_id: 1, marketable: true },
+  { type_id: 3, name: "Mexallon", quantity: 50, location_id: 60000001, location_name: "A", system_id: 1, region_id: 1, marketable: true },
+];
+
+function renderPicker() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <AssetPicker authenticated onSearch={vi.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+function rowNames(): string[] {
+  return within(screen.getByTestId("asset-list"))
+    .getAllByTestId("asset-row")
+    .map((el) => el.querySelector(".font-medium")?.textContent ?? "");
+}
+
+beforeEach(() => {
+  listAssetsMock.mockReset();
+  listAssetsMock.mockResolvedValue({ assets, count: assets.length });
+});
+
+describe("AssetPicker sorting", () => {
+  it("sorts by name ascending by default", async () => {
+    renderPicker();
+    await waitFor(() => expect(screen.getByTestId("asset-list")).toBeInTheDocument());
+    expect(rowNames()).toEqual(["Mexallon", "Pyerite", "Tritanium"]);
+  });
+
+  it("reverses order when toggling direction", async () => {
+    renderPicker();
+    await waitFor(() => expect(screen.getByTestId("asset-list")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("sort-dir"));
+    expect(rowNames()).toEqual(["Tritanium", "Pyerite", "Mexallon"]);
+  });
+
+  it("sorts by quantity ascending", async () => {
+    renderPicker();
+    await waitFor(() => expect(screen.getByTestId("asset-list")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("sort-quantity"));
+    expect(rowNames()).toEqual(["Tritanium", "Mexallon", "Pyerite"]); // 5, 50, 100
+  });
+
+  it("sorts by quantity descending", async () => {
+    renderPicker();
+    await waitFor(() => expect(screen.getByTestId("asset-list")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("sort-quantity"));
+    fireEvent.click(screen.getByTestId("sort-dir"));
+    expect(rowNames()).toEqual(["Pyerite", "Mexallon", "Tritanium"]); // 100, 50, 5
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to #107. The Sell-from-Assets item list is now **sortable by name or quantity** (ascending/descending) in both web and Flutter. Client-side only — no backend/API change.

Also documents the **citadel limitation** as accepted (not fixed): items stored in player structures can't be resolved to a system for routing (the SDE only knows NPC stations), so those show "Keine Verkaufsorte". Recorded in the spec's new *Known Limitations* section.

## Test plan
- [x] Web: Vitest `AssetPicker.test.tsx` 4/4 (name asc default, toggle dir, quantity asc, quantity desc); ESLint clean
- [x] Flutter: `flutter analyze` clean; `sell_assets_screen_layout_test.dart` 11/11 (incl. new sort test); sort control uses `Wrap` to avoid the narrow-pane overflow
- [ ] CI green
- [ ] Post-deploy on-device: sort by name/quantity works

🤖 Generated with [Claude Code](https://claude.com/claude-code)