### PR TITLE
fix(web): clarify ROI market-link expectations (Photon-UI #1349)

### DIFF
--- a/frontend/src/components/trading/PortfolioResultTable.tsx
+++ b/frontend/src/components/trading/PortfolioResultTable.tsx
@@ -43,7 +43,16 @@ export function PortfolioResultTable({ result }: PortfolioResultTableProps) {
       <CardHeader>
         <CardTitle className="text-xl">Kapital-Allokation</CardTitle>
       </CardHeader>
-      <CardContent className="p-0">
+      <CardContent className="space-y-2 p-0">
+        <p
+          data-testid="portfolio-eve-ui-hint"
+          className="px-4 pt-2 text-xs text-muted-foreground"
+        >
+          Tipp: Klick auf einen Item-Namen sendet das Markt-Detail an deinen
+          EVE-Client. Das funktioniert nur, wenn das Markt-Fenster im Spiel
+          schon offen ist (Alt+R) — Photon-UI navigiert nur in geöffneten
+          Fenstern (ESI-Issue #1349).
+        </p>
         <div className="overflow-x-auto">
           <table className="w-full text-sm" aria-label="Kapital-Allokation">
             <thead>
@@ -120,9 +129,13 @@ function PortfolioRowItem({ item }: { item: PortfolioItem }) {
     }
     try {
       await openMarketDetails(item.type_id);
+      // ESI returns 204 regardless of whether the EVE client actually opens
+      // anything — the Photon UI only navigates inside ALREADY-OPEN windows
+      // (esi-issues #1349). Wording reflects that so the user knows where
+      // to look or what to fix if nothing happens.
       toast({
-        title: "Markt geöffnet",
-        description: `${item.name} im EVE-Client geöffnet`,
+        title: "Markt-Detail an EVE gesendet",
+        description: `${item.name} — falls nichts passiert: Markt-Fenster im Spiel (Alt+R) öffnen und nochmal klicken.`,
       });
     } catch (err) {
       toast({


### PR DESCRIPTION
## Summary

Owner-Feedback: ROI-Item-Klick zeigt Toast „Markt geöffnet", aber EVE-Client öffnet kein Fenster. Root-Cause: bekannter Photon-UI-Bug ([esi-issues #1349](https://github.com/esi/esi-issues/issues/1349)) — ESI gibt 204, das Photon-UI navigiert aber nur in **bereits offenen** Fenstern. Kein Bug bei uns.

## Changes

- **Toast** (`handleOpenMarket`) formuliert die Realität aus: „Markt-Detail an EVE gesendet — falls nichts passiert: Markt-Fenster im Spiel (Alt+R) öffnen und nochmal klicken."
- **Statischer Tipp** über der Kapital-Allokations-Tabelle erklärt den Workflow + verweist auf das ESI-Issue.

## Test plan

- [x] `npx vitest run` — 62 passed
- [x] `npx eslint src/components/trading/PortfolioResultTable.tsx` clean
- [ ] CI grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)