### PR TITLE
feat(ux): prefill current region + ship across all forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Region- und Schiff-Auswahl werden überall mit dem aktuellen Wert vorbelegt.** Alle Masken mit Region-/Schiff-Selektor (Web + Flutter: Trading, ROI, Hauling) belegen beim Öffnen die Region mit der aktuellen Region des Characters und das Schiff mit dem aktiven Schiff vor (einmalig, danach bleibt die eigene Auswahl). Fallback wie bisher (Forge / Schiff 648) wenn nicht eingeloggt oder ESI nicht erreichbar. Web-Trading konnte das bereits; jetzt konsistent über alle Masken. Flutter: neuer `currentRegionIdProvider` (aus `GET /character/location`) + geteiltes `CurrentSelectionPrefill`-Mixin. (Hauling nutzt die aktuelle Region weiterhin backend-seitig via `origin_region_id:0`; hier wird nur das Schiff vorbelegt.)
+
 ## [0.12.1] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Logout leert jetzt den React-Query-Cache (`queryClient.clear()`), damit charakterbezogene Daten (Standort, Schiff, …) der vorigen Session nicht an eine nachfolgende Anmeldung im selben Browser ausgeliefert werden können (Cache-Key war nur auf `isAuthenticated` gekeyt).
+
 ### Changed
 
 - **Region- und Schiff-Auswahl werden überall mit dem aktuellen Wert vorbelegt.** Alle Masken mit Region-/Schiff-Selektor (Web + Flutter: Trading, ROI, Hauling) belegen beim Öffnen die Region mit der aktuellen Region des Characters und das Schiff mit dem aktiven Schiff vor (einmalig, danach bleibt die eigene Auswahl). Fallback wie bisher (Forge / Schiff 648) wenn nicht eingeloggt oder ESI nicht erreichbar. Web-Trading konnte das bereits; jetzt konsistent über alle Masken. Flutter: neuer `currentRegionIdProvider` (aus `GET /character/location`) + geteiltes `CurrentSelectionPrefill`-Mixin. (Hauling nutzt die aktuelle Region weiterhin backend-seitig via `origin_region_id:0`; hier wird nur das Schiff vorbelegt.)

--- a/app/lib/features/character/character_api.dart
+++ b/app/lib/features/character/character_api.dart
@@ -30,6 +30,17 @@ class CharacterApi {
     return CharacterShip.fromJson(response.data!);
   }
 
+  // ── GET /api/v1/character/location ─────────────────────────────────────────
+
+  /// Returns the region ID of the character's current solar system, or null if
+  /// the backend can't resolve it. Used to pre-fill region selectors.
+  Future<int?> currentRegionId() async {
+    final response =
+        await _dio.get<Map<String, dynamic>>('/api/v1/character/location');
+    final v = response.data?['region_id'];
+    return v is num ? v.toInt() : null;
+  }
+
   // ── GET /api/v1/character/ships ────────────────────────────────────────────
 
   /// Returns all ships in the character's current hangar.

--- a/app/lib/features/character/providers.dart
+++ b/app/lib/features/character/providers.dart
@@ -40,6 +40,17 @@ final activeShipProvider = FutureProvider<CharacterShip>((ref) async {
   return api.activeShip();
 });
 
+/// Region ID of the character's current solar system; null on error.
+/// Used to pre-fill region selectors with the current region.
+final currentRegionIdProvider = FutureProvider<int?>((ref) async {
+  final api = ref.watch(characterApiProvider);
+  try {
+    return await api.currentRegionId();
+  } catch (_) {
+    return null;
+  }
+});
+
 /// Fetches the character's skills, keyed by [characterId].
 ///
 /// Uses [FutureProvider.family] so callers pass the character ID.

