### PR TITLE
fix(app): character screen shows effective cargo for active ship

### DIFF
--- a/app/lib/features/character/character_screen.dart
+++ b/app/lib/features/character/character_screen.dart
@@ -205,7 +205,10 @@ class _ActiveShipCard extends StatelessWidget {
             const SizedBox(height: 4),
             _InfoRow(
               label: 'Laderaum',
-              value: '${ship.cargoCapacity.toStringAsFixed(1)} m³',
+              value: (ship.effectiveCargoCapacity != null &&
+                      ship.effectiveCargoCapacity! > 0)
+                  ? '${ship.effectiveCargoCapacity!.toStringAsFixed(1)} m³'
+                  : '${ship.cargoCapacity.toStringAsFixed(1)} m³ (Basis)',
             ),
             const SizedBox(height: 4),
             _InfoRow(


### PR DESCRIPTION
## Summary

Folge-Patch zu v0.14.0: Der Flutter-Character-Screen („Laderaum"-Zeile) zeigte für das aktive Schiff weiter die Basis-Hülle, während die Schiff-Dropdowns seit v0.14.0 den Effektiv-Wert nutzen. Jetzt einheitlich: Effektiv wenn vorhanden, sonst Basis-Fallback („X m³ (Basis)").

## Test plan

- [x] `flutter analyze lib/ test/` clean · `flutter test` — 187 passed
- [ ] CI grün
- [ ] On-device: Character-Screen zeigt für die geflogene Nereus ~9.656,9 m³

🤖 Generated with [Claude Code](https://claude.com/claude-code)