### PR TITLE
feat(roi): prefill capital with character wallet balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ROI-Kapital wird mit dem echten Wallet-Kontostand vorbefüllt.** Neuer Endpoint `GET /api/v1/character/wallet` (ESI `/characters/{id}/wallet/`, 60 s gecacht) liefert den ISK-Stand; ROI-Rechner (Web + Flutter) befüllt das Kapital-Feld damit vor — überschreibbar nach dem `override ?? wallet ?? default`-Muster, das Region/Schiff schon nutzen. Erfordert den neuen Scope `esi-wallet.read_character_wallet.v1`; der Wallet-Abruf ist fehlertolerant (Charaktere, die vor der Scope-Erweiterung autorisiert haben, fallen auf den Default zurück).
+
+### Changed
+
+- **SSO fragt zusätzlich `esi-wallet.read_character_wallet.v1` an** (Web + Mobile). **Achtung:** Der Scope muss in beiden EVE-App-Registrierungen auf developers.eveonline.com aktiviert sein, bevor diese Version deployt wird — sonst schlägt der Login fehl. Bestehende Nutzer müssen die App neu autorisieren.
+
 ## [0.12.7] - 2026-05-29
 
 ### Changed

--- a/app/lib/core/env.dart
+++ b/app/lib/core/env.dart
@@ -12,5 +12,6 @@ class Env {
     'esi-clones.read_clones.v1',
     'esi-assets.read_assets.v1',
     'esi-ui.write_waypoint.v1',
+    'esi-wallet.read_character_wallet.v1',
   ];
 }

--- a/app/lib/features/character/character_api.dart
+++ b/app/lib/features/character/character_api.dart
@@ -41,6 +41,16 @@ class CharacterApi {
     return v is num ? v.toInt() : null;
   }
 
+  // ── GET /api/v1/character/wallet ───────────────────────────────────────────
+
+  /// Returns the character's wallet balance in ISK. Used to pre-fill ROI capital.
+  Future<double> walletBalance() async {
+    final response =
+        await _dio.get<Map<String, dynamic>>('/api/v1/character/wallet');
+    final v = response.data?['balance'];
+    return v is num ? v.toDouble() : 0;
+  }
+
   // ── GET /api/v1/character/ships ────────────────────────────────────────────
 
   /// Returns all ships in the character's current hangar.

--- a/app/lib/features/character/providers.dart
+++ b/app/lib/features/character/providers.dart
@@ -41,6 +41,20 @@ final activeShipProvider = FutureProvider<CharacterShip>((ref) async {
   return api.activeShip();
 });
 