--- a/app/lib/features/trading/current_selection_prefill.dart
+++ b/app/lib/features/trading/current_selection_prefill.dart
@@ -1,0 +1,93 @@
+/// Mixin that pre-fills the shared region + ship selection from the character's
+/// CURRENT region and active ship — once, and only while the selection is still
+/// empty (an explicit user choice is never overwritten).
+///
+/// Mirrors the web's `override ?? current ?? default` pattern: the fallback
+/// (ship 648) is applied only once the active ship has resolved (data OR error),
+/// never prematurely while it's still loading — otherwise a late-resolving
+/// active ship (e.g. after a 401 → token refresh) could be blocked. The region
+/// is seeded from the current region when available; if unavailable (not logged
+/// in / error) the region is left untouched (no hard fallback).
+///
+/// Screens call [startSelectionPrefill] from `initState`.
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/trading_models.dart';
+import '../character/providers.dart';
+import 'providers.dart';
+
+mixin CurrentSelectionPrefill<T extends ConsumerStatefulWidget>
+    on ConsumerState<T> {
+  bool _shipPrefilled = false;
+  bool _regionPrefilled = false;
+
+  /// Kicks off the one-time region + ship pre-fill after the first frame.
+  void startSelectionPrefill() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _tryPrefillShip();
+      // Region depends on two async sources (current region id + region list);
+      // set up listeners once, then re-check on every change.
+      ref.listenManual(currentRegionIdProvider, (_, _) => _tryPrefillRegion());
+      ref.listenManual(regionsProvider, (_, _) => _tryPrefillRegion());
+      _tryPrefillRegion();
+    });
+  }
+
+  void _tryPrefillShip() {
+    if (_shipPrefilled) return;
+    final async = ref.read(activeShipTypeIdProvider);
+    if (async.hasValue) {
+      _applyShip(async.value);
+    } else if (async is AsyncError) {
+      _applyShip(null);
+    } else {
+      ref.listenManual(activeShipTypeIdProvider, (_, next) {
+        if (_shipPrefilled) return;
+        if (next.hasValue) {
+          _applyShip(next.value);
+        } else if (next is AsyncError) {
+          _applyShip(null);
+        }
+      });
+    }
+  }
+
+  void _applyShip(int? activeTypeId) {
+    if (_shipPrefilled) return;
+    _shipPrefilled = true;
+    if (ref.read(selectedShipTypeIdProvider) == null) {
+      ref.read(selectedShipTypeIdProvider.notifier).select(activeTypeId ?? 648);
+    }
+  }
+
+  void _tryPrefillRegion() {
+    if (_regionPrefilled) return;
+    final idAsync = ref.read(currentRegionIdProvider);
+    final regionsAsync = ref.read(regionsProvider);
+    final idReady = idAsync.hasValue || idAsync is AsyncError;
+    final regionsReady = regionsAsync.hasValue || regionsAsync is AsyncError;
+    if (!idReady || !regionsReady) return;
+
+    _regionPrefilled = true;
+    // Never override an explicit user choice.
+    if (ref.read(selectedRegionProvider) != null) return;
+
+    final regionId = idAsync.value;
+    final regions = regionsAsync.value;
+    if (regionId == null || regions == null) return; // no current → leave empty
+
+    Region? match;
+    for (final r in regions) {
+      if (r.id == regionId) {
+        match = r;
+        break;
+      }
+    }
+    if (match != null) {
+      ref.read(selectedRegionProvider.notifier).select(match);
+    }
+  }
+}

--- a/app/lib/features/trading/hauling_screen.dart
+++ b/app/lib/features/trading/hauling_screen.dart
@@ -20,6 +20,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../api/hauling_models.dart';
 import '../../core/breakpoint.dart';
+import 'current_selection_prefill.dart';
 import 'hauling_providers.dart';
 import 'providers.dart';
 import 'ship_select.dart';
@@ -124,10 +125,19 @@ class _InputForm extends ConsumerStatefulWidget {
   ConsumerState<_InputForm> createState() => _InputFormState();
 }
 
