### PR TITLE
refactor(app): drop in-game ESI UI buttons + UI scopes from Flutter

### DIFF
--- a/app/lib/api/trading_api.dart
+++ b/app/lib/api/trading_api.dart
@@ -141,36 +141,4 @@ class TradingApi {
     );
   }
 
-  // ── POST /api/v1/esi/ui/autopilot/waypoint ────────────────────────────────
-
-  /// Sets an autopilot waypoint in the EVE client.
-  ///
-  /// [destinationId] — solar system / station / structure ID.
-  /// [addToBeginning] — insert at the start of the route (default false).
-  /// [clearOtherWaypoints] — clear existing route first (default false).
-  Future<void> setWaypoint({
-    required int destinationId,
-    bool addToBeginning = false,
-    bool clearOtherWaypoints = false,
-  }) async {
-    await _dio.post<void>(
-      '/api/v1/esi/ui/autopilot/waypoint',
-      data: {
-        'destination_id': destinationId,
-        'add_to_beginning': addToBeginning,
-        'clear_other_waypoints': clearOtherWaypoints,
-      },
-    );
-  }
-
-  // ── POST /api/v1/esi/ui/openwindow/marketdetails ──────────────────────────
-
-  /// Opens the EVE client's market-details window for [typeId].
-  /// Requires scope `esi-ui.open_window.v1` and a running EVE client.
-  Future<void> openMarketDetails(int typeId) async {
-    await _dio.post<void>(
-      '/api/v1/esi/ui/openwindow/marketdetails',
-      data: {'type_id': typeId},
-    );
-  }
 }

--- a/app/lib/core/env.dart
+++ b/app/lib/core/env.dart
@@ -11,8 +11,6 @@ class Env {
     'esi-skills.read_skills.v1',
     'esi-clones.read_clones.v1',
     'esi-assets.read_assets.v1',
-    'esi-ui.write_waypoint.v1',
     'esi-wallet.read_character_wallet.v1',
-    'esi-ui.open_window.v1',
   ];
 }

--- a/app/lib/features/trading/hauling_screen.dart
+++ b/app/lib/features/trading/hauling_screen.dart
@@ -632,67 +632,9 @@ class HaulingRouteDetail extends ConsumerWidget {
               ],
             ),
           ),
-          const SizedBox(height: 24),
-
-          // ── Action button ────────────────────────────────────────────────
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton.icon(
-              key: const Key('hauling-waypoint-button'),
-              onPressed: () => _setWaypoint(context, ref),
-              icon: const Icon(Icons.navigation_rounded),
-              label: const Text('Route an EVE übertragen'),
-              style: FilledButton.styleFrom(
-                backgroundColor: accent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(vertical: 14),
-                textStyle: const TextStyle(
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16,
-                ),
-              ),
-            ),
-          ),
         ],
       ),
     );
-  }
-
-  Future<void> _setWaypoint(BuildContext context, WidgetRef ref) async {
-    final api = ref.read(tradingApiProvider);
-    try {
-      // Clear existing route; set buy station first, then append sell station.
-      await api.setWaypoint(
-        destinationId: route.buyStationId,
-        clearOtherWaypoints: true,
-        addToBeginning: false,
-      );
-      await api.setWaypoint(
-        destinationId: route.sellStationId,
-        clearOtherWaypoints: false,
-        addToBeginning: false,
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'Route gesetzt: ${route.buySystemName} → ${route.sellSystemName}',
-            ),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Fehler beim Setzen der Route: $e'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    }
   }
 }
 

--- a/app/lib/features/trading/roi_calculator_screen.dart
+++ b/app/lib/features/trading/roi_calculator_screen.dart
@@ -516,20 +516,18 @@ class _PortfolioTable extends ConsumerWidget {
                 DataColumn(label: Text('Fahrten/Tag'), numeric: true),
                 DataColumn(label: Text('Tagesgewinn'), numeric: true),
                 DataColumn(label: Text('ROI%'), numeric: true),
-                DataColumn(label: Text('EVE')),
               ],
               rows: [
                 for (final item in result.items)
                   DataRow(
                     cells: [
-                      DataCell(_ItemNameCell(item: item)),
+                      DataCell(Text(item.name)),
                       DataCell(_RouteCell(item: item)),
                       DataCell(Text(fmtIsk(item.capitalUsed))),
                       DataCell(Text(fmtUnits(item.units))),
                       DataCell(Text(item.tripsPerDay.toStringAsFixed(1))),
                       DataCell(Text(fmtIsk(item.dailyProfit))),
                       DataCell(Text('${item.roiPercent.toStringAsFixed(1)}%')),
-                      DataCell(_WaypointButton(item: item)),
                     ],
                   ),
               ],
