### PR TITLE
feat(sell-assets): refresh button for the asset list

### DIFF
--- a/app/lib/features/trading/sell_assets_screen.dart
+++ b/app/lib/features/trading/sell_assets_screen.dart
@@ -137,25 +137,49 @@ class _PickerPaneState extends ConsumerState<_PickerPane> {
     final busy = ref.watch(sellOptionsProvider).isLoading;
     final assetsAsync = ref.watch(characterAssetsProvider);
 
+    final assetsLoading = assetsAsync.isLoading;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        // ── Search field ───────────────────────────────────────────────────
+        // ── Search field + refresh action ─────────────────────────────────
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: TextField(
-            key: const Key('sell-asset-search'),
-            controller: _searchController,
-            enabled: !busy,
-            onChanged: (v) => setState(() => _query = v.trim().toLowerCase()),
-            decoration: const InputDecoration(
-              labelText: 'Item suchen',
-              prefixIcon: Icon(Icons.search_rounded),
-              border: OutlineInputBorder(),
-              isDense: true,
-              contentPadding:
-                  EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            ),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  key: const Key('sell-asset-search'),
+                  controller: _searchController,
+                  enabled: !busy,
+                  onChanged: (v) =>
+                      setState(() => _query = v.trim().toLowerCase()),
+                  decoration: const InputDecoration(
+                    labelText: 'Item suchen',
+                    prefixIcon: Icon(Icons.search_rounded),
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                    contentPadding:
+                        EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton(
+                key: const Key('sell-asset-refresh'),
+                tooltip: 'Asset-Liste neu laden',
+                visualDensity: VisualDensity.compact,
+                onPressed: (busy || assetsLoading)
+                    ? null
+                    : () => ref.invalidate(characterAssetsProvider),
+                icon: assetsLoading
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.refresh_rounded),
+              ),
+            ],
           ),
         ),
 

--- a/frontend/src/components/trading/AssetPicker.tsx
+++ b/frontend/src/components/trading/AssetPicker.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowDownAZ, ArrowUpAZ, Loader2, Search } from "lucide-react";
+import { ArrowDownAZ, ArrowUpAZ, Loader2, RefreshCw, Search } from "lucide-react";
 import { AssetItem, SellOptionsRequest } from "@/types/trading";
 import { listAssets } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
@@ -42,6 +42,7 @@ export function AssetPicker({
     data,
     isLoading,
     isError,
+    isFetching,
     error,
     refetch,
   } = useQuery({
@@ -90,7 +91,25 @@ export function AssetPicker({
   return (
     <div className="space-y-4 rounded-lg border p-4" data-testid="asset-picker">
       <div className="space-y-2">
-        <Label htmlFor="asset-filter">Asset suchen</Label>
+        <div className="flex items-center justify-between gap-2">
+          <Label htmlFor="asset-filter">Asset suchen</Label>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            data-testid="asset-refresh"
+            onClick={() => refetch()}
+            disabled={isFetching}
+            title="Asset-Liste aus EVE neu laden"
+            aria-label="Asset-Liste neu laden"
+          >
+            {isFetching ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <RefreshCw className="size-4" />
+            )}
+          </Button>
+        </div>
         <div className="relative">
           <Search className="pointer-events-none absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
           <Input


### PR DESCRIPTION
## Summary

Owner-Request: nach Items-Verschieben im Spiel möchte man die Asset-Liste manuell aktualisieren, statt auf den nächsten App-Reload zu warten.

- **Web:** Refresh-Icon-Button neben dem „Asset suchen"-Label im `AssetPicker`. Triggert React-Query `refetch`; während `isFetching` Spinner.
- **Flutter:** Refresh-IconButton rechts vom Suchfeld im Sell-Assets-Picker. Triggert `ref.invalidate(characterAssetsProvider)`; während `isLoading` Spinner.

## Caveat

ESI cached Charakter-Assets serverseitig mit ~1 h TTL — ein Klick auf Refresh kann den alten Stand zeigen, wenn der EVE-Server-Cache noch nicht abgelaufen ist. Das ist außerhalb unseres Einflusses. Backend selbst cached die Liste nicht; jeder Refresh hits ESI direkt.

## Test plan

- [x] `npx vitest run` — 62 passed · ESLint clean
- [x] `flutter analyze lib/ test/` clean · `flutter test` — 186 passed
- [ ] CI grün
- [ ] On-prod: Web → Sell-Assets, Refresh-Button neben „Asset suchen" sichtbar, klick triggert Loader
- [ ] APK on-device: rechts vom Suchfeld Refresh-Icon, Klick aktualisiert die Liste

🤖 Generated with [Claude Code](https://claude.com/claude-code)