-class _InputFormState extends ConsumerState<_InputForm> {
+class _InputFormState extends ConsumerState<_InputForm>
+    with CurrentSelectionPrefill {
   final _capitalController = TextEditingController(text: '500000000');
   bool _avoidLowSec = true;
   String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    // Pre-fill the ship with the character's active ship (region unused here —
+    // hauling derives its origin region from the current location backend-side).
+    startSelectionPrefill();
+  }
 
   @override
   void dispose() {

--- a/app/lib/features/trading/roi_calculator_screen.dart
+++ b/app/lib/features/trading/roi_calculator_screen.dart
@@ -18,6 +18,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../api/portfolio_models.dart';
 import '../../api/trading_models.dart';
 import '../../core/breakpoint.dart';
+import 'current_selection_prefill.dart';
 import 'providers.dart';
 import 'roi_providers.dart';
 import 'ship_select.dart';
@@ -88,7 +89,8 @@ class _InputForm extends ConsumerStatefulWidget {
   ConsumerState<_InputForm> createState() => _InputFormState();
 }
 
-class _InputFormState extends ConsumerState<_InputForm> {
+class _InputFormState extends ConsumerState<_InputForm>
+    with CurrentSelectionPrefill {
   // Numeric inputs.
   final _capitalController = TextEditingController(text: '500000000');
   double _timeBudgetMin = 120;
@@ -101,6 +103,13 @@ class _InputFormState extends ConsumerState<_InputForm> {
   bool _nullSec = false;
 
   String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    // Pre-fill region + ship with the character's current region/active ship.
+    startSelectionPrefill();
+  }
 
   @override
   void dispose() {

--- a/app/lib/features/trading/trading_screen.dart
+++ b/app/lib/features/trading/trading_screen.dart
@@ -15,6 +15,7 @@ import '../../api/trading_models.dart';
 import '../../auth/auth_controller.dart';
 import '../../core/breakpoint.dart';
 import '../trading/providers.dart';
+import 'current_selection_prefill.dart';
 import 'route_detail.dart';
 import 'route_list.dart';
 import 'ship_fitting_card.dart';
@@ -33,51 +34,13 @@ class TradingScreen extends ConsumerStatefulWidget {
   ConsumerState<TradingScreen> createState() => _TradingScreenState();
 }
 
-class _TradingScreenState extends ConsumerState<TradingScreen> {
-  /// Whether the active-ship prefill has already been applied this session.
-  bool _activeShipPrefilled = false;
-
+class _TradingScreenState extends ConsumerState<TradingScreen>
+    with CurrentSelectionPrefill {
   @override
   void initState() {
     super.initState();
-    // Seed selectedShipTypeIdProvider from the active ship once the provider
-    // resolves — mirrors the web's `shipOverride ?? activeShip ?? 648`.
-    WidgetsBinding.instance.addPostFrameCallback((_) => _prefillActiveShip());
-  }
-
-  void _prefillActiveShip() {
-    if (_activeShipPrefilled) return;
-    final asyncActiveShip = ref.read(activeShipTypeIdProvider);
-
-    // Apply the prefill only ONCE the active ship has resolved (data or error).
-    // Mirrors the web's `shipOverride ?? activeShip ?? 648`: the 648 fallback
-    // must NOT be applied prematurely while the active ship is still loading,
-    // otherwise it blocks the real active ship (which can resolve late, e.g.
-    // after a 401→token-refresh) from ever being selected.
-    if (asyncActiveShip.hasValue) {
-      _applyShipPrefill(asyncActiveShip.value);
-    } else if (asyncActiveShip is AsyncError) {
-      _applyShipPrefill(null);
-    } else {
-      ref.listenManual(activeShipTypeIdProvider, (_, next) {
-        if (_activeShipPrefilled) return;
-        if (next.hasValue) {
-          _applyShipPrefill(next.value);
-        } else if (next is AsyncError) {
-          _applyShipPrefill(null);
-        }
-      });
-    }
-  }
-
-  /// Seeds [selectedShipTypeIdProvider] with the active ship (or 648 fallback)
-  /// once, never overwriting an explicit user choice.
-  void _applyShipPrefill(int? activeTypeId) {
-    if (_activeShipPrefilled) return;
-    _activeShipPrefilled = true;
-    if (ref.read(selectedShipTypeIdProvider) == null) {
-      ref.read(selectedShipTypeIdProvider.notifier).select(activeTypeId ?? 648);
-    }
+    // Seed region + ship from the character's current region/active ship once.
+    startSelectionPrefill();
   }
 
   @override

--- a/app/test/current_selection_prefill_test.dart
+++ b/app/test/current_selection_prefill_test.dart
@@ -1,0 +1,76 @@
+/// Verifies the CurrentSelectionPrefill mixin seeds the shared region + ship
+/// selection from the character's current region / active ship — once, and
+/// without overwriting an explicit prior choice.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/trading_models.dart';
+import 'package:eve_o_provit/features/character/providers.dart';
+import 'package:eve_o_provit/features/trading/current_selection_prefill.dart';
+import 'package:eve_o_provit/features/trading/providers.dart';
+
+// Minimal host widget that mounts the mixin.
+class _Host extends ConsumerStatefulWidget {
+  const _Host();
+  @override
+  ConsumerState<_Host> createState() => _HostState();
+}
+
+class _HostState extends ConsumerState<_Host> with CurrentSelectionPrefill {
+  @override
+  void initState() {
+    super.initState();
+    startSelectionPrefill();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+Future<void> _pump(WidgetTester tester, ProviderContainer container) async {
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: _Host()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  const regions = [
+    Region(id: 10000002, name: 'The Forge'),
+    Region(id: 10000042, name: 'Metropolis'),
+  ];
+
+  testWidgets('seeds region + ship from current values', (tester) async {
+    final c = ProviderContainer(overrides: [
+      activeShipTypeIdProvider.overrideWith((ref) async => 12005),
+      currentRegionIdProvider.overrideWith((ref) async => 10000042),
+      regionsProvider.overrideWith((ref) async => regions),
+    ]);
+    addTearDown(c.dispose);
+    await _pump(tester, c);
+
+    expect(c.read(selectedShipTypeIdProvider), 12005);
+    expect(c.read(selectedRegionProvider)?.id, 10000042);
+  });
+
+  testWidgets('falls back to ship 648 when no active ship; region stays null',
+      (tester) async {
+    final c = ProviderContainer(overrides: [
+      // Real provider returns null on error → mixin applies the 648 fallback.
+      activeShipTypeIdProvider.overrideWith((ref) async => null),
+      currentRegionIdProvider.overrideWith((ref) async => null),
+      regionsProvider.overrideWith((ref) async => regions),
+    ]);
+    addTearDown(c.dispose);
+    await _pump(tester, c);
+
+    expect(c.read(selectedShipTypeIdProvider), 648);
+    expect(c.read(selectedRegionProvider), isNull);
+  });
+}

--- a/frontend/src/app/hauling/page.tsx
+++ b/frontend/src/app/hauling/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/lib/auth-context";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -12,7 +12,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { ShipSelect } from "@/components/trading/ShipSelect";
 import { HaulingRouteList } from "@/components/trading/HaulingRouteList";
 import { SkillsAppliedPanel } from "@/components/trading/SkillsAppliedPanel";
-import { findHaulingRoutes } from "@/lib/api-client";
+import { fetchCharacterShip, findHaulingRoutes } from "@/lib/api-client";
 import { HaulingRequest } from "@/types/trading";
 import { Loader2 } from "lucide-react";
 
@@ -45,13 +45,26 @@ function buildRequest(form: HaulingFormState): HaulingRequest {
 function HaulingPageContent() {
   const { isAuthenticated } = useAuth();
   const [form, setForm] = useState<HaulingFormState>(defaultForm);
+  const [shipOverride, setShipOverride] = useState<string | null>(null);
+
+  // Pre-fill the ship with the character's current ship.
+  const { data: currentShip } = useQuery({
+    queryKey: ["characterShip", isAuthenticated],
+    queryFn: fetchCharacterShip,
+    enabled: isAuthenticated,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Effective ship: manual override > current ship > default (purely derived).
+  const selectedShip =
+    shipOverride ?? currentShip?.ship_type_id?.toString() ?? DEFAULT_SHIP;
 
   const haulingMutation = useMutation({
     mutationFn: (req: HaulingRequest) => findHaulingRoutes(req),
   });
 
   const handleSubmit = () => {
-    haulingMutation.mutate(buildRequest(form));
+    haulingMutation.mutate(buildRequest({ ...form, ship: selectedShip }));
   };
 
   const apiError = haulingMutation.isError
@@ -92,8 +105,8 @@ function HaulingPageContent() {
           }}
         >
           <ShipSelect
-            value={form.ship}
-            onChange={(v) => setForm((s) => ({ ...s, ship: v }))}
+            value={selectedShip}
+            onChange={setShipOverride}
             disabled={disabled}
             authenticated={isAuthenticated}
           />

--- a/frontend/src/app/roi-calculator/page.tsx
+++ b/frontend/src/app/roi-calculator/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/lib/auth-context";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -13,7 +13,11 @@ import {
 import { PortfolioResultTable } from "@/components/trading/PortfolioResultTable";
 import { DiversificationScore } from "@/components/trading/DiversificationScore";
 import { SkillsAppliedPanel } from "@/components/trading/SkillsAppliedPanel";
-import { optimizePortfolio } from "@/lib/api-client";
+import {
+  fetchCharacterLocation,
+  fetchCharacterShip,
+  optimizePortfolio,
+} from "@/lib/api-client";
 import { PortfolioRequest } from "@/types/trading";
 import { Loader2 } from "lucide-react";
 
@@ -52,13 +56,50 @@ function buildRequest(form: PortfolioFormState): PortfolioRequest {
 function ROICalculatorContent() {
   const { isAuthenticated } = useAuth();
   const [form, setForm] = useState<PortfolioFormState>(defaultForm);
+  // null = no manual choice yet; effective region/ship are derived below.
+  const [regionOverride, setRegionOverride] = useState<string | null>(null);
+  const [shipOverride, setShipOverride] = useState<string | null>(null);
+
+  // Load the character's current location + ship to pre-fill region/ship.
+  const { data: characterData } = useQuery({
+    queryKey: ["characterData", isAuthenticated],
+    queryFn: async () => {
+      const [location, ship] = await Promise.all([
+        fetchCharacterLocation(),
+        fetchCharacterShip(),
+      ]);
+      return { location, ship };
+    },
+    enabled: isAuthenticated,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Effective values: manual override > current character data > default.
+  // Purely derived (no effect), so the user's choice stays sticky.
+  const effectiveForm: PortfolioFormState = {
+    ...form,
+    region:
+      regionOverride ??
+      characterData?.location.region_id?.toString() ??
+      DEFAULT_REGION,
+    ship:
+      shipOverride ??
+      characterData?.ship.ship_type_id?.toString() ??
+      DEFAULT_SHIP,
+  };
+
+  const handleFormChange = (next: PortfolioFormState) => {
+    if (next.region !== effectiveForm.region) setRegionOverride(next.region);
+    if (next.ship !== effectiveForm.ship) setShipOverride(next.ship);
+    setForm(next);
+  };
 
   const optimizeMutation = useMutation({
     mutationFn: (req: PortfolioRequest) => optimizePortfolio(req),
   });
 
   const handleSubmit = () => {
-    optimizeMutation.mutate(buildRequest(form));
+    optimizeMutation.mutate(buildRequest(effectiveForm));
   };
 
   const apiError = optimizeMutation.isError
@@ -92,8 +133,8 @@ function ROICalculatorContent() {
       <div className="grid gap-6 lg:grid-cols-[340px_1fr]">
         {/* Input form */}
         <PortfolioInputForm
-          state={form}
-          onChange={setForm}
+          state={effectiveForm}
+          onChange={handleFormChange}
           onSubmit={handleSubmit}
           disabled={!isAuthenticated || optimizeMutation.isPending}
           loading={optimizeMutation.isPending}

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { buildAuthorizationUrl } from "./eve-sso";
 
 interface CharacterInfo {
@@ -37,6 +38,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [character, setCharacter] = useState<CharacterInfo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const queryClient = useQueryClient();
 
   const logout = useCallback(async () => {
     await fetch(`${API_BASE_URL}/auth/logout`, {
@@ -45,7 +47,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
     setIsAuthenticated(false);
     setCharacter(null);
-  }, []);
+    // Drop all cached per-character data (location, ship, …) so the next login
+    // in the same browser can't be served the previous character's data.
+    queryClient.clear();
+  }, [queryClient]);
 
   const checkSession = useCallback(async () => {
     try {

--- a/frontend/tests/hooks/useAuth.test.tsx
+++ b/frontend/tests/hooks/useAuth.test.tsx
@@ -1,6 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
 import { AuthProvider, useAuth } from "@/lib/auth-context";
+
+// AuthProvider uses useQueryClient(); wrap it in a QueryClientProvider.
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <AuthProvider>{children}</AuthProvider>
+    </QueryClientProvider>
+  );
+}
 
 vi.mock("@/lib/eve-sso", () => ({
   buildAuthorizationUrl: vi.fn(async () => "https://login.eveonline.com/authorize?mock=1"),
@@ -39,7 +51,7 @@ describe("useAuth Hook (cookie session)", () => {
 
   it("returns the auth context within AuthProvider", async () => {
     vi.stubGlobal("fetch", mockFetchSession(false));
-    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
     expect(result.current).toBeDefined();
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.character).toBeNull();
@@ -55,7 +67,7 @@ describe("useAuth Hook (cookie session)", () => {
   it("checks the session on mount via GET /auth/session with credentials", async () => {
     const fetchMock = mockFetchSession(false);
     vi.stubGlobal("fetch", fetchMock);
-    renderHook(() => useAuth(), { wrapper: AuthProvider });
+    renderHook(() => useAuth(), { wrapper: Wrapper });
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalled();
     });
@@ -66,7 +78,7 @@ describe("useAuth Hook (cookie session)", () => {
 
   it("populates character and isAuthenticated for an authenticated session", async () => {
     vi.stubGlobal("fetch", mockFetchSession(true));
-    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
     await waitFor(() => {
       expect(result.current.isAuthenticated).toBe(true);
     });
@@ -77,7 +89,7 @@ describe("useAuth Hook (cookie session)", () => {
   it("logout calls POST /auth/logout and clears the character", async () => {
     const fetchMock = mockFetchSession(true);
     vi.stubGlobal("fetch", fetchMock);
-    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
     await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
 
     await result.current.logout();
@@ -97,7 +109,7 @@ describe("useAuth Hook (cookie session)", () => {
     delete (window as unknown as { location?: unknown }).location;
     (window as unknown as { location: { href: string } }).location = { href: "" };
 
-    const { result } = renderHook(() => useAuth(), { wrapper: AuthProvider });
+    const { result } = renderHook(() => useAuth(), { wrapper: Wrapper });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     await result.current.login();


### PR DESCRIPTION
## Summary
Wherever there's a **region** or **ship** selector, default it to the character's **current region** / **active ship** on open (one-time, then the user's choice stays sticky; fallback Forge/648 when not logged in or ESI is unreachable).

- **Web Trading** already did this — now consistent everywhere.
- **Web ROI + Hauling**: load current location/ship, derive the effective region/ship (no `setState`-in-effect — uses the override-derive pattern to satisfy `react-hooks/set-state-in-effect`).
- **Flutter Trading + ROI + Hauling**: new `currentRegionIdProvider` (from `GET /character/location`) + a shared `CurrentSelectionPrefill` mixin that seeds the shared `selectedRegionProvider` / `selectedShipTypeIdProvider` once. Flutter Trading previously prefilled only the ship — now region too.
- **Hauling** keeps deriving its origin region backend-side (`origin_region_id:0` = current region); only the ship is prefilled there (no region selector).

No backend change.

## Test plan
- [x] Web: Vitest 62/62; ESLint + tsc clean on touched files
- [x] Flutter: `flutter analyze` clean; full suite 186/186 incl. new `current_selection_prefill_test.dart` (seeds from current; 648 fallback / region stays null when unavailable)
- [ ] CI green
- [ ] On-device: open ROI/Hauling → region = current, ship = active

🤖 Generated with [Claude Code](https://claude.com/claude-code)