@@ -565,119 +563,6 @@ class _RouteCell extends StatelessWidget {
       message: tooltip,
       child: Text(label),
     );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Item name cell — tapping opens the EVE client's market-details window for
-// that item. Same UX intent as the Trophy/Trade action on the web side.
-// ---------------------------------------------------------------------------
-
-class _ItemNameCell extends ConsumerWidget {
-  const _ItemNameCell({required this.item});
-
-  final PortfolioItem item;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return InkWell(
-      key: Key('roi-open-market-${item.typeId}'),
-      onTap: () => _openMarket(context, ref),
-      child: Text(
-        item.name,
-        style: TextStyle(
-          color: Theme.of(context).colorScheme.primary,
-          decoration: TextDecoration.underline,
-          decorationStyle: TextDecorationStyle.dotted,
-        ),
-      ),
-    );
-  }
-
-  Future<void> _openMarket(BuildContext context, WidgetRef ref) async {
-    final api = ref.read(tradingApiProvider);
-    try {
-      await api.openMarketDetails(item.typeId);
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('${item.name} im EVE-Client geöffnet'),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Markt konnte nicht geöffnet werden: $e'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Waypoint button — sets in-game autopilot waypoints (buy then sell)
-//
-// Reuses the exact pattern from route_detail.dart's `_setWaypoint`: clear the
-// route and set the buy station first, then add the sell station, then show a
-// success/error SnackBar.
-// ---------------------------------------------------------------------------
-
-class _WaypointButton extends ConsumerWidget {
-  const _WaypointButton({required this.item});
-
-  final PortfolioItem item;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final enabled = item.buyStationId > 0 && item.sellStationId > 0;
-    return IconButton(
-      key: Key('roi-waypoint-${item.typeId}'),
-      icon: const Icon(Icons.navigation_rounded),
-      tooltip: 'Route an EVE übertragen',
-      visualDensity: VisualDensity.compact,
-      onPressed: enabled ? () => _setWaypoint(context, ref) : null,
-    );
-  }
-
-  Future<void> _setWaypoint(BuildContext context, WidgetRef ref) async {
-    final api = ref.read(tradingApiProvider);
-    try {
-      // Clear existing route; set buy station first, then sell station.
-      await api.setWaypoint(
-        destinationId: item.buyStationId,
-        clearOtherWaypoints: true,
-        addToBeginning: false,
-      );
-      await api.setWaypoint(
-        destinationId: item.sellStationId,
-        clearOtherWaypoints: false,
-        addToBeginning: false,
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Route an EVE übertragen'),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Fehler beim Setzen der Route: $e'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    }
   }
 }
 

--- a/app/lib/features/trading/route_detail.dart
+++ b/app/lib/features/trading/route_detail.dart
@@ -9,7 +9,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../api/trading_models.dart';
-import '../trading/providers.dart';
 import 'route_card.dart' show formatIskPerHour;
 
 /// Full detail view for a [TradingRoute].
@@ -60,66 +59,9 @@ class RouteDetail extends ConsumerWidget {
 
           // ── Route meta block ───────────────────────────────────────────────
           _MetaCard(route: route),
-          const SizedBox(height: 24),
-
-          // ── Action button ──────────────────────────────────────────────────
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton.icon(
-              onPressed: () => _setWaypoint(context, ref),
-              icon: const Icon(Icons.navigation_rounded),
-              label: const Text('Route in EVE setzen'),
-              style: FilledButton.styleFrom(
-                backgroundColor: accent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(vertical: 14),
-                textStyle: const TextStyle(
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16,
-                ),
-              ),
-            ),
-          ),
         ],
       ),
     );
