### PR TITLE
fix(sell-assets): walk asset tree to find NPC station behind a container

### DIFF
--- a/backend/internal/services/asset_fetcher.go
+++ b/backend/internal/services/asset_fetcher.go
@@ -10,7 +10,13 @@ import (
 )
 
 // RawAsset is the minimal ESI asset shape the aggregator needs.
+//
+// ItemID is the ESI item_id of *this* asset stack. We need it so that we can
+// resolve "item-in-container" cases: a child asset's LocationID points to its
+// container's ItemID (not to the station). Walking the chain bottom-up via
+// ItemID → LocationID lookups eventually hits an SDE-known station.
 type RawAsset struct {
+	ItemID       int64
 	TypeID       int
 	LocationID   int64
 	Quantity     int
@@ -37,6 +43,7 @@ func NewESIAssetFetcher() *ESIAssetFetcher {
 }
 
 type esiAssetPage struct {
+	ItemID       int64  `json:"item_id"`
 	TypeID       int    `json:"type_id"`
 	LocationID   int64  `json:"location_id"`
 	Quantity     int    `json:"quantity"`
@@ -90,7 +97,13 @@ func (f *ESIAssetFetcher) page(ctx context.Context, base, token string, page int
 	}
 	out := make([]RawAsset, 0, len(raw))
 	for _, a := range raw {
-		out = append(out, RawAsset{TypeID: a.TypeID, LocationID: a.LocationID, Quantity: a.Quantity, LocationFlag: a.LocationFlag})
+		out = append(out, RawAsset{
+			ItemID:       a.ItemID,
+			TypeID:       a.TypeID,
+			LocationID:   a.LocationID,
+			Quantity:     a.Quantity,
+			LocationFlag: a.LocationFlag,
+		})
 	}
 	return out, pages, nil
 }

--- a/backend/internal/services/asset_sale_service.go
+++ b/backend/internal/services/asset_sale_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sort"
 
 	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
@@ -152,11 +153,13 @@ func (s *AssetSaleService) SellOptions(ctx context.Context, req *models.SellOpti
 		Options:       []models.SellOption{},
 	}
 
-	originSys, err := s.sdeRepo.GetSystemIDForLocation(ctx, req.LocationID)
+	// Try the direct LocationID first (asset directly in a station hangar).
+	// If that fails, the asset may be nested in a container (item_id ≥ 1e12)
+	// that itself sits in an NPC station — walk the asset tree up to find
+	// the real station. Only a true citadel (no parent in NPC space) keeps
+	// the unresolvable reason.
+	originSys, err := s.resolveOriginSystem(ctx, req.LocationID, characterID, accessToken)
 	if err != nil {
-		// SDE only knows NPC stations — citadel/Upwell IDs (>=1e12) can't be
-		// resolved to a system, so we can't route from them. Tell the client
-		// explicitly so the UI can suggest moving the items to an NPC station.
 		resp.NotRoutableReason = "origin_in_player_structure"
 		return resp, nil
 	}
@@ -215,6 +218,45 @@ func (s *AssetSaleService) SellOptions(ctx context.Context, req *models.SellOpti
 		}
 	}
 	return resp, nil
+}
+
+// resolveOriginSystem returns the system ID that contains the given asset
+// LocationID. If the LocationID resolves directly via the SDE (NPC station),
+// it returns immediately. Otherwise the asset may be nested inside a container
+// (ItemID stored as another asset's LocationID), so we fetch the character's
+// asset list and walk the chain ItemID → LocationID until we either hit an
+// SDE-known station or run out of parents (real citadel / loop).
+//
+// Bounded by maxDepth steps to prevent pathological chains or cycles.
+func (s *AssetSaleService) resolveOriginSystem(ctx context.Context, locationID int64, characterID int, accessToken string) (int64, error) {
+	const maxDepth = 8
+	// Direct hit?
+	if sysID, err := s.sdeRepo.GetSystemIDForLocation(ctx, locationID); err == nil {
+		return sysID, nil
+	}
+	// Build an ItemID → LocationID lookup from the character's asset list.
+	assets, err := s.assets.FetchCharacterAssets(ctx, characterID, accessToken)
+	if err != nil {
+		return 0, fmt.Errorf("origin unresolvable + asset fetch failed: %w", err)
+	}
+	parent := make(map[int64]int64, len(assets))
+	for _, a := range assets {
+		if a.ItemID != 0 {
+			parent[a.ItemID] = a.LocationID
+		}
+	}
+	current := locationID
+	for depth := 0; depth < maxDepth; depth++ {
+		next, ok := parent[current]
+		if !ok {
+			break // no parent — terminal unresolvable
+		}
+		if sysID, err := s.sdeRepo.GetSystemIDForLocation(ctx, next); err == nil {
+			return sysID, nil
+		}
+		current = next
+	}
+	return 0, fmt.Errorf("origin unresolvable after %d hops", maxDepth)
 }
 
 // buildOption computes net + route for one sell location. destSys is the system to route

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -222,6 +222,47 @@ func TestAssetSaleService_SellOptions_UnresolvableOrigin_ReturnsEmptySlice(t *te
 	}
 }
 