+/// Character's wallet balance in ISK; null when not authenticated or on error
+/// (e.g. the character authorized before the wallet scope was added). Used to
+/// pre-fill the ROI capital field.
+final walletBalanceProvider = FutureProvider<double?>((ref) async {
+  final auth = ref.watch(authControllerProvider).value;
+  if (auth is! Authenticated) return null;
+  final api = ref.watch(characterApiProvider);
+  try {
+    return await api.walletBalance();
+  } catch (_) {
+    return null;
+  }
+});
+
 /// Region ID of the character's current solar system; null on error.
 /// Used to pre-fill region selectors with the current region.
 final currentRegionIdProvider = FutureProvider<int?>((ref) async {

--- a/app/lib/features/trading/roi_calculator_screen.dart
+++ b/app/lib/features/trading/roi_calculator_screen.dart
@@ -19,6 +19,7 @@ import '../../api/portfolio_models.dart';
 import '../../api/trading_models.dart';
 import '../../core/breakpoint.dart';
 import '../../core/format.dart';
+import '../character/providers.dart';
 import 'current_selection_prefill.dart';
 import 'providers.dart';
 import 'roi_providers.dart';
@@ -105,11 +106,30 @@ class _InputFormState extends ConsumerState<_InputForm>
 
   String? _error;
 
+  // Wallet → capital prefill: apply once, and never over an explicit user edit
+  // (mirrors the region/ship `override ?? current ?? default` semantics).
+  bool _capitalPrefilled = false;
+  bool _capitalUserEdited = false;
+
   @override
   void initState() {
     super.initState();
     // Pre-fill region + ship with the character's current region/active ship.
     startSelectionPrefill();
+    // Pre-fill capital with the character's wallet balance.
+    ref.listenManual(walletBalanceProvider, (_, _) => _tryPrefillCapital());
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => _tryPrefillCapital());
+  }
+
+  void _tryPrefillCapital() {
+    if (_capitalPrefilled || _capitalUserEdited) return;
+    final async = ref.read(walletBalanceProvider);
+    if (!async.hasValue && async is! AsyncError) return; // still loading
+    _capitalPrefilled = true;
+    final balance = async.value;
+    if (balance == null || balance <= 0) return; // no wallet → keep default
+    _capitalController.text = balance.floor().toString();
   }
 
   @override
@@ -214,6 +234,7 @@ class _InputFormState extends ConsumerState<_InputForm>
           enabled: !busy,
           keyboardType: TextInputType.number,
           inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          onChanged: (_) => _capitalUserEdited = true,
           decoration: const InputDecoration(
             labelText: 'Kapital',
             border: OutlineInputBorder(),

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -169,6 +169,7 @@ func setupApp(c *AppContainer) *fiber.App {
 	protected.Get("/character/location", c.TradingHandler.GetCharacterLocation)
 	protected.Get("/character/ship", c.TradingHandler.GetCharacterShip)
 	protected.Get("/character/ships", c.TradingHandler.GetCharacterShips)
+	protected.Get("/character/wallet", c.TradingHandler.GetCharacterWallet)
 
 	protected.Get("/characters/:characterId/skills", c.CharacterHandler.GetCharacterSkills)
 	protected.Get("/characters/:characterId/fitting/:shipTypeId", c.FittingHandler.GetCharacterFitting)

--- a/backend/internal/handlers/trading.go
+++ b/backend/internal/handlers/trading.go
@@ -261,6 +261,38 @@ func (h *TradingHandler) GetCharacterShips(c *fiber.Ctx) error {
 	return c.JSON(ships)
 }
 
+// GetCharacterWallet handles GET /api/v1/character/wallet
+//
+// @Summary Get character wallet balance
+// @Description Get the authenticated character's wallet balance in ISK (used to prefill ROI capital)
+// @Tags Character
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {object} map[string]interface{} "Object with balance (float, ISK)"
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/character/wallet [get]
+func (h *TradingHandler) GetCharacterWallet(c *fiber.Ctx) error {
+	characterID, ok := c.Locals("character_id").(int)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
+	}
+	accessToken, ok := c.Locals("access_token").(string)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
+	}
+
+	balance, err := h.characterHelper.GetWalletBalance(c.Context(), characterID, accessToken)
+	if err != nil {
+		log.Printf("ERROR: GetCharacterWallet failed for characterID=%d: %v", characterID, err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to fetch wallet balance",
+		})
+	}
+
+	return c.JSON(fiber.Map{"balance": balance})
+}
+
 // SetAutopilotWaypoint handles POST /api/v1/esi/ui/autopilot/waypoint
 // Sets a waypoint in the EVE client's autopilot via ESI UI API
 //

--- a/backend/internal/handlers/trading_test.go
+++ b/backend/internal/handlers/trading_test.go
@@ -433,6 +433,23 @@ func TestCharacterEndpoints_Authentication(t *testing.T) {
 	t.Skip("Authentication tests require integration test setup with middleware")
 }
 