-  }
-
-  Future<void> _setWaypoint(BuildContext context, WidgetRef ref) async {
-    final api = ref.read(tradingApiProvider);
-    try {
-      // Clear existing route; set buy system first, then sell system.
-      await api.setWaypoint(
-        destinationId: route.buySystemId,
-        clearOtherWaypoints: true,
-        addToBeginning: false,
-      );
-      await api.setWaypoint(
-        destinationId: route.sellSystemId,
-        clearOtherWaypoints: false,
-        addToBeginning: false,
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'Route gesetzt: ${route.buySystemName} → ${route.sellSystemName}',
-            ),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Fehler beim Setzen der Route: $e'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    }
   }
 }
 

--- a/app/lib/features/trading/sell_assets_screen.dart
+++ b/app/lib/features/trading/sell_assets_screen.dart
@@ -22,7 +22,6 @@ import '../../api/asset_models.dart';
 import '../../core/breakpoint.dart';
 import '../../core/format.dart';
 import '../../core/security_risk.dart';
-import 'providers.dart';
 import 'sell_assets_providers.dart';
 
 // ---------------------------------------------------------------------------
@@ -867,60 +866,9 @@ class SellOptionDetail extends ConsumerWidget {
               ),
             ],
           ),
-          const SizedBox(height: 24),
-
-          // ── Action button ────────────────────────────────────────────────
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton.icon(
-              key: const Key('sell-waypoint-button'),
-              onPressed: () => _setWaypoint(context, ref),
-              icon: const Icon(Icons.navigation_rounded),
-              label: const Text('Route an EVE übertragen'),
-              style: FilledButton.styleFrom(
-                backgroundColor: accent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(vertical: 14),
-                textStyle: const TextStyle(
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16,
-                ),
-              ),
-            ),
-          ),
         ],
       ),
     );
-  }
-
-  Future<void> _setWaypoint(BuildContext context, WidgetRef ref) async {
-    final api = ref.read(tradingApiProvider);
-    try {
-      // Single sell destination; clear any existing route.
-      await api.setWaypoint(
-        destinationId: option.stationId,
-        clearOtherWaypoints: true,
-        addToBeginning: false,
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Route gesetzt: ${option.systemName}'),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Fehler beim Setzen der Route: $e'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
-      }
-    }
   }
 }
 

--- a/app/test/e2e/support/fakes.dart
+++ b/app/test/e2e/support/fakes.dart
@@ -316,12 +316,6 @@ class FakeTradingApi extends TradingApi {
   Future<PortfolioResult> optimizePortfolio(PortfolioRequest request) async =>
       fakePortfolioResponse();
 
-  @override
-  Future<void> setWaypoint({
-    required int destinationId,
-    bool addToBeginning = false,
-    bool clearOtherWaypoints = false,
-  }) async {}
 }
 
 // ---------------------------------------------------------------------------

