### PR TITLE
fix(roi): cap allocation by order-book availability (cheapest tier)

### DIFF
--- a/backend/internal/services/portfolio_service.go
+++ b/backend/internal/services/portfolio_service.go
@@ -50,19 +50,20 @@ func (s *PortfolioService) Optimize(ctx context.Context, req *models.PortfolioRe
 			dailyVol = r.VolumeMetrics.DailyVolumeAvg
 		}
 		cands = append(cands, Candidate{
-			TypeID:          r.ItemTypeID,
-			Name:            r.ItemName,
-			ProfitPerUnit:   r.ProfitPerUnit,
-			BuyPricePerUnit: r.BuyPrice,
-			UnitVolume:      r.ItemVolume,
-			DailyVolume:     dailyVol,
-			TripMinutes:     r.RoundTripSeconds / 60.0,
-			BuySystemName:   r.BuySystemName,
-			BuyStationName:  r.BuyStationName,
-			BuyStationID:    r.BuyStationID,
-			SellSystemName:  r.SellSystemName,
-			SellStationName: r.SellStationName,
-			SellStationID:   r.SellStationID,
+			TypeID:            r.ItemTypeID,
+			Name:              r.ItemName,
+			ProfitPerUnit:     r.ProfitPerUnit,
+			BuyPricePerUnit:   r.BuyPrice,
+			UnitVolume:        r.ItemVolume,
+			DailyVolume:       dailyVol,
+			TripMinutes:       r.RoundTripSeconds / 60.0,
+			MaxAvailableUnits: r.Quantity, // order-book limit at cheapest tier
+			BuySystemName:     r.BuySystemName,
+			BuyStationName:    r.BuyStationName,
+			BuyStationID:      r.BuyStationID,
+			SellSystemName:    r.SellSystemName,
+			SellStationName:   r.SellStationName,
+			SellStationID:     r.SellStationID,
 		})
 	}
 
@@ -142,6 +143,11 @@ type Candidate struct {
 	UnitVolume      float64 // m³ per unit
 	DailyVolume     float64 // market daily volume (for liquidity cap)
 	TripMinutes     float64 // round-trip minutes for this route
+	// MaxAvailableUnits is the order-book availability at the cheapest sell-order
+	// tier (i.e. how many units are buyable at BuyPricePerUnit). Caps the
+	// allocation so the optimizer doesn't extrapolate the cheapest price across
+	// hundreds of units when only a handful exist at that price.
+	MaxAvailableUnits int
 	// Execution location (buy at the buy station, sell at the sell station).
 	BuySystemName   string
 	BuyStationName  string
@@ -218,6 +224,13 @@ func (o *PortfolioOptimizer) Optimize(cands []Candidate, p OptimizeParams) Portf
 		maxUnits := int(c.DailyVolume * p.LiquidityCapPct / 100.0)
 		if capCap := int(perItemCapital / c.BuyPricePerUnit); capCap < maxUnits {
 			maxUnits = capCap
+		}
+		// Cap by order-book availability at the cheapest tier — otherwise the
+		// optimizer extrapolates the cheapest price across units that don't
+		// exist at that price (the next tier is usually much more expensive
+		// and would flip the ROI negative). See route_finder.AvailableQuantity.
+		if c.MaxAvailableUnits > 0 && c.MaxAvailableUnits < maxUnits {
+			maxUnits = c.MaxAvailableUnits
 		}
 		if maxUnits < 1 {
 			continue

--- a/backend/internal/services/portfolio_service_test.go
+++ b/backend/internal/services/portfolio_service_test.go
@@ -46,6 +46,27 @@ func TestOptimize_LiquidityCapLimitsUnits(t *testing.T) {
 	}
 }
 
+// TestOptimize_CapsAtOrderBookAvailability covers the case we hit on prod:
+// the cheapest sell-order tier has only N units, but the optimizer was
+// extrapolating that price across hundreds of units (capital/price). With
+// MaxAvailableUnits set from the route's order-book limit, the allocation
+// must not exceed N — otherwise the projected ROI is fiction.
+func TestOptimize_CapsAtOrderBookAvailability(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	c := cand(1, "Carbon", 300, 85, 0.1, 1_000_000, 10) // huge daily volume, big capital
+	c.MaxAvailableUnits = 2                             // but only 2 units at this price
+	res := opt.Optimize([]Candidate{c}, OptimizeParams{
+		Capital: 1e9, CargoCapacity: 1e9, TimeBudgetMin: 1e9,
+		LiquidityCapPct: 100, MaxItemPct: 100,
+	})
+	if len(res.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(res.Items))
+	}
+	if res.Items[0].Units > 2 {
+		t.Errorf("order-book cap violated: got %d units, want ≤ 2", res.Items[0].Units)
+	}
+}
+
 func TestOptimize_TimeBudgetLimitsTrips(t *testing.T) {
 	opt := NewPortfolioOptimizer()
 	cands := []Candidate{cand(1, "A", 5, 10, 1, 1e9, 10)}


### PR DESCRIPTION
## Summary

Reporter (EVE-Markt-Screenshot): ROI empfiehlt **154 Carbon zu 85 ISK** mit 354% ROI — der EVE-Markt zeigt aber nur **2 Stück** zu diesem Preis. Die nächsten 4.092 Stück kosten **332,51 ISK** → ROI würde mit der zweiten Tier kippen.

## Root cause

- `route_finder.go` rechnet `AvailableQuantity = min(cheapest-sell-VolumeRemain, highest-buy-VolumeRemain)` korrekt aus (= 2 für Carbon).
- `TradingRoute.Quantity` trägt diesen Wert.
- `portfolio_service.go` baut daraus `Candidate`, ließ dabei aber `Quantity` weg.
- Optimizer rechnet `maxUnits = min(liquidity_cap, kapital / cheapest_price)` — extrapolierte den Cheapest-Tier-Preis über Mengen, die zu dem Preis gar nicht existierten.

## Fix

- `Candidate.MaxAvailableUnits` neu, befüllt aus `TradingRoute.Quantity`.
- `Optimize` cappt `maxUnits` zusätzlich darauf.
- Regressionstest: bei `MaxAvailableUnits=2` darf die Allokation nicht > 2 sein, auch wenn Kapital + Liquiditäts-Cap viel mehr erlauben würden.

## Test plan

- [x] Backend `go test ./...` — alle grün; gofmt/vet clean
- [ ] CI grün
- [ ] Web on-Prod: gleicher Region/Schiff/Kapital-Setup wie im Bug-Screenshot, Carbon-Empfehlung muss jetzt realistische Stückzahl + ROI zeigen

🤖 Generated with [Claude Code](https://claude.com/claude-code)