### PR TITLE
feat(roi): show + sort by ISK/h; verify sell-side cap

### DIFF
--- a/app/lib/api/portfolio_models.dart
+++ b/app/lib/api/portfolio_models.dart
@@ -77,6 +77,7 @@ class PortfolioItem {
     required this.tripsPerDay,
     required this.dailyProfit,
     required this.roiPercent,
+    this.iskPerHour = 0,
     this.buySystemName = '',
     this.buyStationName = '',
     this.buyStationId = 0,
@@ -106,6 +107,10 @@ class PortfolioItem {
   /// Backend: `roi_percent` — return on invested capital, in percent.
   final double roiPercent;
 
+  /// Backend: `isk_per_hour` — daily profit per hour of haul time. Items are
+  /// pre-sorted by this metric desc.
+  final double iskPerHour;
+
   /// Backend: `buy_system_name` — solar system where the item is bought.
   final String buySystemName;
 
@@ -133,6 +138,7 @@ class PortfolioItem {
       tripsPerDay: (json['trips_per_day'] as num?)?.toDouble() ?? 0,
       dailyProfit: (json['daily_profit'] as num?)?.toDouble() ?? 0,
       roiPercent: (json['roi_percent'] as num?)?.toDouble() ?? 0,
+      iskPerHour: (json['isk_per_hour'] as num?)?.toDouble() ?? 0,
       buySystemName: json['buy_system_name'] as String? ?? '',
       buyStationName: json['buy_station_name'] as String? ?? '',
       buyStationId: (json['buy_station_id'] as num?)?.toInt() ?? 0,

--- a/app/lib/features/trading/roi_calculator_screen.dart
+++ b/app/lib/features/trading/roi_calculator_screen.dart
@@ -515,6 +515,7 @@ class _PortfolioTable extends ConsumerWidget {
                 DataColumn(label: Text('Units'), numeric: true),
                 DataColumn(label: Text('Fahrten/Tag'), numeric: true),
                 DataColumn(label: Text('Tagesgewinn'), numeric: true),
+                DataColumn(label: Text('ISK/h'), numeric: true),
                 DataColumn(label: Text('ROI%'), numeric: true),
               ],
               rows: [
@@ -527,6 +528,7 @@ class _PortfolioTable extends ConsumerWidget {
                       DataCell(Text(fmtUnits(item.units))),
                       DataCell(Text(item.tripsPerDay.toStringAsFixed(1))),
                       DataCell(Text(fmtIsk(item.dailyProfit))),
+                      DataCell(Text(fmtIsk(item.iskPerHour))),
                       DataCell(Text('${item.roiPercent.toStringAsFixed(1)}%')),
                     ],
                   ),

--- a/backend/internal/models/portfolio.go
+++ b/backend/internal/models/portfolio.go
@@ -12,6 +12,10 @@ type PortfolioRequest struct {
 } // @name PortfolioRequest
 
 // PortfolioItem is one allocated position in the suggested portfolio.
+//
+// ISKPerHour rates the position by time-value: `daily_profit / (time_used/60)`
+// where `time_used = trips_per_day * trip_minutes`. Items are pre-sorted by
+// this metric desc (= the actually most efficient line on screen).
 type PortfolioItem struct {
 	TypeID      int     `json:"type_id"`
 	Name        string  `json:"name"`
@@ -19,7 +23,8 @@ type PortfolioItem struct {
 	Units       int     `json:"units"`
 	TripsPerDay float64 `json:"trips_per_day"`
 	DailyProfit float64 `json:"daily_profit"`
-	ROIPercent  float64 `json:"roi_percent"` // daily_profit / capital_used * 100
+	ROIPercent  float64 `json:"roi_percent"`  // daily_profit / capital_used * 100
+	ISKPerHour  float64 `json:"isk_per_hour"` // net daily profit per hour of haul time
 	// Where to execute the haul: buy at the buy station, sell at the sell station.
 	BuySystemName   string `json:"buy_system_name"`
 	BuyStationName  string `json:"buy_station_name"`

--- a/backend/internal/services/portfolio_service.go
+++ b/backend/internal/services/portfolio_service.go
@@ -91,6 +91,7 @@ func (s *PortfolioService) Optimize(ctx context.Context, req *models.PortfolioRe
 			TripsPerDay:     it.TripsPerDay,
 			DailyProfit:     it.DailyProfit,
 			ROIPercent:      roi,
+			ISKPerHour:      it.ISKPerHour,
 			BuySystemName:   it.BuySystemName,
 			BuyStationName:  it.BuyStationName,
 			BuyStationID:    it.BuyStationID,
@@ -174,6 +175,7 @@ type OutcomeItem struct {
 	Units       int
 	TripsPerDay float64
 	DailyProfit float64
+	ISKPerHour  float64 // daily_profit / (trips_per_day * trip_minutes / 60)
 	// Execution location, carried through from the candidate.
 	BuySystemName   string
 	BuyStationName  string
@@ -266,9 +268,14 @@ func (o *PortfolioOptimizer) Optimize(cands []Candidate, p OptimizeParams) Portf
 		capUsed := float64(units) * s.c.BuyPricePerUnit
 		profit := float64(units) * s.c.ProfitPerUnit
 		timeUsed := float64(trips) * s.c.TripMinutes
+		iskPerHour := 0.0
+		if timeUsed > 0 {
+			iskPerHour = profit / (timeUsed / 60.0)
+		}
 		items = append(items, OutcomeItem{
 			TypeID: s.c.TypeID, Name: s.c.Name, CapitalUsed: capUsed,
 			Units: units, TripsPerDay: float64(trips), DailyProfit: profit,
+			ISKPerHour:    iskPerHour,
 			BuySystemName: s.c.BuySystemName, BuyStationName: s.c.BuyStationName, BuyStationID: s.c.BuyStationID,
 			SellSystemName: s.c.SellSystemName, SellStationName: s.c.SellStationName, SellStationID: s.c.SellStationID,
 		})
@@ -278,6 +285,16 @@ func (o *PortfolioOptimizer) Optimize(cands []Candidate, p OptimizeParams) Portf
 		totalProfit += profit
 		totalTime += timeUsed
 	}
+
+	// Display order: ISK/h desc — the optimizer allocates by efficiency, but
+	// the user reads the list as "where do I make the most money per hour".
+	// Tiebreak by daily profit so the headline number doesn't jump around.
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].ISKPerHour != items[j].ISKPerHour {
+			return items[i].ISKPerHour > items[j].ISKPerHour
+		}
+		return items[i].DailyProfit > items[j].DailyProfit
+	})
 
 	return PortfolioOutcome{
 		Items: items, TotalCapitalUsed: totalCap, TotalDailyProfit: totalProfit,

--- a/backend/internal/services/portfolio_service_test.go
+++ b/backend/internal/services/portfolio_service_test.go
@@ -46,6 +46,50 @@ func TestOptimize_LiquidityCapLimitsUnits(t *testing.T) {
 	}
 }
 
+// TestOptimize_SortsResultByISKPerHour: the displayed list must be ordered by
+// ISK/h descending, even when the internal allocation order (by efficiency)
+// would put items differently. Two items, same daily profit, but item B has
+// half the trip time → item B must come first.
+func TestOptimize_SortsResultByISKPerHour(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	slow := cand(1, "Slow", 100, 1, 0, 1e9, 60) // 60 min/trip
+	fast := cand(2, "Fast", 100, 1, 0, 1e9, 10) // 10 min/trip
+	res := opt.Optimize([]Candidate{slow, fast}, OptimizeParams{
+		Capital: 1e9, CargoCapacity: 1e9, TimeBudgetMin: 1e9,
+		LiquidityCapPct: 100, MaxItemPct: 50,
+	})
+	if len(res.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(res.Items))
+	}
+	if res.Items[0].Name != "Fast" || res.Items[1].Name != "Slow" {
+		t.Errorf("items must be sorted by ISK/h desc; got %s, %s", res.Items[0].Name, res.Items[1].Name)
+	}
+	if res.Items[0].ISKPerHour <= res.Items[1].ISKPerHour {
+		t.Errorf("ISK/h not descending: %v then %v", res.Items[0].ISKPerHour, res.Items[1].ISKPerHour)
+	}
+}
+
+// TestOptimize_RespectsSellSideAvailability is a focused variant of the
+// general order-book test: even if the cheapest sell-order has unlimited
+// volume, the buyer-side `highest_buy.VolumeRemain` (already baked into
+// route_finder's AvailableQuantity) must cap the recommendation.
+// MaxAvailableUnits encodes that joint min(buy, sell) limit.
+func TestOptimize_RespectsSellSideAvailability(t *testing.T) {
+	opt := NewPortfolioOptimizer()
+	c := cand(1, "Carbon", 300, 85, 0.1, 1_000_000, 10)
+	c.MaxAvailableUnits = 5 // imagine: cheapest sell has 1000, but highest buy only wants 5
+	res := opt.Optimize([]Candidate{c}, OptimizeParams{
+		Capital: 1e9, CargoCapacity: 1e9, TimeBudgetMin: 1e9,
+		LiquidityCapPct: 100, MaxItemPct: 100,
+	})
+	if len(res.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(res.Items))
+	}
+	if res.Items[0].Units > 5 {
+		t.Errorf("sell-side cap violated: got %d units, want ≤ 5", res.Items[0].Units)
+	}
+}
+
 // TestOptimize_CapsAtOrderBookAvailability covers the case we hit on prod:
 // the cheapest sell-order tier has only N units, but the optimizer was
 // extrapolating that price across hundreds of units (capital/price). With

--- a/frontend/src/components/trading/PortfolioResultTable.tsx
+++ b/frontend/src/components/trading/PortfolioResultTable.tsx
@@ -76,6 +76,9 @@ export function PortfolioResultTable({ result }: PortfolioResultTableProps) {
                   Tagesgewinn
                 </th>
                 <th scope="col" className="px-4 py-3 text-right font-medium">
+                  ISK/h
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
                   ROI%
                 </th>
                 <th scope="col" className="px-4 py-3 font-medium">
@@ -103,7 +106,7 @@ export function PortfolioResultTable({ result }: PortfolioResultTableProps) {
                 <td className="px-4 py-3 text-right text-green-600 dark:text-green-400">
                   {formatISKWithSeparators(result.total_daily_profit)}
                 </td>
-                <td className="px-4 py-3" colSpan={2} />
+                <td className="px-4 py-3" colSpan={3} />
               </tr>
             </tfoot>
           </table>
@@ -207,6 +210,9 @@ function PortfolioRowItem({ item }: { item: PortfolioItem }) {
       <td className="px-4 py-3 text-right">{item.trips_per_day}</td>
       <td className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
         {formatISKWithSeparators(item.daily_profit)}
+      </td>
+      <td className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
+        {formatISKWithSeparators(item.isk_per_hour)}
       </td>
       <td
         className={cn(

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -172,6 +172,8 @@ export interface PortfolioItem {
   trips_per_day: number;
   daily_profit: number;
   roi_percent: number;
+  /** Daily profit per hour of haul time. Items are pre-sorted by this metric. */
+  isk_per_hour: number;
   // Buy/sell location (station → station haul)
   buy_system_name: string;
   buy_station_name: string;


### PR DESCRIPTION
## Summary

Owner-Goal:
1. ROI-Liste nach ISK/h anzeigen und sortieren.
2. Maximale Stückzahl beim VERKAUF beachten (nicht zuviel einkaufen).

## (1) ISK/h-Display + Sortierung

- `PortfolioItem.isk_per_hour` neu: `daily_profit / (trips_per_day × trip_minutes / 60)`.
- `Optimize` sortiert das Outcome jetzt nach ISK/h desc (Tiebreak `DailyProfit`); die Allokation läuft weiterhin nach Capital-Efficiency (für die Auswahl der besten Items), nur die Anzeige-Reihenfolge ändert sich.
- Web (`PortfolioResultTable`) + Flutter (`roi_calculator_screen`) zeigen die neue Spalte „ISK/h".
- Regressionstest: bei gleichem Daily-Profit muss das Item mit kürzerer Reisezeit oben stehen.

## (2) Sell-Side-Cap

**Bestätigt: ist bereits implementiert.** `route_finder` cappt seit langem `AvailableQuantity = min(cheapest-sell-VolumeRemain, highest-buy-VolumeRemain)`. Seit v0.15.3 wird das als `Candidate.MaxAvailableUnits` in den Optimizer durchgereicht; `maxUnits` ist zusätzlich darauf gecappt.

Neuer Test `TestOptimize_RespectsSellSideAvailability` prüft den Sell-Side-Fall isoliert: `MaxAvailableUnits=5` + großzügiges Kapital → Allokation ≤ 5. Kein Code-Change nötig, nur Verifikation.

## Test plan

- [x] Backend `go test ./...` — alle grün; gofmt/vet clean
- [x] `npx vitest run` — 62 passed · ESLint clean
- [x] `flutter analyze lib/ test/` clean · `flutter test` — 186 passed
- [ ] CI grün
- [ ] On-prod: ROI-Lauf zeigt ISK/h-Spalte; Sortierung passt (höchstes ISK/h zuerst)

🤖 Generated with [Claude Code](https://claude.com/claude-code)