--- a/app/test/hauling_screen_layout_test.dart
+++ b/app/test/hauling_screen_layout_test.dart
@@ -221,9 +221,6 @@ void main() {
     expect(find.text('Meta-4 Module A'), findsOneWidget);
     // Cargo column headers.
     expect(find.text('Gewinn/m³'), findsOneWidget);
-    // Waypoint action button present.
-    expect(find.byKey(const Key('hauling-waypoint-button')), findsOneWidget);
-    expect(find.text('Route an EVE übertragen'), findsOneWidget);
   });
 
   testWidgets('Empty routes result shows the empty-state', (tester) async {

--- a/app/test/roi_calculator_screen_layout_test.dart
+++ b/app/test/roi_calculator_screen_layout_test.dart
@@ -177,16 +177,12 @@ void main() {
     expect(find.text('72/100'), findsOneWidget);
   });
 
-  testWidgets('Allocation rows render Route text + waypoint button',
-      (tester) async {
+  testWidgets('Allocation rows render compact route text', (tester) async {
     await _pumpScreen(tester, 1280);
 
     // Compact "buy → sell" route label.
     expect(find.text('Jita → Amarr'), findsOneWidget);
     expect(find.text('Jita → Dodixie'), findsOneWidget);
-    // One waypoint button per allocation row.
-    expect(find.byKey(const Key('roi-waypoint-34')), findsOneWidget);
-    expect(find.byKey(const Key('roi-waypoint-35')), findsOneWidget);
   });
 
   testWidgets('Empty items result shows the no-viable-portfolio empty-state',

--- a/app/test/sell_assets_screen_layout_test.dart
+++ b/app/test/sell_assets_screen_layout_test.dart
@@ -281,16 +281,16 @@ void main() {
     expect(find.text('Region'), findsWidgets);
   });
 
-  testWidgets('Tapping an option opens the detail with the waypoint button',
-      (tester) async {
+  testWidgets('Tapping an option opens the detail view', (tester) async {
     await _pumpScreen(tester, 1280);
 
     // Tap the second (current_region) option; the best+first share station id.
     await tester.tap(find.text('Sobaseki Outpost'));
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const Key('sell-waypoint-button')), findsOneWidget);
-    expect(find.text('Route an EVE übertragen'), findsOneWidget);
+    // The detail view shows the station name (also already visible in the
+    // list, but rendering twice is a fine proxy for "the detail opened").
+    expect(find.text('Sobaseki Outpost'), findsWidgets);
   });
 
   testWidgets('Empty options result shows the empty-state', (tester) async {

--- a/app/test/trading_api_test.dart
+++ b/app/test/trading_api_test.dart
@@ -257,30 +257,4 @@ void main() {
     });
   });
 
-  // ── setWaypoint ───────────────────────────────────────────────────────────
-
-  group('TradingApi.setWaypoint', () {
-    test('POSTs to /api/v1/esi/ui/autopilot/waypoint with correct body',
-        () async {
-      String? capturedPath;
-      Map<String, dynamic>? capturedBody;
-
-      dio.httpClientAdapter = _CallbackAdapter((options) {
-        capturedPath = options.path;
-        capturedBody = options.data as Map<String, dynamic>?;
-        return ResponseBody.fromString('', 204);
-      });
-
-      await api.setWaypoint(
-        destinationId: 30000142,
-        addToBeginning: true,
-        clearOtherWaypoints: false,
-      );
-
-      expect(capturedPath, '/api/v1/esi/ui/autopilot/waypoint');
-      expect(capturedBody?['destination_id'], 30000142);
-      expect(capturedBody?['add_to_beginning'], true);
-      expect(capturedBody?['clear_other_waypoints'], false);
-    });
-  });
 }

--- a/app/test/trading_screen_layout_test.dart
+++ b/app/test/trading_screen_layout_test.dart
@@ -53,12 +53,6 @@ class _FakeApi extends TradingApi {
         refreshAllowed: true,
       );
 
-  @override
-  Future<void> setWaypoint({
-    required int destinationId,
-    bool addToBeginning = false,
-    bool clearOtherWaypoints = false,
-  }) async {}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Owner-Entscheidung: die Tablet-App ist ein Planungs-/Analyse-Client, keine Spiele-Fernbedienung. Spiele-Aktions-Buttons (Route an EVE übertragen, ROI-Item-Tap → Marktdetails) und die UI-Scopes fliegen aus der Flutter-Seite raus. Web behält beide Features (Waypoint-Übertragung funktioniert dort; Markt-Open ist ESI-seitig flaky → bleibt bestehen).

## Changes

- `app/lib/core/env.dart` — `esi-ui.write_waypoint.v1` + `esi-ui.open_window.v1` raus aus der Scope-Liste.
- `app/lib/api/trading_api.dart` — `setWaypoint` und `openMarketDetails` entfernt.
- ROI / Hauling / Route-Detail / Sell-Assets — Waypoint-Buttons + Handler raus, ROI-Item-Tap zurück zu plain Text.
- Tests — waypoint-button-Assertions ersetzt durch Detail-View-Sichtbarkeits-Checks.

## Test plan

- [x] `flutter analyze lib/ test/` clean
- [x] `flutter test` — 186 passed
- [ ] CI grün
- [ ] On-device nach Deploy: Flutter zeigt keine Spiele-Buttons mehr, Re-Login fragt die UI-Scopes nicht mehr an

🤖 Generated with [Claude Code](https://claude.com/claude-code)