### PR TITLE
feat(sell-assets): surface ESI cache-expiry so users know when refresh helps

### DIFF
--- a/app/lib/api/asset_models.dart
+++ b/app/lib/api/asset_models.dart
@@ -79,6 +79,7 @@ class AssetsResponse {
   const AssetsResponse({
     required this.assets,
     required this.count,
+    this.cacheExpiresAt,
   });
 
   /// Backend: `assets`
@@ -86,6 +87,11 @@ class AssetsResponse {
 
   /// Backend: `count`
   final int count;
+
+  /// Backend: `cache_expires_at` — ESI serves the same snapshot until this
+  /// point; a refresh before then returns identical data. Null when ESI didn't
+  /// return a parseable `Expires` header.
+  final DateTime? cacheExpiresAt;
 
   /// True when the character owns no (marketable or otherwise) assets.
   bool get isEmpty => assets.isEmpty;
@@ -98,6 +104,9 @@ class AssetsResponse {
           .map(AssetItem.fromJson)
           .toList(),
       count: (json['count'] as num?)?.toInt() ?? 0,
+      cacheExpiresAt: DateTime.tryParse(
+        json['cache_expires_at'] as String? ?? '',
+      ),
     );
   }
 }

--- a/app/lib/features/trading/sell_assets_screen.dart
+++ b/app/lib/features/trading/sell_assets_screen.dart
@@ -14,6 +14,8 @@
 ///                right; tapping an option shows its detail in a dialog.
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -182,6 +184,11 @@ class _PickerPaneState extends ConsumerState<_PickerPane> {
             ],
           ),
         ),
