### PR TITLE
fix(sell-assets): explain why citadel-origin items have no routes

### DIFF
--- a/app/lib/api/asset_models.dart
+++ b/app/lib/api/asset_models.dart
@@ -241,6 +241,7 @@ class SellOptionsResponse {
     required this.best,
     required this.options,
     required this.skillsApplied,
+    this.notRoutableReason,
   });
 
   /// Backend: `type_id`
@@ -263,6 +264,11 @@ class SellOptionsResponse {
 
   /// Backend: `skills_applied`
   final SkillsApplied skillsApplied;
+
+  /// Backend: `not_routable_reason` — set when the empty result has a known
+  /// cause (currently only `"origin_in_player_structure"`). UI shows an
+  /// actionable hint instead of the generic "no buyers" message.
+  final String? notRoutableReason;
 
   /// True when no sell locations were returned.
   bool get isEmpty => options.isEmpty;
@@ -292,6 +298,7 @@ class SellOptionsResponse {
               salesTaxRate: 0,
               brokerFeeRate: 0,
             ),
+      notRoutableReason: json['not_routable_reason'] as String?,
     );
   }
 }

--- a/app/lib/features/trading/sell_assets_screen.dart
+++ b/app/lib/features/trading/sell_assets_screen.dart
@@ -380,7 +380,7 @@ class _ResultPane extends ConsumerWidget {
           return const _IdleHint();
         }
         if (resp.isEmpty) {
-          return const _EmptyResult();
+          return _EmptyResult(reason: resp.notRoutableReason);
         }
         return _OptionList(response: resp, twoPane: twoPane);
       },
@@ -421,10 +421,16 @@ class _IdleHint extends StatelessWidget {
 }
 
 class _EmptyResult extends StatelessWidget {
-  const _EmptyResult();
+  const _EmptyResult({this.reason});
+
+  /// Backend `not_routable_reason`. When set, the UI shows an actionable
+  /// explanation instead of the generic "no buyers" message.
+  final String? reason;
 
   @override
   Widget build(BuildContext context) {
+    final isCitadel = reason == 'origin_in_player_structure';
+    final muted = Theme.of(context).colorScheme.onSurface.withAlpha(140);
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(32),
@@ -433,19 +439,28 @@ class _EmptyResult extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
-              Icons.sentiment_dissatisfied_rounded,
+              isCitadel
+                  ? Icons.info_outline_rounded
+                  : Icons.sentiment_dissatisfied_rounded,
               size: 56,
               color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
             ),
             const SizedBox(height: 16),
             Text(
-              'Keine Verkaufsorte gefunden',
+              isCitadel
+                  ? 'Items liegen in einer Player-Structure'
+                  : 'Keine Verkaufsorte gefunden',
               textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    color:
-                        Theme.of(context).colorScheme.onSurface.withAlpha(140),
-                  ),
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(color: muted),
             ),
+            if (isCitadel) ...[
+              const SizedBox(height: 8),
+              Text(
+                'Routen aus Citadel/Upwell können wir nicht berechnen — die SDE kennt nur NPC-Stationen. Verlagere den Bestand in eine NPC-Station, dann erscheinen hier die Verkaufsorte.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(color: muted),
+              ),
+            ],
           ],
         ),
       ),

--- a/backend/internal/models/assets.go
+++ b/backend/internal/models/assets.go
@@ -44,12 +44,19 @@ type SellOption struct {
 }
 
 // SellOptionsResponse is the ranked result for one selected item.
+//
+// NotRoutableReason is set when the result is empty for a *reason worth showing
+// to the user* (rather than just "no buyers"). Currently the only value is
+// "origin_in_player_structure" — the item sits in a citadel / Upwell structure,
+// which the SDE can't resolve to a system, so we can't compute any route. The
+// client should render an actionable message ("move to an NPC station").
 type SellOptionsResponse struct {
-	TypeID         int           `json:"type_id"`
-	Name           string        `json:"name"`
-	Quantity       int           `json:"quantity"`
-	OriginSystemID int           `json:"origin_system_id"`
-	Best           *SellOption   `json:"best"`
-	Options        []SellOption  `json:"options"`
-	SkillsApplied  SkillsApplied `json:"skills_applied"`
+	TypeID            int           `json:"type_id"`
+	Name              string        `json:"name"`
+	Quantity          int           `json:"quantity"`
+	OriginSystemID    int           `json:"origin_system_id"`
+	Best              *SellOption   `json:"best"`
+	Options           []SellOption  `json:"options"`
+	SkillsApplied     SkillsApplied `json:"skills_applied"`
+	NotRoutableReason string        `json:"not_routable_reason,omitempty"`
 }

