### PR TITLE
feat(ui): ship dropdown shows the effective cargo (= optimizer value)

### DIFF
--- a/app/lib/features/character/character_models.dart
+++ b/app/lib/features/character/character_models.dart
@@ -94,6 +94,7 @@ class CharacterShip {
     required this.shipItemId,
     required this.shipTypeName,
     required this.cargoCapacity,
+    this.effectiveCargoCapacity,
   });
 
   final int shipTypeId;
@@ -101,6 +102,7 @@ class CharacterShip {
   final int shipItemId;
   final String shipTypeName;
   final double cargoCapacity;
+  final double? effectiveCargoCapacity;
 
   factory CharacterShip.fromJson(Map<String, dynamic> json) {
     return CharacterShip(
@@ -109,6 +111,8 @@ class CharacterShip {
       shipItemId: (json['ship_item_id'] as num).toInt(),
       shipTypeName: json['ship_type_name'] as String? ?? '',
       cargoCapacity: (json['cargo_capacity'] as num?)?.toDouble() ?? 0.0,
+      effectiveCargoCapacity:
+          (json['effective_cargo_capacity'] as num?)?.toDouble(),
     );
   }
 
@@ -147,6 +151,7 @@ class CharacterAssetShip {
     required this.locationFlag,
     required this.cargoCapacity,
     required this.isSingleton,
+    this.effectiveCargoCapacity,
   });
 
   final int itemId;
@@ -156,6 +161,7 @@ class CharacterAssetShip {
   final String locationName;
   final String locationFlag;
   final double cargoCapacity;
+  final double? effectiveCargoCapacity;
   final bool isSingleton;
 
   factory CharacterAssetShip.fromJson(Map<String, dynamic> json) {
@@ -167,6 +173,8 @@ class CharacterAssetShip {
       locationName: json['location_name'] as String? ?? '',
       locationFlag: json['location_flag'] as String? ?? '',
       cargoCapacity: (json['cargo_capacity'] as num?)?.toDouble() ?? 0.0,
+      effectiveCargoCapacity:
+          (json['effective_cargo_capacity'] as num?)?.toDouble(),
       isSingleton: json['is_singleton'] as bool? ?? false,
     );
   }

--- a/app/lib/features/trading/ship_select.dart
+++ b/app/lib/features/trading/ship_select.dart
@@ -33,12 +33,14 @@ const List<_FallbackShip> _fallbackShips = [
   _FallbackShip(33693, 'Miasmos', 63338.0),
 ];
 
-/// A uniform dropdown option (type id + display name + cargo m³).
+/// A uniform dropdown option. [cargoM3] is the base hull cargo;
+/// [effectiveM3] is the optimizer-value (hull + skills + modules) when known.
 class _ShipOpt {
-  const _ShipOpt(this.typeId, this.name, this.cargoM3);
+  const _ShipOpt(this.typeId, this.name, this.cargoM3, [this.effectiveM3]);
   final int typeId;
   final String name;
   final double cargoM3;
+  final double? effectiveM3;
 }
 
 // ---------------------------------------------------------------------------
@@ -74,7 +76,12 @@ class _ShipSelectState extends ConsumerState<ShipSelect> {
     final base = <_ShipOpt>[];
     if (hangar.isNotEmpty) {
       for (final s in hangar) {
-        base.add(_ShipOpt(s.typeId, s.typeName, s.cargoCapacity));
+        base.add(_ShipOpt(
+          s.typeId,
+          s.typeName,
+          s.cargoCapacity,
+          s.effectiveCargoCapacity,
+        ));
       }
     } else {
       for (final f in _fallbackShips) {
@@ -91,7 +98,12 @@ class _ShipSelectState extends ConsumerState<ShipSelect> {
     if (active != null && active.shipTypeId > 0) {
       final name =
           active.shipTypeName.isNotEmpty ? active.shipTypeName : active.shipName;
-      opts.add(_ShipOpt(active.shipTypeId, name, active.cargoCapacity));
+      opts.add(_ShipOpt(
+        active.shipTypeId,
+        name,
+        active.cargoCapacity,
+        active.effectiveCargoCapacity,
+      ));
       seen.add(active.shipTypeId);
     }
     for (final o in base) {
@@ -117,7 +129,7 @@ class _ShipSelectState extends ConsumerState<ShipSelect> {
             (o) => DropdownMenuItem<int>(
               value: o.typeId,
               child: Text(
-                '${o.name} (Basis ${_formatCargo(o.cargoM3)})',
+                _labelForShip(o),
                 overflow: TextOverflow.ellipsis,
               ),
             ),
@@ -131,6 +143,17 @@ class _ShipSelectState extends ConsumerState<ShipSelect> {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Dropdown label: prefer the effective cargo (the optimizer's value, matches
+/// EVE in-game); fall back to base with a "Basis" prefix so the bare number
+/// can't be misread as the calc input.
+String _labelForShip(_ShipOpt o) {
+  final eff = o.effectiveM3;
+  if (eff != null && eff > 0) {
+    return '${o.name} (${_formatCargo(eff)})';
+  }
+  return '${o.name} (Basis ${_formatCargo(o.cargoM3)})';
+}
 
 String _formatCargo(double m3) {
   if (m3 >= 1000) {

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -142,7 +142,7 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 
 	// Request handlers
 	c.Handlers = handlers.New(c.DB, c.SDERepo, c.MarketRepo, c.ESIClient)
-	c.TradingHandler = handlers.NewTradingHandler(routeService, c.SDERepo, shipService, systemService, characterHelper, cargoService)
+	c.TradingHandler = handlers.NewTradingHandler(routeService, c.SDERepo, shipService, systemService, characterHelper, cargoService, fittingService)
 	c.CharacterHandler = handlers.NewCharacterHandler(skillsService)
 	c.FittingHandler = handlers.NewFittingHandler(fittingService)
 	c.CalculationHandler = handlers.NewCalculationHandler(c.DB.SDE, fittingService)

--- a/backend/internal/handlers/trading.go
+++ b/backend/internal/handlers/trading.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
@@ -25,7 +26,8 @@ type TradingHandler struct {
 	shipService     services.ShipServicer            // For ship capacity queries
 	systemService   services.SystemServicer          // For system/region/station info
 	characterHelper *services.CharacterHelper
-	cargoService    services.CargoServicer // For effective cargo capacity calculation
+	cargoService    services.CargoServicer   // For effective cargo capacity calculation
+	fittingService  services.FittingServicer // For effective cargo per ship (dropdown enrichment)
 }
 
 // NewTradingHandler creates a new trading handler instance
@@ -36,6 +38,7 @@ func NewTradingHandler(
 	systemService services.SystemServicer,
 	charHelper *services.CharacterHelper,
 	cargoService services.CargoServicer,
+	fittingService services.FittingServicer,
 ) *TradingHandler {
 	return &TradingHandler{
 		calculator:      calculator,
@@ -44,6 +47,7 @@ func NewTradingHandler(
 		systemService:   systemService,
 		characterHelper: charHelper,
 		cargoService:    cargoService,
+		fittingService:  fittingService,
 	}
 }
 
@@ -485,6 +489,14 @@ func (h *TradingHandler) fetchESICharacterShip(ctx context.Context, characterID 
 		ship.CargoCapacity = capacities.BaseCargoHold
 	}
 
+	// Effective cargo (hull + skills + fitted modules) for the dropdown label —
+	// best-effort; on failure the client falls back to the base with "Basis".
+	if h.fittingService != nil {
+		if fit, ferr := h.fittingService.GetShipFitting(ctx, characterID, int(esiShip.ShipTypeID), accessToken); ferr == nil && fit != nil && fit.Bonuses.EffectiveCargo > 0 {
+			ship.EffectiveCargoCapacity = fit.Bonuses.EffectiveCargo
+		}
+	}
+
 	return ship, nil
 }
 
@@ -570,10 +582,47 @@ func (h *TradingHandler) fetchESICharacterShips(ctx context.Context, characterID
 		})
 	}
 
+	// Enrich each singleton ship with its effective cargo (hull + skills +
+	// fitted modules) — the same value the optimizer uses. The dropdown then
+	// shows the number that matches EVE in-game instead of the bare hull base.
+	// Fan out with capped concurrency; fittings are cached, so subsequent loads
+	// are cheap. Best-effort: leave EffectiveCargoCapacity == 0 on failure so
+	// the client falls back to the base label.
+	h.enrichShipsWithEffectiveCargo(ctx, ships, characterID, accessToken)
+
 	return &models.CharacterShipsResponse{
 		Ships: ships,
 		Count: len(ships),
 	}, nil
+}
+
+// enrichShipsWithEffectiveCargo fills EffectiveCargoCapacity for each singleton
+// ship in-place. Caps concurrency at 4 to avoid hammering ESI; non-singletons
+// (packaged) and ships with no resolvable fitting keep EffectiveCargoCapacity=0.
+func (h *TradingHandler) enrichShipsWithEffectiveCargo(ctx context.Context, ships []models.CharacterAssetShip, characterID int, accessToken string) {
+	if h.fittingService == nil {
+		return
+	}
+	const maxConcurrent = 4
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	for i := range ships {
+		if !ships[i].IsSingleton {
+			continue
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			fit, err := h.fittingService.GetShipFitting(ctx, characterID, int(ships[idx].TypeID), accessToken)
+			if err != nil || fit == nil || fit.Bonuses.EffectiveCargo <= 0 {
+				return
+			}
+			ships[idx].EffectiveCargoCapacity = fit.Bonuses.EffectiveCargo
+		}(i)
+	}
+	wg.Wait()
 }
 
 // setESIAutopilotWaypoint sets a waypoint in the EVE client via ESI UI API

--- a/backend/internal/models/trading.go
+++ b/backend/internal/models/trading.go
@@ -127,23 +127,30 @@ type CharacterLocation struct {
 
 // CharacterShip represents character ship information
 type CharacterShip struct {
-	ShipTypeID    int64   `json:"ship_type_id"`
-	ShipName      string  `json:"ship_name"`
-	ShipItemID    int64   `json:"ship_item_id"`
-	ShipTypeName  string  `json:"ship_type_name"`
-	CargoCapacity float64 `json:"cargo_capacity"`
+	ShipTypeID             int64   `json:"ship_type_id"`
+	ShipName               string  `json:"ship_name"`
+	ShipItemID             int64   `json:"ship_item_id"`
+	ShipTypeName           string  `json:"ship_type_name"`
+	CargoCapacity          float64 `json:"cargo_capacity"`
+	EffectiveCargoCapacity float64 `json:"effective_cargo_capacity,omitempty"`
 }
 
-// CharacterAssetShip represents a ship in character assets
+// CharacterAssetShip represents a ship in character assets.
+//
+// CargoCapacity is the base hull cargo (without skills/modules).
+// EffectiveCargoCapacity is the value the optimizer actually uses (hull +
+// skills + fitted modules); 0 when the per-ship enrichment failed and the
+// client should fall back to the base. The label uses effective when > 0.
 type CharacterAssetShip struct {
-	ItemID        int64   `json:"item_id"`
-	TypeID        int64   `json:"type_id"`
-	TypeName      string  `json:"type_name"`
-	LocationID    int64   `json:"location_id"`
-	LocationName  string  `json:"location_name"`
-	LocationFlag  string  `json:"location_flag"`
-	CargoCapacity float64 `json:"cargo_capacity"`
-	IsSingleton   bool    `json:"is_singleton"`
+	ItemID                 int64   `json:"item_id"`
+	TypeID                 int64   `json:"type_id"`
+	TypeName               string  `json:"type_name"`
+	LocationID             int64   `json:"location_id"`
+	LocationName           string  `json:"location_name"`
+	LocationFlag           string  `json:"location_flag"`
+	CargoCapacity          float64 `json:"cargo_capacity"`
+	EffectiveCargoCapacity float64 `json:"effective_cargo_capacity,omitempty"`
+	IsSingleton            bool    `json:"is_singleton"`
 }
 
 // CharacterShipsResponse represents the response for character ships

--- a/frontend/src/components/trading/ShipSelect.tsx
+++ b/frontend/src/components/trading/ShipSelect.tsx
@@ -67,6 +67,7 @@ export function ShipSelect({
             type_id: active.ship_type_id,
             name: active.ship_type_name || active.ship_name,
             cargo_capacity: active.cargo_capacity,
+            effective_cargo_capacity: active.effective_cargo_capacity,
           });
         }
       } finally {
@@ -101,16 +102,21 @@ export function ShipSelect({
         </SelectTrigger>
         <SelectContent>
           {options.map((ship) => {
-            // Show the BASE hull cargo (without skills/modules). The optimizer
-            // uses the effective cargo from the fitting; we say "Basis" so the
-            // label doesn't read as the value used for the calculation.
-            const cargoDisplay = ship.cargo_capacity >= 1000
-              ? `${(ship.cargo_capacity / 1000).toFixed(1)}k m³`
-              : `${Math.round(ship.cargo_capacity)} m³`;
+            // Prefer the effective cargo (matches what the optimizer uses and
+            // what EVE shows in-game). Fall back to the base hull cargo with a
+            // "Basis" prefix when the backend couldn't enrich the entry.
+            const effective = ship.effective_cargo_capacity;
+            const useEffective = effective != null && effective > 0;
+            const value = useEffective ? effective : ship.cargo_capacity;
+            const cargoFmt =
+              value >= 1000
+                ? `${(value / 1000).toFixed(1)}k m³`
+                : `${Math.round(value)} m³`;
+            const cargoDisplay = useEffective ? cargoFmt : `Basis ${cargoFmt}`;
 
             return (
               <SelectItem key={ship.type_id} value={ship.type_id.toString()}>
-                {ship.name} (Basis {cargoDisplay})
+                {ship.name} ({cargoDisplay})
               </SelectItem>
             );
           })}

--- a/frontend/src/types/character.ts
+++ b/frontend/src/types/character.ts
@@ -16,6 +16,8 @@ export interface CharacterShip {
   ship_item_id: number;
   ship_type_name: string;
   cargo_capacity: number;
+  /** Effective cargo (hull + skills + fitted modules). Absent if enrichment failed. */
+  effective_cargo_capacity?: number;
 }
 
 /**

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -85,7 +85,12 @@ export interface Region {
 export interface Ship {
   type_id: number;
   name: string;
+  /** Base hull cargo (without skills/modules). */
   cargo_capacity: number;
+  /** Effective cargo (hull + skills + fitted modules); same value the optimizer
+   *  uses. Absent when the backend couldn't enrich the entry — fall back to
+   *  `cargo_capacity` with a "Basis" label. */
+  effective_cargo_capacity?: number;
 }
 
 export interface TradingFilters {


### PR DESCRIPTION
## Summary

„Nereus (Basis 2,7k m³)" im Schiff-Dropdown war zwar ehrlich, las sich aber wie der Rechenwert — und der Nutzer sieht in EVE für dieselbe Nereus (mit Cargo Expandern + Skills) ~9.656 m³. Jetzt zeigt der Dropdown den **effektiven** Cargo, also genau den Wert, mit dem der Optimizer seit v0.12.4 rechnet. Fallback auf „Basis Xk m³" wenn die Anreicherung scheitert.

## Approach

- **Backend:** `CharacterAssetShip` und `CharacterShip` haben jetzt `effective_cargo_capacity` (omitempty).
  - `/character/ships`: Nach dem Aufbau der Hangar-Liste reichern wir jedes singleton Schiff parallel mit `FittingService.GetShipFitting` an (Concurrency-Cap 4, Best-Effort). Fittings sind 5 Min Redis-gecacht — erste Dropdown-Öffnung kostet ~2–5 s, danach instant.
  - `/character/ship` (aktives Schiff): selber One-Shot-Fitting-Fetch.
- **Web + Flutter:** Label zeigt den Effektiv-Wert (`9,7k m³`) wenn `effective_cargo_capacity > 0`, sonst `Basis 2,7k m³`.

## Trade-offs

- Pro Hangar-Schiff ein zusätzlicher Fitting-Lookup beim ersten Listen-Aufruf (parallel, capped). Cache federt das ab.
- Wenn der Fitting-Service für ein Schiff scheitert (kein gespeichertes Fitting, ESI-Timeout, …): leise Degradation → "Basis"-Label. Kein Crash, kein leerer Wert.

## Test plan

- [x] Backend `go test ./internal/handlers/ ./internal/services/` — grün; `gofmt`/`go vet` clean
- [x] `npx vitest run` — 62 passed · `npx eslint src/` clean
- [x] `flutter analyze lib/ test/` clean · `flutter test` — 187 passed
- [ ] CI grün
- [ ] Nach Deploy: ROI-Screen prüfen → Nereus zeigt den realen Effektiv-Wert (~9.6k m³), nicht 2.7k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)