### PR TITLE
fix(sell-assets): no crash when item is in a player structure

### DIFF
--- a/backend/internal/services/asset_sale_service.go
+++ b/backend/internal/services/asset_sale_service.go
@@ -142,9 +142,14 @@ func (s *AssetSaleService) SellOptions(ctx context.Context, req *models.SellOpti
 		name = info.Name
 	}
 
+	// Options is always a (possibly empty) slice — never nil — so the JSON
+	// response stays a JSON array. A nil slice marshals as `null`, which crashes
+	// clients that call .length on the result (saw this when 296 × Shield Power
+	// Relay I sat in a player structure → origin unresolvable → empty path).
 	resp := &models.SellOptionsResponse{
 		TypeID: req.TypeID, Name: name, Quantity: req.Quantity,
 		SkillsApplied: skillsApplied,
+		Options:       []models.SellOption{},
 	}
 
 	originSys, err := s.sdeRepo.GetSystemIDForLocation(ctx, req.LocationID)

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -1,8 +1,10 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -174,6 +176,44 @@ func TestAssetSaleService_ListAssets_Aggregates(t *testing.T) {
 	}
 	if res.Assets[0].SystemID != 30000142 || res.Assets[0].RegionID != 10000002 {
 		t.Fatalf("location not resolved: %+v", res.Assets[0])
+	}
+}
+
+// TestAssetSaleService_SellOptions_UnresolvableOrigin_ReturnsEmptySlice
+// covers the player-structure / citadel case: GetSystemIDForLocation fails →
+// we return early. The Options field MUST be a non-nil slice (JSON []), never
+// nil (would marshal as JSON null and crash the web client on options.length).
+// Reported: 296× Shield Power Relay I in a player structure crashed sell-assets.
+func TestAssetSaleService_SellOptions_UnresolvableOrigin_ReturnsEmptySlice(t *testing.T) {
+	sde := newAssetTestSDE(t)
+	defer sde.Close()
+	repo := database.NewSDERepository(sde)
+	svc := NewAssetSaleService(
+		fakeAssetSkills{},
+		fakeHubFetcher{ordersByRegion: map[int][]esi.ESIMarketOrder{}},
+		fakeTypeNamer{name: "Shield Power Relay I", marketable: true},
+		fakeAssetFetcher{},
+		fakeFitting{}, fakeActiveShip{}, repo, sde, applogger.New(),
+	)
+	// LocationID that isn't in the SDE (mimics a player structure / citadel).
+	req := &models.SellOptionsRequest{TypeID: 1183, LocationID: 1_040_000_000_000, Quantity: 296}
+	res, err := svc.SellOptions(context.Background(), req, 1, "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Options == nil {
+		t.Fatal("Options must be an empty slice, not nil (JSON null breaks the web client)")
+	}
+	if len(res.Options) != 0 {
+		t.Fatalf("Options should be empty for unresolvable origin, got %d entries", len(res.Options))
+	}
+	// And the JSON encoding must contain `"options":[]`, never `"options":null`.
+	blob, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(blob, []byte(`"options":[]`)) {
+		t.Fatalf("expected JSON to contain `\"options\":[]`, got: %s", string(blob))
 	}
 }
 

--- a/frontend/src/components/trading/SellOptionsResult.tsx
+++ b/frontend/src/components/trading/SellOptionsResult.tsx
@@ -68,7 +68,10 @@ function ScopeBadge({ scope }: { scope: SellOptionScope }) {
  * Options without market data render muted. An empty list shows a hint.
  */
 export function SellOptionsResult({ best, options }: SellOptionsResultProps) {
-  if (options.length === 0) {
+  // Tolerate `null` from older backends / unresolvable origins (player structures
+  // return an empty path that historically marshaled as JSON null).
+  const safeOptions = options ?? [];
+  if (safeOptions.length === 0) {
     return (
       <div
         data-testid="sell-options-empty"
@@ -89,7 +92,7 @@ export function SellOptionsResult({ best, options }: SellOptionsResultProps) {
         />
       )}
       <div className="space-y-3" data-testid="sell-options-list">
-        {options.map((option, idx) => (
+        {safeOptions.map((option, idx) => (
           <SellOptionCard
             key={`${option.station_id}-${idx}`}
             option={option}


### PR DESCRIPTION
## Summary

Bei einem Verkauf von 296 × Shield Power Relay I crashte die Sell-Assets-Seite mit „Cannot read properties of null (reading 'length')".

**Ursache:** Liegt ein Item in einer Player-Structure / Citadel, lässt sich der Origin nicht zu einem System auflösen (SDE kennt nur NPC-Stationen). Der Service ging in einen früh-Return-Pfad, in dem `Options` ein Go-nil-Slice blieb → JSON `null` → Web crasht auf `options.length`.

**Fix beidseitig:**
- **Backend:** `SellOptionsResponse.Options` wird immer als `[]SellOption{}` initialisiert → bleibt JSON-Array. Regressionstest deckt den unresolvable-Origin-Pfad ab und prüft zusätzlich die Wire-Repräsentation (`"options":[]`, nie `"options":null`).
- **Web:** `SellOptionsResult` ist defensiv gegen `null` geworden (`options ?? []`), damit ältere Backend-Versionen oder unerwartete Edge-Cases nicht mehr crashen können.

UX-Verhalten danach: Citadel-Item → leere Liste → bestehender Empty-State „Keine Verkaufsorte gefunden". Die dokumentierte Citadel-Limitierung bleibt; nur der Crash ist weg.

## Test plan

- [x] Backend `go test ./internal/services/ -run TestAssetSaleService_SellOptions` — beide PASS (neuer Test deckt nil-slice / JSON-null ab)
- [x] `npx vitest run` — 62 passed
- [x] `npx eslint src/components/trading/SellOptionsResult.tsx` clean
- [ ] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)