--- a/backend/internal/services/asset_sale_service.go
+++ b/backend/internal/services/asset_sale_service.go
@@ -154,7 +154,11 @@ func (s *AssetSaleService) SellOptions(ctx context.Context, req *models.SellOpti
 
 	originSys, err := s.sdeRepo.GetSystemIDForLocation(ctx, req.LocationID)
 	if err != nil {
-		return resp, nil // origin unresolvable -> empty options
+		// SDE only knows NPC stations — citadel/Upwell IDs (>=1e12) can't be
+		// resolved to a system, so we can't route from them. Tell the client
+		// explicitly so the UI can suggest moving the items to an NPC station.
+		resp.NotRoutableReason = "origin_in_player_structure"
+		return resp, nil
 	}
 	resp.OriginSystemID = int(originSys)
 	currentRegion, _ := s.sdeRepo.GetRegionIDForSystem(ctx, originSys)

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -215,6 +215,11 @@ func TestAssetSaleService_SellOptions_UnresolvableOrigin_ReturnsEmptySlice(t *te
 	if !bytes.Contains(blob, []byte(`"options":[]`)) {
 		t.Fatalf("expected JSON to contain `\"options\":[]`, got: %s", string(blob))
 	}
+	// And we surface WHY there are no options so the UI can show an actionable
+	// message instead of the generic "no buyers found" empty state.
+	if res.NotRoutableReason != "origin_in_player_structure" {
+		t.Errorf("not_routable_reason = %q, want %q", res.NotRoutableReason, "origin_in_player_structure")
+	}
 }
 
 func TestAssetSaleService_SellOptions_RanksTakerNet(t *testing.T) {

--- a/frontend/src/app/sell-assets/page.tsx
+++ b/frontend/src/app/sell-assets/page.tsx
@@ -85,6 +85,7 @@ function SellAssetsPageContent() {
               <SellOptionsResult
                 best={sellMutation.data.best}
                 options={sellMutation.data.options}
+                notRoutableReason={sellMutation.data.not_routable_reason}
               />
               <SkillsAppliedPanel skills={sellMutation.data.skills_applied} />
             </div>

--- a/frontend/src/components/trading/SellOptionsResult.tsx
+++ b/frontend/src/components/trading/SellOptionsResult.tsx
@@ -14,6 +14,9 @@ import { setWaypoint } from "@/lib/api-client";
 interface SellOptionsResultProps {
   best: SellOption | null;
   options: SellOption[];
+  /** Set when the empty result has a known cause; UI shows an actionable hint
+   *  instead of the generic "no buyers" message. */
+  notRoutableReason?: string;
 }
 
 const SECURITY_BADGE: Record<
@@ -67,17 +70,38 @@ function ScopeBadge({ scope }: { scope: SellOptionScope }) {
  * pre-sorted by total_net. Each option can be pushed to the in-game autopilot.
  * Options without market data render muted. An empty list shows a hint.
  */
-export function SellOptionsResult({ best, options }: SellOptionsResultProps) {
+export function SellOptionsResult({
+  best,
+  options,
+  notRoutableReason,
+}: SellOptionsResultProps) {
   // Tolerate `null` from older backends / unresolvable origins (player structures
   // return an empty path that historically marshaled as JSON null).
   const safeOptions = options ?? [];
   if (safeOptions.length === 0) {
+    const isCitadelOrigin = notRoutableReason === "origin_in_player_structure";
     return (
       <div
         data-testid="sell-options-empty"
+        data-reason={notRoutableReason || undefined}
         className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
       >
-        Keine Verkaufsorte gefunden
+        {isCitadelOrigin ? (
+          <>
+            <p className="font-medium">
+              Items liegen in einer Player-Structure (Citadel/Upwell).
+            </p>
+            <p className="mt-1">
+              Routen können wir aus Player-Structures nicht berechnen — die
+              SDE kennt nur NPC-Stationen. Verlagere den Bestand in eine
+              NPC-Station; dann erscheinen hier die Verkaufsorte. (ROI/Trading
+              zeigen die Marktdaten weiterhin an, weil sie regionsweit
+              rechnen, nicht von deinem Standort.)
+            </p>
+          </>
+        ) : (
+          "Keine Verkaufsorte gefunden"
+        )}
       </div>
     );
   }

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -314,4 +314,8 @@ export interface SellOptionsResponse {
   best: SellOption | null;
   options: SellOption[]; // pre-sorted by total_net desc
   skills_applied: SkillsApplied;
+  /** Set when the empty options list deserves an explanation. Current values:
+   *  "origin_in_player_structure" — the item sits in a citadel; SDE can't
+   *  resolve its system, so no route is possible. */
+  not_routable_reason?: string;
 }


### PR DESCRIPTION
## Summary

Reporter (Screenshots): ROI findet Carbon-Handel Clellinon→Ellmay; Sell-Assets sagt für dieselben 46 Carbon nur „Keine Verkaufsorte gefunden". Ursache: die Items liegen in einer Player-Structure (Station-ID 1.05×10¹² → Citadel/Upwell), die SDE kennt nur NPC-Stationen, also kann das Backend keinen Origin-System auflösen → früh-Return mit leerer Optionsliste. Diskrepanz ist seit v0.13.2 da, aber die Empty-State-Meldung war ununterscheidbar von „wirklich keine Käufer".

## Fix

- **Backend:** `SellOptionsResponse.not_routable_reason` (omitempty). Wert `"origin_in_player_structure"` wird gesetzt, wenn `GetSystemIDForLocation` scheitert. Regressionstest deckt das ab.
- **Web + Flutter:** `_EmptyResult` rendert konditional. Bei Citadel-Origin: „Items liegen in einer Player-Structure (Citadel/Upwell). Verlagere den Bestand in eine NPC-Station, dann erscheinen hier die Verkaufsorte." Sonst die bisherige Meldung.

## Test plan

- [x] `go test ./internal/services/` — grün, neuer Test (`TestAssetSaleService_SellOptions_UnresolvableOrigin_ReturnsEmptySlice`) prüft jetzt zusätzlich `not_routable_reason`
- [x] `npx vitest run` — 62 passed · ESLint clean
- [x] `flutter analyze lib/ test/` clean · `flutter test` — 186 passed
- [ ] CI grün
- [ ] On-prod nach Deploy: Sell-Assets mit Citadel-Item zeigt jetzt die konkrete Citadel-Meldung statt nur „Keine Verkaufsorte gefunden"

🤖 Generated with [Claude Code](https://claude.com/claude-code)