### PR TITLE
feat: ship warp speed + align time factor into route/ROI travel time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Routen-/ROI-Reisezeit nutzt jetzt die schiff-/fitting-/skill-spezifische Warp-Geschwindigkeit und Align-Zeit.** Bisher rechnete der Routen-/ROI-Pfad die Reisezeit mit festen Default-Werten (3,0 AU/s Warp, 6 s Align) — die Agilität/Geschwindigkeit des Schiffs spielte keine Rolle. `applyCharacterSkills` liefert jetzt zusätzlich die deterministisch berechnete effektive Warp-Geschwindigkeit (AU/s) und Align-Zeit aus dem Fitting (Skills + Module) und speist sie in `CalculateTravelTime` ein; `getDefaultFitting` (nicht besessene Schiffe) liefert die Basis-Werte der Hülle. Dadurch schaffen schnellere, agilere Schiffe korrekt mehr Fahrten im Zeitbudget (z.B. Iteron Mark V align ~16 s vs. Imicus ~6 s). Explizite Request-Parameter haben weiterhin Vorrang.
+
 ## [0.12.4] - 2026-05-29
 
 ### Fixed

--- a/backend/internal/services/fitting_service.go
+++ b/backend/internal/services/fitting_service.go
@@ -575,9 +575,19 @@ func (s *FittingService) getDefaultFitting(shipTypeID int) *FittingData {
 	// the hull's BASE cargo from the SDE so callers still get a ship-specific
 	// capacity — returning 0 here would make every such ship look identical
 	// (and break route/ROI calc, which divides cargo by item volume).
+	ctx := context.Background()
 	baseCargo := 0.0
 	if caps, err := cargo.GetShipCapacities(s.sdeDB, int64(shipTypeID), nil); err == nil && caps != nil {
 		baseCargo = caps.BaseCargoHold
+	}
+	// Also derive the hull's base warp speed + align time (no skills/modules) so
+	// route/ROI travel time is ship-specific even without a player fitting.
+	warpAUS, alignTime := 0.0, 0.0
+	if ws, err := navigation.GetShipWarpSpeedDeterministic(ctx, s.sdeDB, int64(shipTypeID), nil, nil); err == nil && ws != nil {
+		warpAUS = ws.EffectiveWarpSpeed
+	}
+	if ir, err := navigation.GetShipInertiaDeterministic(ctx, s.sdeDB, int64(shipTypeID), nil, nil); err == nil && ir != nil {
+		alignTime = ir.AlignTime
 	}
 	return &FittingData{
 		ShipTypeID:    shipTypeID,
@@ -586,11 +596,13 @@ func (s *FittingService) getDefaultFitting(shipTypeID int) *FittingData {
 			CargoBonus:          baseCargo,
 			WarpSpeedMultiplier: 1.0,
 			InertiaModifier:     1.0,
+			AlignTime:           alignTime,
 			BaseCargo:           baseCargo,
 			SkillsBonusM3:       0.0,
 			SkillsBonusPct:      0.0,
 			ModulesBonusM3:      0.0,
 			EffectiveCargo:      baseCargo,
+			WarpSpeedAUS:        warpAUS,
 		},
 	}
 }

--- a/backend/internal/services/route_service.go
+++ b/backend/internal/services/route_service.go
@@ -135,10 +135,21 @@ func (rs *RouteService) Calculate(ctx context.Context, regionID, shipTypeID int,
 		}
 		baseCapacity = shipCap.BaseCargoHold
 
-		// Apply character skills and fitting (required - no fallback)
-		effectiveCapacity, skillBonusPercent, fittingBonusM3 = rs.applyCharacterSkills(calcCtx, baseCapacity, shipTypeID)
+		// Apply character skills and fitting (cargo + warp speed + align time).
+		var shipWarpAUS, shipAlign float64
+		effectiveCapacity, shipWarpAUS, shipAlign, skillBonusPercent, fittingBonusM3 = rs.applyCharacterSkills(calcCtx, baseCapacity, shipTypeID)
 
 		cargoCapacity = effectiveCapacity
