### PR TITLE
fix: ship cargo affects ROI — default fitting uses base cargo, not 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Schiffswahl ohne Wirkung bei nicht besessenen Schiffen (ROI/Trading).** Wählte man ein Schiff, das der Character nicht im Besitz hat (kein abrufbares Fitting), lieferte `getDefaultFitting` eine Cargo-Kapazität von **0** statt der Hüllen-Basiskapazität. Dadurch rechnete der Route-/ROI-Optimizer für *jedes* solche Schiff mit 0 m³ → identisches (degeneriertes) Ergebnis, egal ob 400 m³ oder 5800 m³. `getDefaultFitting` nutzt jetzt das schiffsspezifische Basis-Cargo aus der SDE, sodass die Schiffsgröße wieder korrekt in Einheiten/Fahrt → Fahrten/Tag → Tagesgewinn eingeht.
+
 ## [0.12.3] - 2026-05-29
 
 ### Fixed

--- a/backend/internal/services/fitting_service.go
+++ b/backend/internal/services/fitting_service.go
@@ -571,18 +571,26 @@ func (s *FittingService) getShipBaseAttributes(ctx context.Context, shipTypeID i
 
 // getDefaultFitting returns empty fitting with no bonuses (graceful degradation)
 func (s *FittingService) getDefaultFitting(shipTypeID int) *FittingData {
+	// No player fitting available (ship not owned / ESI failure). Fall back to
+	// the hull's BASE cargo from the SDE so callers still get a ship-specific
+	// capacity — returning 0 here would make every such ship look identical
+	// (and break route/ROI calc, which divides cargo by item volume).
+	baseCargo := 0.0
+	if caps, err := cargo.GetShipCapacities(s.sdeDB, int64(shipTypeID), nil); err == nil && caps != nil {
+		baseCargo = caps.BaseCargoHold
+	}
 	return &FittingData{
 		ShipTypeID:    shipTypeID,
 		FittedModules: []FittedModule{},
 		Bonuses: FittingBonuses{
-			CargoBonus:          0.0,
+			CargoBonus:          baseCargo,
 			WarpSpeedMultiplier: 1.0,
 			InertiaModifier:     1.0,
-			BaseCargo:           0.0,
+			BaseCargo:           baseCargo,
 			SkillsBonusM3:       0.0,
 			SkillsBonusPct:      0.0,
 			ModulesBonusM3:      0.0,
-			EffectiveCargo:      0.0,
+			EffectiveCargo:      baseCargo,
 		},
 	}
 }


### PR DESCRIPTION
## Summary
Reported: in the ROI calculator, choosing a 400 m³ ship vs a 5800 m³ ship gave the **same** result — ship size had no effect.

**Root cause:** when the character doesn't own the selected ship (no fitting fetchable from ESI), `FittingService.getDefaultFitting` returned a fitting with `EffectiveCargo = 0`. The route/ROI optimizer computes `units_per_trip = cargo ÷ item_volume`, so a cargo of 0 makes every such ship degenerate to the same (empty/zero) allocation — regardless of the ship's real hull size. Both 400 m³ and 5800 m³ ships resolved to 0 → identical output.

**Fix:** `getDefaultFitting` now falls back to the hull's base cargo from the SDE (`cargo.GetShipCapacities`) instead of 0. Verified against the SDE: Imicus → 400, Nereus → 2700, Iteron Mark V → 5800 (matching the dropdown). Owned ships still use their real skill/fitting-adjusted effective cargo; only the no-fitting fallback changed.

No frontend change.

## Test plan
- [x] `gofmt`/`go vet` clean; `go test -short ./internal/services` pass; `go build ./...`
- [x] SDE check: base cargo is ship-specific (Imicus 400 / Iteron 5800)
- [ ] CI green
- [ ] Post-deploy: ROI with a small vs large (non-owned) ship now yields different units/trips/profit

🤖 Generated with [Claude Code](https://claude.com/claude-code)