### PR TITLE
feat(roi): tap item name to open the EVE market window

### DIFF
--- a/app/lib/api/trading_api.dart
+++ b/app/lib/api/trading_api.dart
@@ -162,4 +162,15 @@ class TradingApi {
       },
     );
   }
+
+  // ── POST /api/v1/esi/ui/openwindow/marketdetails ──────────────────────────
+
+  /// Opens the EVE client's market-details window for [typeId].
+  /// Requires scope `esi-ui.open_window.v1` and a running EVE client.
+  Future<void> openMarketDetails(int typeId) async {
+    await _dio.post<void>(
+      '/api/v1/esi/ui/openwindow/marketdetails',
+      data: {'type_id': typeId},
+    );
+  }
 }

--- a/app/lib/core/env.dart
+++ b/app/lib/core/env.dart
@@ -13,5 +13,6 @@ class Env {
     'esi-assets.read_assets.v1',
     'esi-ui.write_waypoint.v1',
     'esi-wallet.read_character_wallet.v1',
+    'esi-ui.open_window.v1',
   ];
 }

--- a/app/lib/features/trading/roi_calculator_screen.dart
+++ b/app/lib/features/trading/roi_calculator_screen.dart
@@ -522,7 +522,7 @@ class _PortfolioTable extends ConsumerWidget {
                 for (final item in result.items)
                   DataRow(
                     cells: [
-                      DataCell(Text(item.name)),
+                      DataCell(_ItemNameCell(item: item)),
                       DataCell(_RouteCell(item: item)),
                       DataCell(Text(fmtIsk(item.capitalUsed))),
                       DataCell(Text(fmtUnits(item.units))),
@@ -565,6 +565,58 @@ class _RouteCell extends StatelessWidget {
       message: tooltip,
       child: Text(label),
     );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Item name cell — tapping opens the EVE client's market-details window for
+// that item. Same UX intent as the Trophy/Trade action on the web side.
+// ---------------------------------------------------------------------------
+
+class _ItemNameCell extends ConsumerWidget {
+  const _ItemNameCell({required this.item});
+
+  final PortfolioItem item;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return InkWell(
+      key: Key('roi-open-market-${item.typeId}'),
+      onTap: () => _openMarket(context, ref),
+      child: Text(
+        item.name,
+        style: TextStyle(
+          color: Theme.of(context).colorScheme.primary,
+          decoration: TextDecoration.underline,
+          decorationStyle: TextDecorationStyle.dotted,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openMarket(BuildContext context, WidgetRef ref) async {
+    final api = ref.read(tradingApiProvider);
+    try {
+      await api.openMarketDetails(item.typeId);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${item.name} im EVE-Client geöffnet'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Markt konnte nicht geöffnet werden: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
   }
 }
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -176,6 +176,7 @@ func setupApp(c *AppContainer) *fiber.App {
 
 	esiUI := protected.Group("/esi/ui")
 	esiUI.Post("/autopilot/waypoint", c.TradingHandler.SetAutopilotWaypoint)
+	esiUI.Post("/openwindow/marketdetails", c.TradingHandler.OpenMarketDetails)
 
 	trading := protected.Group("/trading")
 	trading.Get("/profit-margins", handleProfitMargins)

--- a/backend/internal/handlers/trading.go
+++ b/backend/internal/handlers/trading.go
@@ -297,6 +297,82 @@ func (h *TradingHandler) GetCharacterWallet(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"balance": balance})
 }
 
+// OpenMarketDetails handles POST /api/v1/esi/ui/openwindow/marketdetails
+// Opens the EVE client's market-details window for a given type via ESI UI API.
+//
+// @Summary Open market details window in EVE client
+// @Description Opens the market window for a given type_id in the EVE client.
+// @Description Requires scope: esi-ui.open_window.v1
+// @Tags ESI UI
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body object{type_id=int} true "Type ID to open"
+// @Success 204 "Market details window opened"
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 404 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/esi/ui/openwindow/marketdetails [post]
+func (h *TradingHandler) OpenMarketDetails(c *fiber.Ctx) error {
+	accessToken, ok := c.Locals("access_token").(string)
+	if !ok {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
+	}
+
+	var req struct {
+		TypeID int `json:"type_id"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+	if req.TypeID <= 0 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid type_id"})
+	}
+
+	if err := h.openESIMarketDetails(c.Context(), accessToken, req.TypeID); err != nil {
+		switch err.Error() {
+		case "unauthorized":
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Not authenticated or missing scope esi-ui.open_window.v1"})
+		case "not_found":
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "EVE client not running"})
+		default:
+			log.Printf("ERROR: OpenMarketDetails failed for typeID=%d: %v", req.TypeID, err)
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to open market details"})
+		}
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// openESIMarketDetails calls ESI /ui/openwindow/marketdetails for the given type.
+func (h *TradingHandler) openESIMarketDetails(ctx context.Context, accessToken string, typeID int) error {
+	url := fmt.Sprintf("https://esi.evetech.net/latest/ui/openwindow/marketdetails/?type_id=%d", typeID)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 204 {
+		return nil
+	}
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return fmt.Errorf("unauthorized")
+	}
+	if resp.StatusCode == 404 {
+		return fmt.Errorf("not_found")
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("ESI returned status %d: %s", resp.StatusCode, string(body))
+}
+
 // SetAutopilotWaypoint handles POST /api/v1/esi/ui/autopilot/waypoint
 // Sets a waypoint in the EVE client's autopilot via ESI UI API
 //

--- a/backend/internal/handlers/trading_test.go
+++ b/backend/internal/handlers/trading_test.go
@@ -450,6 +450,61 @@ func TestGetCharacterWallet_RequiresAuth(t *testing.T) {
 	}
 }
 
+// TestOpenMarketDetails_Validation tests the input validation guards on the
+// open-market-details endpoint (auth presence + valid type_id).
+func TestOpenMarketDetails_Validation(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		expectedStatus int
+	}{
+		{"missing type_id", `{}`, fiber.StatusBadRequest},
+		{"zero type_id", `{"type_id":0}`, fiber.StatusBadRequest},
+		{"negative type_id", `{"type_id":-5}`, fiber.StatusBadRequest},
+		{"invalid json", `not-json`, fiber.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := fiber.New()
+			// Mock auth: provide dummy access_token so we exercise validation.
+			app.Use("/m", func(c *fiber.Ctx) error {
+				c.Locals("access_token", "dummy-token")
+				return c.Next()
+			})
+			handler := &TradingHandler{}
+			app.Post("/m", handler.OpenMarketDetails)
+
+			req := httptest.NewRequest("POST", "/m", bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("Test request failed: %v", err)
+			}
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tt.expectedStatus)
+			}
+		})
+	}
+}
+
+// TestOpenMarketDetails_RequiresAuth confirms the endpoint rejects requests
+// without an access_token local (production has the auth middleware in front).
+func TestOpenMarketDetails_RequiresAuth(t *testing.T) {
+	app := fiber.New()
+	handler := &TradingHandler{}
+	app.Post("/m", handler.OpenMarketDetails)
+
+	req := httptest.NewRequest("POST", "/m", bytes.NewBufferString(`{"type_id":34}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test request failed: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, fiber.StatusUnauthorized)
+	}
+}
+
 // TestResponseStructures tests that response structures are correct
 func TestResponseStructures(t *testing.T) {
 	t.Run("RouteCalculationResponse", func(t *testing.T) {

--- a/frontend/src/components/trading/PortfolioResultTable.tsx
+++ b/frontend/src/components/trading/PortfolioResultTable.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/lib/auth-context";
-import { setWaypoint } from "@/lib/api-client";
+import { openMarketDetails, setWaypoint } from "@/lib/api-client";
 
 interface PortfolioResultTableProps {
   result: PortfolioResult;
@@ -109,6 +109,30 @@ function PortfolioRowItem({ item }: { item: PortfolioItem }) {
   const { toast } = useToast();
   const [isSettingRoute, setIsSettingRoute] = useState(false);
 
+  const handleOpenMarket = async () => {
+    if (!isAuthenticated) {
+      toast({
+        title: "Nicht eingeloggt",
+        description: "EVE SSO Login erforderlich",
+        variant: "destructive",
+      });
+      return;
+    }
+    try {
+      await openMarketDetails(item.type_id);
+      toast({
+        title: "Markt geöffnet",
+        description: `${item.name} im EVE-Client geöffnet`,
+      });
+    } catch (err) {
+      toast({
+        title: "Fehler",
+        description: err instanceof Error ? err.message : "Unbekannter Fehler",
+        variant: "destructive",
+      });
+    }
+  };
+
   const handleSetRoute = async () => {
     if (!isAuthenticated) {
       toast({
@@ -145,7 +169,16 @@ function PortfolioRowItem({ item }: { item: PortfolioItem }) {
       data-type-id={item.type_id}
       className="border-b transition-colors hover:bg-muted/40"
     >
-      <td className="px-4 py-3 font-medium">{item.name}</td>
+      <td className="px-4 py-3 font-medium">
+        <button
+          type="button"
+          onClick={handleOpenMarket}
+          className="text-left hover:underline underline-offset-2 hover:text-primary transition-colors"
+          title="Marktdetails im EVE-Client öffnen"
+        >
+          {item.name}
+        </button>
+      </td>
       <td
         className="px-4 py-3 whitespace-nowrap text-muted-foreground"
         title={`${item.buy_station_name} → ${item.sell_station_name}`}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -335,3 +335,30 @@ export async function setWaypoint(
     throw new Error(`Failed to set waypoint: ${response.statusText}`);
   }
 }
+
+/**
+ * Open the EVE client's market-details window for a given type. The client must
+ * be running and the character must have authorized the esi-ui.open_window.v1
+ * scope. Useful for jumping straight from a portfolio row to the in-game market.
+ */
+export async function openMarketDetails(typeId: number): Promise<void> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/esi/ui/openwindow/marketdetails`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ type_id: typeId }),
+    }
+  );
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Error("Missing scope esi-ui.open_window.v1");
+    }
+    if (response.status === 404) {
+      throw new Error("EVE client not running");
+    }
+    throw new Error(`Failed to open market details: ${response.statusText}`);
+  }
+}

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -33,6 +33,7 @@ const EVE_SCOPES: string[] = [
   "esi-ui.write_waypoint.v1",
   "esi-skills.read_skills.v1",
   "esi-wallet.read_character_wallet.v1",
+  "esi-ui.open_window.v1",
 ];
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

Owner-Request: aus der ROI-Portfolio-Tabelle direkt das Markt-Fenster des Items im EVE-Client öffnen können.

- **Backend:** neuer Endpoint `POST /api/v1/esi/ui/openwindow/marketdetails` mit `{type_id}` (analog zum bestehenden `autopilot/waypoint`). Tests decken Auth-Guard + Eingabe-Validierung ab.
- **Web:** Item-Name in `PortfolioResultTable` ist klickbar (`button` mit Underline-Hover-Style); ruft `openMarketDetails(type_id)` und zeigt Toast bei Erfolg/Fehler.
- **Flutter:** ROI-Allocation-Table — der Item-Name ist tappable (`InkWell`, dotted-underline); SnackBar-Feedback.

## Scope

Neuer ESI-Scope `esi-ui.open_window.v1` (Web + Mobile). Vom Owner bereits in beiden EVE-App-Registrierungen aktiviert. **Re-Login nötig** für bestehende Sessions.

## Test plan

- [x] Backend `go test ./internal/handlers/ ./internal/services/` — grün; `gofmt`/`vet` clean
- [x] `npx vitest run` — 62 passed · `npx eslint src/` clean
- [x] `flutter analyze lib/ test/` clean · `flutter test` — 187 passed
- [ ] CI grün
- [ ] On-device: ROI-Run, Item-Name antippen → EVE-Client öffnet Marktdetails-Fenster

🤖 Generated with [Claude Code](https://claude.com/claude-code)