### PR TITLE
fix(ui): ship dropdown label says 'Basis' so it isn't read as the calc value

### DIFF
--- a/app/lib/features/trading/ship_select.dart
+++ b/app/lib/features/trading/ship_select.dart
@@ -117,7 +117,7 @@ class _ShipSelectState extends ConsumerState<ShipSelect> {
             (o) => DropdownMenuItem<int>(
               value: o.typeId,
               child: Text(
-                '${o.name} (${_formatCargo(o.cargoM3)})',
+                '${o.name} (Basis ${_formatCargo(o.cargoM3)})',
                 overflow: TextOverflow.ellipsis,
               ),
             ),

--- a/frontend/src/components/trading/ShipSelect.tsx
+++ b/frontend/src/components/trading/ShipSelect.tsx
@@ -101,14 +101,16 @@ export function ShipSelect({
         </SelectTrigger>
         <SelectContent>
           {options.map((ship) => {
-            // Format cargo capacity: show in m³ if < 1000, otherwise in k m³
+            // Show the BASE hull cargo (without skills/modules). The optimizer
+            // uses the effective cargo from the fitting; we say "Basis" so the
+            // label doesn't read as the value used for the calculation.
             const cargoDisplay = ship.cargo_capacity >= 1000
               ? `${(ship.cargo_capacity / 1000).toFixed(1)}k m³`
               : `${Math.round(ship.cargo_capacity)} m³`;
 
             return (
               <SelectItem key={ship.type_id} value={ship.type_id.toString()}>
-                {ship.name} ({cargoDisplay})
+                {ship.name} (Basis {cargoDisplay})
               </SelectItem>
             );
           })}


### PR DESCRIPTION
## Summary

Reporter sah „Nereus (2.7k m³)" in der Schiffsauswahl und vermutete, der Rechner würde mit 2,7k m³ statt den echten ~9,6k m³ (Nereus + Cargo Expander + Skills, wie in EVE angezeigt) arbeiten.

**Realität:** Die Routen-/ROI-Rechnung nutzt seit v0.12.4 die korrekte effektive Cargo-Kapazität aus dem Fitting (siehe `ShipFittingCard` / Backend-Fitting-Path). Nur das Dropdown-Label zeigt den Basis-Hull-Cargo (`/character/ships` liefert bewusst `BaseCargoHold`).

**Fix:** Label sagt jetzt explizit „Basis" (Web + Flutter), damit der Wert nicht mehr als Rechenbasis missverstanden wird. Inhaltlich ändert sich nichts an der Berechnung.

## Test plan

- [x] `npx vitest run` — 62 passed
- [x] `npx eslint src/components/trading/ShipSelect.tsx` clean
- [x] `flutter analyze lib/ test/` clean · `flutter test` — 187 passed
- [ ] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)