+
+		// Feed the ship's deterministic warp speed / align time into the travel-time
+		// calc so faster, more agile ships do more trips per time budget. Explicit
+		// request params (if any) take precedence; otherwise use the ship's values.
+		if warpSpeed == nil && shipWarpAUS > 0 {
+			warpSpeed = &shipWarpAUS
+		}
+		if alignTime == nil && shipAlign > 0 {
+			alignTime = &shipAlign
+		}
 	} else {
 		// Capacity was provided explicitly - use as both base and effective
 		baseCapacity = cargoCapacity
@@ -324,10 +335,12 @@ func (rs *RouteService) getRegionName(ctx context.Context, regionID int) (string
 	return rs.sdeRepo.GetRegionName(ctx, regionID)
 }
 
-// applyCharacterSkills extracts character context and applies skills to cargo capacity
-// Returns (effectiveCapacity, skillBonusPercent, fittingBonusM3)
-// Requires character authentication in context
-func (rs *RouteService) applyCharacterSkills(ctx context.Context, baseCapacity float64, shipTypeID int) (float64, float64, float64) {
+// applyCharacterSkills extracts character context and applies skills + fitting to the
+// ship's cargo capacity, warp speed and align time (all deterministic, from FittingService).
+// Returns (effectiveCapacity, warpSpeedAUS, alignTime, skillBonusPercent, fittingBonusM3).
+// warpSpeedAUS/alignTime are 0 when unavailable (caller then falls back to nav defaults).
+// Requires character authentication in context.
+func (rs *RouteService) applyCharacterSkills(ctx context.Context, baseCapacity float64, shipTypeID int) (float64, float64, float64, float64, float64) {
 	// Extract character_id (required - no fallback)
 	characterID := ctx.Value(contextKeyCharacterID)
 	accessToken := ctx.Value(contextKeyAccessToken)
@@ -335,7 +348,7 @@ func (rs *RouteService) applyCharacterSkills(ctx context.Context, baseCapacity f
 	if characterID == nil || accessToken == nil {
 		// This should never happen if AuthMiddleware is properly configured
 		log.Printf("ERROR: Missing character context in applyCharacterSkills")
-		return baseCapacity, 0.0, 0.0
+		return baseCapacity, 0.0, 0.0, 0.0, 0.0
 	}
 
 	charID, ok1 := characterID.(int)
@@ -343,20 +356,20 @@ func (rs *RouteService) applyCharacterSkills(ctx context.Context, baseCapacity f
 
 	if !ok1 || !ok2 || charID <= 0 || token == "" {
 		log.Printf("ERROR: Invalid character context types")
-		return baseCapacity, 0.0, 0.0
+		return baseCapacity, 0.0, 0.0, 0.0, 0.0
 	}
 
-	// Get deterministic cargo capacity directly from FittingService
+	// Get deterministic cargo + warp speed + align time from FittingService (skills + modules).
 	fitting, err := rs.fittingService.GetShipFitting(ctx, charID, shipTypeID, token)
 	if err != nil {
 		log.Printf("ERROR: Failed to get ship fitting: %v", err)
-		return baseCapacity, 0.0, 0.0
+		return baseCapacity, 0.0, 0.0, 0.0, 0.0
 	}
 
 	totalCapacity := fitting.Bonuses.EffectiveCargo
 
-	log.Printf("Applied cargo capacity: base=%.2f, total=%.2f m³",
-		baseCapacity, totalCapacity)
+	log.Printf("Applied cargo=%.2f m³ (base=%.2f), warp=%.2f AU/s, align=%.2fs",
+		totalCapacity, baseCapacity, fitting.Bonuses.WarpSpeedAUS, fitting.Bonuses.AlignTime)
 
-	return totalCapacity, 0.0, 0.0
+	return totalCapacity, fitting.Bonuses.WarpSpeedAUS, fitting.Bonuses.AlignTime, 0.0, 0.0
 }


### PR DESCRIPTION
## Summary
Follow-up to the cargo fix. The route/ROI travel-time calc used **fixed navigation defaults** (3.0 AU/s warp, 6 s align), so a ship's agility/speed never affected the result — only cargo did. A fast frigate and a slow freighter on the same route were modeled with identical trip time.

**Change:** `applyCharacterSkills` now also returns the ship's deterministic **effective warp speed (AU/s)** and **align time** from the FittingService (skills + fitted modules), and `Calculate` feeds them into `CalculateTravelTime`. `getDefaultFitting` (ships the character doesn't own) supplies the hull's base warp/align from the SDE, so travel time is ship-specific even without a player fitting. Explicit request nav params still take precedence.

**Effect:** faster, more agile ships now complete more trips within the time budget → higher daily profit when time is the binding constraint. Verified against the SDE: Iteron Mark V → warp 3.5 AU/s / align ~16 s, Imicus → warp 5.0 / align ~6 s, Crow → warp 5.0 / align ~5 s.

No frontend change.

## Test plan
- [x] `gofmt`/`go vet` clean; `go build ./...`; `go test -short ./internal/services ./pkg/evedb/...` pass
- [x] SDE check: deterministic warp/align are ship-specific (Iteron vs Imicus vs Crow)
- [ ] CI green
- [ ] Post-deploy: ROI A/B — a fast vs slow ship (similar cargo) now yields different trips/day

🤖 Generated with [Claude Code](https://claude.com/claude-code)