+// TestAssetSaleService_SellOptions_ItemInContainerInNPCStation covers the
+// case the owner reported: the asset's LocationID is the *container's* ItemID
+// (≥ 1e12) but that container itself sits in an NPC station's hangar. Walking
+// ItemID→LocationID in the character's asset list one step up yields the
+// station, so sell-options must still be computed (not the citadel fallback).
+func TestAssetSaleService_SellOptions_ItemInContainerInNPCStation(t *testing.T) {
+	sde := newAssetTestSDE(t)
+	defer sde.Close()
+	repo := database.NewSDERepository(sde)
+
+	const containerItemID = int64(1_050_676_761_748) // looks like a citadel, isn't
+	const jitaIVStationID = int64(60003760)          // SDE-known NPC station
+
+	// The container is an asset of the character, residing in the station hangar.
+	// The Carbon stack we want to sell is an asset whose LocationID = container.
+	svc := NewAssetSaleService(
+		fakeAssetSkills{},
+		fakeHubFetcher{ordersByRegion: map[int][]esi.ESIMarketOrder{
+			10000002: {{IsBuyOrder: true, Price: 400.0, VolumeRemain: 1000, LocationID: jitaIVStationID}},
+		}},
+		fakeTypeNamer{name: "Carbon", marketable: true},
+		fakeAssetFetcher{assets: []RawAsset{
+			{ItemID: containerItemID, TypeID: 17363, LocationID: jitaIVStationID, LocationFlag: "Hangar"},
+			// Carbon's own ItemID doesn't matter for the lookup of its origin,
+			// but the request's LocationID must match the container's ItemID.
+		}},
+		fakeFitting{}, fakeActiveShip{}, repo, sde, applogger.New(),
+	)
+	req := &models.SellOptionsRequest{TypeID: 34, LocationID: containerItemID, Quantity: 46}
+	res, err := svc.SellOptions(context.Background(), req, 1, "tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NotRoutableReason != "" {
+		t.Errorf("expected no not_routable_reason (container resolves via asset tree), got %q", res.NotRoutableReason)
+	}
+	if res.OriginSystemID == 0 {
+		t.Errorf("expected origin system resolved via asset tree, got 0")
+	}
+}
+
 func TestAssetSaleService_SellOptions_RanksTakerNet(t *testing.T) {
 	sde := newAssetTestSDE(t)
 	defer sde.Close()


### PR DESCRIPTION
## Summary

Owner-Reporter: Carbon-Stack im Container (z.B. Personal Hangar Container) innerhalb einer NPC-Station. ESI gibt für die Carbon-Asset `location_id` = Container-ItemID (≥ 1×10¹², sieht aus wie eine Citadel-ID), nicht die Station-ID. v0.15.4 zeigte deshalb die Citadel-Empfehlung „verlagere in NPC-Station" — fälschlich, denn der Container LIEGT bereits in einer NPC-Station.

## Fix

- `RawAsset` trägt jetzt `ItemID` (war vorher nicht durchgereicht).
- Neuer `resolveOriginSystem`-Helper: erst direkter SDE-Lookup (Asset direkt im Stations-Hangar) — wie bisher. Bei Fehlschlag wird die volle Asset-Liste gefetcht, eine `ItemID→LocationID`-Map gebaut und die Container-Kette bottom-up gelaufen (max. 8 Hops als Loop-Schutz). Sobald ein Hop in einer SDE-bekannten Station landet, wird dessen System zurückgegeben.
- Nur wenn die Kette ohne Treffer endet (echte Citadel als oberstes Parent, oder Asset hat keinen Parent-Eintrag), bleibt der bisherige `"origin_in_player_structure"`-Pfad mit der entsprechenden UI-Meldung.

## Test plan

- [x] Backend `go test ./...` — alle grün; gofmt/vet clean
- [x] Neuer Regressionstest (`TestAssetSaleService_SellOptions_ItemInContainerInNPCStation`): Container → NPC-Station → kein `not_routable_reason`, OriginSystemID gesetzt
- [x] Citadel-Test bleibt grün (Kette endet ohne SDE-Treffer → bisheriger Pfad)
- [ ] CI grün
- [ ] On-prod: Carbon im Container ist jetzt routbar; ROI/Sell-Assets liefern für dasselbe Item beide Routen

🤖 Generated with [Claude Code](https://claude.com/claude-code)