+// TestGetCharacterWallet_RequiresAuth tests that the wallet endpoint rejects
+// requests without authentication locals (set by middleware in production).
+func TestGetCharacterWallet_RequiresAuth(t *testing.T) {
+	app := fiber.New()
+	handler := &TradingHandler{}
+	app.Get("/wallet", handler.GetCharacterWallet)
+
+	req := httptest.NewRequest("GET", "/wallet", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Failed to execute request: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("Status code = %v, want %v", resp.StatusCode, fiber.StatusUnauthorized)
+	}
+}
+
 // TestResponseStructures tests that response structures are correct
 func TestResponseStructures(t *testing.T) {
 	t.Run("RouteCalculationResponse", func(t *testing.T) {

--- a/backend/internal/services/character_helper.go
+++ b/backend/internal/services/character_helper.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -173,6 +174,49 @@ func (h *CharacterHelper) GetActiveShipTypeID(ctx context.Context, characterID i
 		return 0, err
 	}
 	return ship.ShipTypeID, nil
+}
+
+// GetWalletBalance returns the character's wallet balance in ISK
+// (ESI /characters/{id}/wallet/). Cached briefly so the ROI capital prefill
+// doesn't hit ESI on every screen open. Never returns 0 on failure — the
+// caller must distinguish "broke" from "lookup failed".
+func (h *CharacterHelper) GetWalletBalance(ctx context.Context, characterID int, accessToken string) (float64, error) {
+	cacheKey := fmt.Sprintf("character_wallet:%d", characterID)
+
+	if cached, err := h.redisClient.Get(ctx, cacheKey).Result(); err == nil {
+		if balance, perr := strconv.ParseFloat(cached, 64); perr == nil {
+			return balance, nil
+		}
+	}
+
+	url := fmt.Sprintf("https://esi.evetech.net/latest/characters/%d/wallet/", characterID)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("ESI wallet API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var balance float64
+	if err := json.NewDecoder(resp.Body).Decode(&balance); err != nil {
+		return 0, err
+	}
+
+	// Balance changes often; the prefill tolerates ~1 min of staleness.
+	h.redisClient.Set(ctx, cacheKey, strconv.FormatFloat(balance, 'f', -1, 64), 60*time.Second)
+
+	return balance, nil
 }
 
 // CalculateTaxRate calculates broker fee + sales tax based on character skills

--- a/backend/internal/services/character_helper_test.go
+++ b/backend/internal/services/character_helper_test.go
@@ -298,6 +298,46 @@ func TestGetCharacterLocation_InSpace(t *testing.T) {
 	assert.Nil(t, result.StructureID)
 }
 
+// TestGetWalletBalance_CacheHit tests wallet retrieval with cache hit (no ESI call)
+func TestGetWalletBalance_CacheHit(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+	defer redisClient.Close()
+
+	helper := NewCharacterHelper(redisClient)
+	ctx := context.Background()
+
+	cacheKey := "character_wallet:12345"
+	s.Set(cacheKey, "1234567.89")
+	s.SetTTL(cacheKey, 60*time.Second)
+
+	balance, err := helper.GetWalletBalance(ctx, 12345, "fake-token")
+	require.NoError(t, err)
+	assert.InDelta(t, 1234567.89, balance, 0.001)
+}
+
+// TestGetWalletBalance_EmptyCache tests wallet fetch with cache miss (ESI unavailable → error)
+func TestGetWalletBalance_EmptyCache(t *testing.T) {
+	s := miniredis.RunT(t)
+	defer s.Close()
+
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: s.Addr(),
+	})
+	defer redisClient.Close()
+
+	helper := NewCharacterHelper(redisClient)
+	ctx := context.Background()
+
+	// No cache entry and ESI is not mocked → must error, never silently return 0.
+	_, err := helper.GetWalletBalance(ctx, 12345, "fake-token")
+	assert.Error(t, err, "Should error when ESI is not available and cache is empty")
+}
+
 // TestCharacterSkill_Marshaling tests JSON marshaling of character skills
 func TestCharacterSkill_Marshaling(t *testing.T) {
 	skill := CharacterSkill{

--- a/frontend/src/app/roi-calculator/page.tsx
+++ b/frontend/src/app/roi-calculator/page.tsx
@@ -16,6 +16,7 @@ import { SkillsAppliedPanel } from "@/components/trading/SkillsAppliedPanel";
 import {
   fetchCharacterLocation,
   fetchCharacterShip,
+  fetchCharacterWallet,
   optimizePortfolio,
 } from "@/lib/api-client";
 import { PortfolioRequest } from "@/types/trading";
@@ -56,19 +57,23 @@ function buildRequest(form: PortfolioFormState): PortfolioRequest {
 function ROICalculatorContent() {
   const { isAuthenticated } = useAuth();
   const [form, setForm] = useState<PortfolioFormState>(defaultForm);
-  // null = no manual choice yet; effective region/ship are derived below.
+  // null = no manual choice yet; effective region/ship/capital are derived below.
   const [regionOverride, setRegionOverride] = useState<string | null>(null);
   const [shipOverride, setShipOverride] = useState<string | null>(null);
+  const [capitalOverride, setCapitalOverride] = useState<number | null>(null);
 
-  // Load the character's current location + ship to pre-fill region/ship.
+  // Load the character's current location + ship + wallet to pre-fill the form.
   const { data: characterData } = useQuery({
     queryKey: ["characterData", isAuthenticated],
     queryFn: async () => {
-      const [location, ship] = await Promise.all([
+      const [location, ship, wallet] = await Promise.all([
         fetchCharacterLocation(),
         fetchCharacterShip(),
+        // Wallet needs the (newer) wallet scope; tolerate its absence so a
+        // character authorized before the scope was added still works.
+        fetchCharacterWallet().catch(() => null),
       ]);
-      return { location, ship };
+      return { location, ship, wallet };
     },
     enabled: isAuthenticated,
     staleTime: 5 * 60 * 1000,
@@ -86,11 +91,18 @@ function ROICalculatorContent() {
       shipOverride ??
       characterData?.ship.ship_type_id?.toString() ??
       DEFAULT_SHIP,
+    capital:
+      capitalOverride ??
+      (characterData?.wallet != null
+        ? Math.floor(characterData.wallet)
+        : form.capital),
   };
 
   const handleFormChange = (next: PortfolioFormState) => {
     if (next.region !== effectiveForm.region) setRegionOverride(next.region);
     if (next.ship !== effectiveForm.ship) setShipOverride(next.ship);
+    if (next.capital !== effectiveForm.capital)
+      setCapitalOverride(next.capital);
     setForm(next);
   };
 

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -80,6 +80,22 @@ export async function fetchCharacterShip(): Promise<CharacterShip> {
 }
 
 /**
+ * Fetch character's wallet balance in ISK (requires authentication)
+ */
+export async function fetchCharacterWallet(): Promise<number> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/character/wallet`, {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch wallet balance: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as { balance: number };
+  return data.balance;
+}
+
+/**
  * Fetch all character ships in hangars (requires authentication)
  */
 export async function fetchCharacterShips(): Promise<Ship[]> {

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -32,6 +32,7 @@ const EVE_SCOPES: string[] = [
   "esi-assets.read_assets.v1",
   "esi-ui.write_waypoint.v1",
   "esi-skills.read_skills.v1",
+  "esi-wallet.read_character_wallet.v1",
 ];
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

ROI-Rechner befüllt das Kapital-Feld mit dem echten Wallet-Kontostand des Characters vor (statt fixem 500 M Default).

- **Backend:** neuer Endpoint `GET /api/v1/character/wallet` → `CharacterHelper.GetWalletBalance` (ESI `/characters/{id}/wallet/`, 60 s Redis-Cache, kein stiller 0-Fallback). TDD: Cache-Hit + Cache-Miss-Helper-Tests, Handler-Auth-Guard-Test.
- **Web + Flutter:** Kapital wird mit dem Wallet-Stand vorbefüllt, überschreibbar nach `override ?? wallet ?? default` (gleiches Muster wie Region/Schiff). Wallet-Abruf ist fehlertolerant — wer vor der Scope-Erweiterung autorisiert hat, fällt sauber auf den Default zurück.

## ⚠️ Deploy-Gate (Aktion erforderlich)

Es kommt der neue Scope `esi-wallet.read_character_wallet.v1` dazu (Web + Mobile SSO). **Vor dem Deploy** muss dieser Scope in **beiden** EVE-App-Registrierungen auf developers.eveonline.com aktiviert sein (Web-Client `4d0514c2…`, Mobile-Client `32626…`), sonst schlägt der Login für alle fehl. Bestehende Nutzer müssen die App **neu autorisieren**.

## Test plan

- [x] Backend `go test ./internal/services/ ./internal/handlers/` — grün; `gofmt`/`go vet` clean
- [x] `flutter analyze lib/` clean · `flutter test` — 187 passed
- [x] `npx vitest run` — 62 passed · `npx eslint src/` clean
- [ ] CI grün
- [ ] EVE-App-Scope aktiviert (Web + Mobile) — **vor Merge/Deploy**
- [ ] Nach Deploy: on-device E2E (Re-Login mit neuem Scope, ROI-Kapital = Wallet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)