+        if (assetsAsync.value?.cacheExpiresAt != null)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: _CacheHint(expiresAt: assetsAsync.value!.cacheExpiresAt!),
+          ),
 
         // ── Sort control ───────────────────────────────────────────────────
         Padding(
@@ -919,6 +926,72 @@ class SellOptionDetail extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Surfaces the ESI cache-expiry so the user knows when a refresh can actually
+/// pull fresh state. ESI cached the asset list for ~1 h after CCP's last
+/// update; refreshing before [expiresAt] returns the same snapshot.
+class _CacheHint extends StatefulWidget {
+  const _CacheHint({required this.expiresAt});
+  final DateTime expiresAt;
+
+  @override
+  State<_CacheHint> createState() => _CacheHintState();
+}
+
+class _CacheHintState extends State<_CacheHint> {
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    // Update the countdown every 30 s.
+    _ticker = Timer.periodic(const Duration(seconds: 30), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final diff = widget.expiresAt.difference(DateTime.now());
+    final time =
+        '${widget.expiresAt.toLocal().hour.toString().padLeft(2, '0')}:${widget.expiresAt.toLocal().minute.toString().padLeft(2, '0')}';
+    String label;
+    if (diff.inSeconds <= 0) {
+      label =
+          'ESI-Cache abgelaufen — Refresh holt jetzt frische Daten.';
+    } else if (diff.inMinutes < 1) {
+      label =
+          'ESI-Cache läuft gleich ab (${diff.inSeconds} s) — Refresh holt dann frische Daten.';
+    } else {
+      label =
+          'ESI-Cache läuft bis $time (${diff.inMinutes} min) — Refresh vorher zeigt denselben Stand.';
+    }
+    return Row(
+      children: [
+        Icon(
+          Icons.access_time_rounded,
+          size: 14,
+          color: Theme.of(context).colorScheme.onSurface.withAlpha(140),
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurface.withAlpha(140),
+                ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/backend/internal/models/assets.go
+++ b/backend/internal/models/assets.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 // AssetItem is one aggregated owned stack: a type at a location with a summed quantity.
 type AssetItem struct {
 	TypeID       int    `json:"type_id"`
@@ -13,9 +15,16 @@ type AssetItem struct {
 }
 
 // AssetsResponse is the GET /trading/assets payload.
+//
+// CacheExpiresAt is the ESI cache-expiry (UTC RFC 3339). ESI serves the same
+// snapshot until that point — a client-side refresh before then will return
+// identical data. The UI surfaces this so the user knows when a refresh can
+// actually pull fresh state. Omitted when ESI didn't return a parseable
+// `Expires` header (treated as "unknown").
 type AssetsResponse struct {
-	Assets []AssetItem `json:"assets"`
-	Count  int         `json:"count"`
+	Assets         []AssetItem `json:"assets"`
+	Count          int         `json:"count"`
+	CacheExpiresAt *time.Time  `json:"cache_expires_at,omitempty"`
 }
 
 // SellOptionsRequest is the POST /trading/assets/sell-options body.

--- a/backend/internal/services/asset_fetcher.go
+++ b/backend/internal/services/asset_fetcher.go
@@ -24,8 +24,13 @@ type RawAsset struct {
 }
 
 // assetFetcher fetches a character's full asset list (keeps AssetSaleService testable).
+//
+// expiresAt is the ESI cache-expiry time parsed from the `Expires` response
+// header. Until that point, ESI serves the same snapshot — a client refresh
+// won't see fresh data. Returns the zero value if the header was missing or
+// unparseable; callers must treat that as "expiry unknown".
 type assetFetcher interface {
-	FetchCharacterAssets(ctx context.Context, characterID int, accessToken string) ([]RawAsset, error)
+	FetchCharacterAssets(ctx context.Context, characterID int, accessToken string) (assets []RawAsset, expiresAt time.Time, err error)
 }
 
 // ESIAssetFetcher calls /characters/{id}/assets/ with pagination (X-Pages).
@@ -50,40 +55,41 @@ type esiAssetPage struct {
 	LocationFlag string `json:"location_flag"`
 }
 
-// FetchCharacterAssets pulls every page of the character's assets.
-func (f *ESIAssetFetcher) FetchCharacterAssets(ctx context.Context, characterID int, accessToken string) ([]RawAsset, error) {
+// FetchCharacterAssets pulls every page of the character's assets and returns
+// the ESI cache-expiry from the first page's `Expires` header.
+func (f *ESIAssetFetcher) FetchCharacterAssets(ctx context.Context, characterID int, accessToken string) ([]RawAsset, time.Time, error) {
 	base := fmt.Sprintf("%s/latest/characters/%d/assets/", f.baseURL, characterID)
-	first, pages, err := f.page(ctx, base, accessToken, 1)
+	first, pages, expiresAt, err := f.page(ctx, base, accessToken, 1)
 	if err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
 	all := first
 	for p := 2; p <= pages; p++ {
-		more, _, err := f.page(ctx, base, accessToken, p)
+		more, _, _, err := f.page(ctx, base, accessToken, p)
 		if err != nil {
-			return nil, err
+			return nil, time.Time{}, err
 		}
 		all = append(all, more...)
 	}
-	return all, nil
+	return all, expiresAt, nil
 }
 
-func (f *ESIAssetFetcher) page(ctx context.Context, base, token string, page int) ([]RawAsset, int, error) {
+func (f *ESIAssetFetcher) page(ctx context.Context, base, token string, page int) ([]RawAsset, int, time.Time, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"?page="+strconv.Itoa(page), nil)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, time.Time{}, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	resp, err := f.client.Do(req)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, time.Time{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, 0, fmt.Errorf("unauthorized")
+		return nil, 0, time.Time{}, fmt.Errorf("unauthorized")
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, 0, fmt.Errorf("ESI assets status %d", resp.StatusCode)
+		return nil, 0, time.Time{}, fmt.Errorf("ESI assets status %d", resp.StatusCode)
 	}
 	pages := 1
 	if x := resp.Header.Get("X-Pages"); x != "" {
@@ -91,9 +97,18 @@ func (f *ESIAssetFetcher) page(ctx context.Context, base, token string, page int
 			pages = v
 		}
 	}
+	// ESI's `Expires` header is RFC 1123 / http.TimeFormat. Best-effort: parse
+	// it; on failure leave expiresAt as zero so the caller treats it as
+	// "unknown" rather than crashing.
+	var expiresAt time.Time
+	if x := resp.Header.Get("Expires"); x != "" {
+		if t, err := http.ParseTime(x); err == nil {
+			expiresAt = t.UTC()
+		}
+	}
 	var raw []esiAssetPage
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
-		return nil, 0, err
+		return nil, 0, time.Time{}, err
 	}
 	out := make([]RawAsset, 0, len(raw))
 	for _, a := range raw {
@@ -105,5 +120,5 @@ func (f *ESIAssetFetcher) page(ctx context.Context, base, token string, page int
 			LocationFlag: a.LocationFlag,
 		})
 	}
-	return out, pages, nil
+	return out, pages, expiresAt, nil
 }

--- a/backend/internal/services/asset_fetcher_test.go
+++ b/backend/internal/services/asset_fetcher_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestESIAssetFetcher_Paginates(t *testing.T) {
@@ -21,12 +22,32 @@ func TestESIAssetFetcher_Paginates(t *testing.T) {
 	defer srv.Close()
 
 	f := &ESIAssetFetcher{baseURL: srv.URL, client: srv.Client()}
-	got, err := f.FetchCharacterAssets(context.Background(), 123, "token")
+	got, _, err := f.FetchCharacterAssets(context.Background(), 123, "token")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if len(got) != 2 || got[0].TypeID != 34 || got[0].Quantity != 100 || got[1].TypeID != 35 {
 		t.Fatalf("unexpected assets: %+v", got)
+	}
+}
+
+// TestESIAssetFetcher_ParsesExpiresHeader: ESI signaliert per `Expires`-Header,
+// bis wann der serverseitige Cache läuft. Refresh-Klicks vor diesem Zeitpunkt
+// liefern dieselben Daten — die UI braucht den Wert, um das anzuzeigen.
+func TestESIAssetFetcher_ParsesExpiresHeader(t *testing.T) {
+	wantExpiry := time.Date(2026, 5, 30, 15, 0, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Expires", wantExpiry.Format(http.TimeFormat))
+		fmt.Fprint(w, `[{"type_id":34,"location_id":60003760,"quantity":1,"location_flag":"Hangar"}]`)
+	}))
+	defer srv.Close()
+	f := &ESIAssetFetcher{baseURL: srv.URL, client: srv.Client()}
+	_, gotExpiry, err := f.FetchCharacterAssets(context.Background(), 1, "tok")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !gotExpiry.Equal(wantExpiry) {
+		t.Errorf("expiry = %s, want %s", gotExpiry, wantExpiry)
 	}
 }
 
@@ -36,7 +57,7 @@ func TestESIAssetFetcher_Unauthorized(t *testing.T) {
 	}))
 	defer srv.Close()
 	f := &ESIAssetFetcher{baseURL: srv.URL, client: srv.Client()}
-	if _, err := f.FetchCharacterAssets(context.Background(), 1, "bad"); err == nil {
+	if _, _, err := f.FetchCharacterAssets(context.Background(), 1, "bad"); err == nil {
 		t.Fatalf("expected error on 401")
 	}
 }

--- a/backend/internal/services/asset_sale_service.go
+++ b/backend/internal/services/asset_sale_service.go
@@ -108,7 +108,7 @@ func NewAssetSaleService(
 
 // ListAssets returns the character's owned items aggregated by (type, location).
 func (s *AssetSaleService) ListAssets(ctx context.Context, characterID int, accessToken string) (*models.AssetsResponse, error) {
-	raw, err := s.assets.FetchCharacterAssets(ctx, characterID, accessToken)
+	raw, expiresAt, err := s.assets.FetchCharacterAssets(ctx, characterID, accessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,11 @@ func (s *AssetSaleService) ListAssets(ctx context.Context, characterID int, acce
 		}
 		items = append(items, item)
 	}
-	return &models.AssetsResponse{Assets: items, Count: len(items)}, nil
+	resp := &models.AssetsResponse{Assets: items, Count: len(items)}
+	if !expiresAt.IsZero() {
+		resp.CacheExpiresAt = &expiresAt
+	}
+	return resp, nil
 }
 
 // SellOptions ranks taker sell locations for one owned item.
@@ -235,7 +239,7 @@ func (s *AssetSaleService) resolveOriginSystem(ctx context.Context, locationID i
 		return sysID, nil
 	}
 	// Build an ItemID → LocationID lookup from the character's asset list.
-	assets, err := s.assets.FetchCharacterAssets(ctx, characterID, accessToken)
+	assets, _, err := s.assets.FetchCharacterAssets(ctx, characterID, accessToken)
 	if err != nil {
 		return 0, fmt.Errorf("origin unresolvable + asset fetch failed: %w", err)
 	}

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 
@@ -17,10 +18,13 @@ import (
 
 // --- fakes for the service test ---
 
-type fakeAssetFetcher struct{ assets []RawAsset }
+type fakeAssetFetcher struct {
+	assets    []RawAsset
+	expiresAt time.Time
+}
 
-func (f fakeAssetFetcher) FetchCharacterAssets(_ context.Context, _ int, _ string) ([]RawAsset, error) {
-	return f.assets, nil
+func (f fakeAssetFetcher) FetchCharacterAssets(_ context.Context, _ int, _ string) ([]RawAsset, time.Time, error) {
+	return f.assets, f.expiresAt, nil
 }
 
 type fakeAssetSkills struct{}

--- a/frontend/src/components/trading/AssetPicker.tsx
+++ b/frontend/src/components/trading/AssetPicker.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowDownAZ, ArrowUpAZ, Loader2, RefreshCw, Search } from "lucide-react";
+import { ArrowDownAZ, ArrowUpAZ, Clock, Loader2, RefreshCw, Search } from "lucide-react";
 import { AssetItem, SellOptionsRequest } from "@/types/trading";
 import { listAssets } from "@/lib/api-client";
 import { cn } from "@/lib/utils";
@@ -121,6 +121,9 @@ export function AssetPicker({
             onChange={(e) => setFilter(e.target.value)}
           />
         </div>
+        {data?.cache_expires_at && (
+          <CacheHint expiresAt={data.cache_expires_at} />
+        )}
       </div>
 
       {!isLoading && !isError && (data?.assets?.length ?? 0) > 0 && (
@@ -277,5 +280,48 @@ export function AssetPicker({
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * Surfaces the ESI cache-expiry so the user knows when a refresh can actually
+ * pull fresh state. ESI cached the asset list for ~1 h after CCP's last
+ * update; clicking refresh before [expiresAt] returns the same snapshot.
+ * Auto-updates the countdown every 30 seconds.
+ */
+function CacheHint({ expiresAt }: { expiresAt: string }) {
+  // `now` is state so the countdown re-renders on each tick; reading
+  // `Date.now()` during render would be an impure side-effect.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const expires = new Date(expiresAt);
+  const diffSec = Math.round((expires.getTime() - now) / 1000);
+  const time = expires.toLocaleTimeString("de-DE", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  let label: string;
+  if (diffSec <= 0) {
+    label = `ESI-Cache abgelaufen — Refresh holt jetzt frische Daten.`;
+  } else if (diffSec < 60) {
+    label = `ESI-Cache läuft gleich ab (${diffSec} s) — Refresh holt dann frische Daten.`;
+  } else {
+    const min = Math.round(diffSec / 60);
+    label = `ESI-Cache läuft bis ${time} (${min} min) — Refresh vorher zeigt denselben Stand.`;
+  }
+  return (
+    <p
+      data-testid="asset-cache-hint"
+      className="text-xs text-muted-foreground"
+      title={`Expires: ${expires.toISOString()}`}
+    >
+      <Clock className="mr-1 inline-block size-3 align-[-2px]" />
+      {label}
+    </p>
   );
 }

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -279,6 +279,10 @@ export interface AssetItem {
 export interface AssetsResponse {
   assets: AssetItem[];
   count: number;
+  /** ESI cache-expiry (RFC 3339). Until this point ESI serves the same
+   *  snapshot, so a refresh before then returns identical data. Absent when
+   *  ESI didn't return a parseable Expires header. */
+  cache_expires_at?: string;
 }
 
 export interface SellOptionsRequest {


### PR DESCRIPTION
## Summary

Reporter: Carbon längst verkauft, taucht aber nach Refresh weiter in der Asset-Liste auf. Ursache: ESI-Server-Cache (~1 h TTL) — vor Ablauf liefert ESI dieselbe Snapshot, egal wie oft wir refreshen. Der Caveat war zwar bekannt, aber im UI nicht sichtbar.

## Changes

- **Backend:** `assetFetcher`-Interface gibt jetzt zusätzlich die `Expires`-Zeit aus dem ESI-Header zurück. `AssetsResponse.cache_expires_at` (RFC 3339, omitempty) trägt den Wert weiter. Regressionstest deckt den Header-Parser ab.
- **Web:** `CacheHint`-Komponente unter dem Suchfeld zeigt einen Countdown — „ESI-Cache läuft bis HH:MM (X min) — Refresh vorher zeigt denselben Stand." Nach Ablauf: „ESI-Cache abgelaufen — Refresh holt jetzt frische Daten." Auto-Refresh alle 30 s.
- **Flutter:** `_CacheHint`-Widget mit identischer Logik (Timer.periodic, dispose).

## Test plan

- [x] Backend `go test ./...` — alle grün; gofmt/vet clean
- [x] `npx vitest run` — 62 passed · ESLint clean
- [x] `flutter analyze lib/ test/` clean · `flutter test` — 186 passed
- [ ] CI grün
- [ ] On-prod: Sell-Assets-Seite zeigt den Cache-Hinweis unter dem Suchfeld; nach Ablauf wechselt der Text

🤖 Generated with [Claude Code](https://claude.com/claude-code)