### PR TITLE
fix(frontend): surface load failures instead of silent fallbacks (#147)

### DIFF
--- a/frontend/src/app/character/page.tsx
+++ b/frontend/src/app/character/page.tsx
@@ -67,7 +67,9 @@ export default function CharacterPage() {
       setLocation(data);
     } catch (err) {
       console.error("Failed to fetch character location:", err);
-      setLocationError("Keine Daten verfügbar");
+      setLocationError(
+        err instanceof Error ? err.message : "Standort konnte nicht geladen werden",
+      );
     }
   }, []);
 
@@ -87,7 +89,9 @@ export default function CharacterPage() {
       setShip(data);
     } catch (err) {
       console.error("Failed to fetch character ship:", err);
-      setShipError("Keine Daten verfügbar");
+      setShipError(
+        err instanceof Error ? err.message : "Schiff konnte nicht geladen werden",
+      );
     }
   }, []);
 

--- a/frontend/src/app/roi-calculator/page.tsx
+++ b/frontend/src/app/roi-calculator/page.tsx
@@ -70,14 +70,28 @@ function ROICalculatorContent() {
         fetchCharacterLocation(),
         fetchCharacterShip(),
         // Wallet needs the (newer) wallet scope; tolerate its absence so a
-        // character authorized before the scope was added still works.
-        fetchCharacterWallet().catch(() => null),
+        // character authorized before the scope was added still works — but
+        // capture the failure so the UI can say the capital is a placeholder
+        // rather than silently presenting the default as the real balance.
+        fetchCharacterWallet().then(
+          (value) => ({ value }),
+          (err): { error: string } => ({
+            error:
+              err instanceof Error
+                ? err.message
+                : "Wallet konnte nicht geladen werden",
+          }),
+        ),
       ]);
       return { location, ship, wallet };
     },
     enabled: isAuthenticated,
     staleTime: 5 * 60 * 1000,
   });
+
+  const wallet = characterData?.wallet;
+  const walletValue = wallet && "value" in wallet ? wallet.value : null;
+  const walletError = wallet && "error" in wallet ? wallet.error : null;
 
   // Effective values: manual override > current character data > default.
   // Purely derived (no effect), so the user's choice stays sticky.
@@ -93,10 +107,13 @@ function ROICalculatorContent() {
       DEFAULT_SHIP,
     capital:
       capitalOverride ??
-      (characterData?.wallet != null
-        ? Math.floor(characterData.wallet)
-        : form.capital),
+      (walletValue != null ? Math.floor(walletValue) : form.capital),
   };
+
+  // The capital is the default placeholder ONLY because the wallet fetch failed
+  // and the user hasn't entered a value — surface that so it's not mistaken for
+  // the real balance.
+  const showWalletWarning = walletError != null && capitalOverride == null;
 
   const handleFormChange = (next: PortfolioFormState) => {
     if (next.region !== effectiveForm.region) setRegionOverride(next.region);
@@ -138,6 +155,17 @@ function ROICalculatorContent() {
           <AlertDescription>
             Melde dich per EVE SSO an, um eine skill-bereinigte
             Kapital-Allokation zu berechnen.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {showWalletWarning && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertTitle>Wallet-Guthaben nicht geladen</AlertTitle>
+          <AlertDescription>
+            {walletError} — es wird das Standardkapital verwendet. Bitte das
+            Kapital manuell setzen; der Wert ist <strong>nicht</strong> dein
+            echtes Guthaben.
           </AlertDescription>
         </Alert>
       )}

--- a/frontend/src/app/trading/page.tsx
+++ b/frontend/src/app/trading/page.tsx
@@ -38,7 +38,10 @@ async function calculateRoutes(regionId: number, shipTypeId: number): Promise<Tr
 
   if (!response.ok) throw new Error(`API Error: ${response.statusText}`);
   const data = await response.json();
-  return data.routes || [];
+  if (!Array.isArray(data.routes)) {
+    throw new Error("Invalid routes response: 'routes' missing or not an array");
+  }
+  return data.routes;
 }
 
 function TradingPageContent() {

--- a/frontend/src/components/trading/RegionSelect.tsx
+++ b/frontend/src/components/trading/RegionSelect.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/select";
 import { fetchRegions } from "@/lib/api-client";
 import { Region } from "@/types/trading";
-import { regions as fallbackRegions } from "@/lib/mock-data/regions";
 import { RegionStalenessIndicator } from "./RegionStalenessIndicator";
 import { RegionRefreshButton } from "./RegionRefreshButton";
 
@@ -33,20 +32,23 @@ export function RegionSelect({
   onRefreshComplete,
   onRefreshStateChange,
 }: RegionSelectProps) {
-  const [regions, setRegions] = useState<Region[]>(fallbackRegions);
+  const [regions, setRegions] = useState<Region[]>([]);
   const [loading, setLoading] = useState(true);
+  // True when the region list couldn't be loaded — shown loudly instead of
+  // silently substituting a hardcoded mock list as if it were real.
+  const [loadError, setLoadError] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
     const loadRegions = async () => {
+      setLoadError(false);
       try {
         const data = await fetchRegions();
-        if (data && data.length > 0) {
-          setRegions(data);
-        }
+        setRegions(data);
       } catch (error) {
-        console.error("Failed to fetch regions, using fallback:", error);
-        // Keep fallback regions on error
+        console.error("Failed to fetch regions:", error);
+        setRegions([]);
+        setLoadError(true);
       } finally {
         setLoading(false);
       }
@@ -64,9 +66,17 @@ export function RegionSelect({
     <div className="space-y-2">
       <label className="text-sm font-medium">Region</label>
       <div className="flex items-center gap-2">
-        <Select value={value} onValueChange={onChange} disabled={disabled || loading}>
+        <Select value={value} onValueChange={onChange} disabled={disabled || loading || loadError}>
           <SelectTrigger className="w-full">
-            <SelectValue placeholder={loading ? "Lade Regionen..." : "Region wählen..."} />
+            <SelectValue
+              placeholder={
+                loading
+                  ? "Lade Regionen..."
+                  : loadError
+                    ? "Regionen nicht verfügbar"
+                    : "Region wählen..."
+              }
+            />
           </SelectTrigger>
           <SelectContent>
             {regions.map((region) => (
@@ -85,10 +95,15 @@ export function RegionSelect({
           />
         )}
       </div>
+      {loadError && (
+        <p className="text-xs text-destructive" role="alert">
+          Regionen konnten nicht geladen werden. Bitte Seite neu laden.
+        </p>
+      )}
       {showStaleness && value && (
-        <RegionStalenessIndicator 
-          key={refreshKey} 
-          regionId={value} 
+        <RegionStalenessIndicator
+          key={refreshKey}
+          regionId={value}
         />
       )}
     </div>

--- a/frontend/src/components/trading/RegionStalenessIndicator.tsx
+++ b/frontend/src/components/trading/RegionStalenessIndicator.tsx
@@ -68,7 +68,14 @@ export function RegionStalenessIndicator({
   }
 
   if (error) {
-    return null; // Silent failure
+    // Don't hide the failure — show that the data age is unknown rather than
+    // rendering nothing (which reads as "data is fresh").
+    return (
+      <div className={cn("flex items-center gap-1.5 text-xs text-destructive", className)}>
+        <Clock className="h-3 w-3" />
+        <span>Datenalter unbekannt</span>
+      </div>
+    );
   }
 
   const { age_minutes } = dataAge;

--- a/frontend/src/components/trading/ShipSelect.tsx
+++ b/frontend/src/components/trading/ShipSelect.tsx
@@ -25,14 +25,18 @@ export function ShipSelect({
   disabled,
   authenticated = false,
 }: ShipSelectProps) {
-  const [ships, setShips] = useState<Ship[]>(fallbackShips);
+  // Unauthenticated users get a generic example list (a legitimate default —
+  // there is no character to load). Authenticated users get their real hangar;
+  // on a fetch failure we show NO ships and a loud error instead of passing off
+  // the generic list as their fleet.
+  const [ships, setShips] = useState<Ship[]>(authenticated ? [] : fallbackShips);
   // The active ship (the one being flown) — not necessarily in the hangar list,
   // so it's merged into the options separately to keep the current-ship default
   // selectable.
   const [activeShip, setActiveShip] = useState<Ship | null>(null);
   const [loading, setLoading] = useState(false);
-  // True when the ship fetch failed (network/auth) and we fell back to the
-  // generic hauler list — surfaced so the user isn't silently shown wrong ships.
+  // True when loading the authenticated character's ships failed — surfaced as a
+  // prominent error so wrong/empty data is never read as the real fleet.
   const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
@@ -57,18 +61,19 @@ export function ShipSelect({
             return null;
           }),
         ]);
-        if (characterShips && characterShips.length > 0) {
-          setShips(characterShips);
-        } else {
-          setShips(fallbackShips);
-        }
+        // On failure show NO ships (never the generic mock list as if it were
+        // the character's). An empty-but-successful hangar is also just empty.
+        setShips(characterShips ?? []);
         if (active?.ship_type_id) {
           setActiveShip({
             type_id: active.ship_type_id,
             name: active.ship_type_name || active.ship_name,
             cargo_capacity: active.cargo_capacity,
             effective_cargo_capacity: active.effective_cargo_capacity,
+            effective_cargo_unavailable: active.effective_cargo_unavailable,
           });
+        } else {
+          setActiveShip(null);
         }
       } finally {
         setLoadError(failed);
@@ -103,8 +108,10 @@ export function ShipSelect({
         <SelectContent>
           {options.map((ship) => {
             // Prefer the effective cargo (matches what the optimizer uses and
-            // what EVE shows in-game). Fall back to the base hull cargo with a
-            // "Basis" prefix when the backend couldn't enrich the entry.
+            // what EVE shows in-game). When the backend's fitting enrichment
+            // ERRORED, the effective volume is genuinely unknown — say so
+            // instead of passing off the base hull as the fitted value. Only a
+            // ship that truly has no cargo-expander shows the bare "Basis" hull.
             const effective = ship.effective_cargo_capacity;
             const useEffective = effective != null && effective > 0;
             const value = useEffective ? effective : ship.cargo_capacity;
@@ -112,7 +119,11 @@ export function ShipSelect({
               value >= 1000
                 ? `${(value / 1000).toFixed(1)}k m³`
                 : `${Math.round(value)} m³`;
-            const cargoDisplay = useEffective ? cargoFmt : `Basis ${cargoFmt}`;
+            const cargoDisplay = ship.effective_cargo_unavailable
+              ? `Basis ${cargoFmt} — fitted unbekannt`
+              : useEffective
+                ? cargoFmt
+                : `Basis ${cargoFmt}`;
 
             return (
               <SelectItem key={ship.type_id} value={ship.type_id.toString()}>
@@ -123,8 +134,9 @@ export function ShipSelect({
         </SelectContent>
       </Select>
       {loadError && (
-        <p className="text-xs text-amber-600 dark:text-amber-500" role="status">
-          Deine Schiffe konnten nicht geladen werden — Standardliste angezeigt.
+        <p className="text-xs text-destructive" role="alert">
+          Deine Schiffe konnten nicht geladen werden. Bitte neu laden — es wird
+          keine Ersatzliste angezeigt, um falsche Schiffsdaten zu vermeiden.
         </p>
       )}
     </div>

--- a/frontend/src/components/trading/SkillsDisplay.tsx
+++ b/frontend/src/components/trading/SkillsDisplay.tsx
@@ -140,6 +140,32 @@ export function SkillsDisplay() {
     );
   }
 
+  // Skills failed to load (and were not silently replaced by zeroed defaults).
+  // Surface the error loudly rather than rendering nothing or fake values.
+  if (!skills && error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Character Skills</CardTitle>
+          <CardDescription className="text-destructive">
+            Skills konnten nicht geladen werden: {error}
+          </CardDescription>
+          <CardAction>
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              title="Refresh skills"
+            >
+              <RefreshCw className={isRefreshing ? "animate-spin" : ""} />
+            </Button>
+          </CardAction>
+        </CardHeader>
+      </Card>
+    );
+  }
+
   if (!skills) {
     return null;
   }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -31,6 +31,11 @@ interface BackendShipsResponse {
     type_id: number;
     type_name: string;
     cargo_capacity: number;
+    effective_cargo_capacity?: number;
+    // Set by the backend when fitting enrichment ERRORED (vs. a ship that
+    // simply has no cargo-expander). The UI surfaces this instead of silently
+    // showing the base hull as if it were the real fitted value.
+    effective_cargo_unavailable?: boolean;
   }>;
   count: number;
 }
@@ -46,7 +51,10 @@ export async function fetchRegions(): Promise<Region[]> {
   }
 
   const data: BackendRegionsResponse = await response.json();
-  return data.regions || [];
+  if (!Array.isArray(data.regions)) {
+    throw new Error("Invalid regions response: 'regions' missing or not an array");
+  }
+  return data.regions;
 }
 
 /**
@@ -109,12 +117,21 @@ export async function fetchCharacterShips(): Promise<Ship[]> {
 
   const data: BackendShipsResponse = await response.json();
 
-  // Convert backend format to Ship format
-  return data.ships?.map((ship) => ({
+  if (!Array.isArray(data.ships)) {
+    throw new Error("Invalid ships response: 'ships' missing or not an array");
+  }
+
+  // Convert backend format to Ship format. effective_cargo_capacity and the
+  // enrichment-error flag are carried through so the dropdown can show the
+  // fitted volume (or a visible "unknown" marker) instead of falling back to
+  // the base hull silently.
+  return data.ships.map((ship) => ({
     type_id: ship.type_id,
     name: ship.type_name,
     cargo_capacity: ship.cargo_capacity,
-  })) || [];
+    effective_cargo_capacity: ship.effective_cargo_capacity,
+    effective_cargo_unavailable: ship.effective_cargo_unavailable,
+  }));
 }
 
 /**
@@ -164,7 +181,10 @@ export async function searchItems(
   }
 
   const data: BackendItemSearchResponse = await response.json();
-  return data.items || [];
+  if (!Array.isArray(data.items)) {
+    throw new Error("Invalid item search response: 'items' missing or not an array");
+  }
+  return data.items;
 }
 
 /**

--- a/frontend/src/lib/trading-skills-context.tsx
+++ b/frontend/src/lib/trading-skills-context.tsx
@@ -67,9 +67,11 @@ export function TradingSkillsProvider({ children }: { children: React.ReactNode 
     } catch (err) {
       console.error("[TradingSkillsContext] Failed to fetch skills:", err);
       setError(err instanceof Error ? err.message : "Failed to fetch skills");
-      
-      // Fallback to default skills on error
-      setSkills(getDefaultSkills());
+
+      // Do NOT substitute zeroed default skills here — that would silently feed
+      // wrong (worst-case) fee/cargo numbers into the UI as if they were real.
+      // Leave skills null so consumers surface the error instead.
+      setSkills(null);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/types/character.ts
+++ b/frontend/src/types/character.ts
@@ -16,8 +16,11 @@ export interface CharacterShip {
   ship_item_id: number;
   ship_type_name: string;
   cargo_capacity: number;
-  /** Effective cargo (hull + skills + fitted modules). Absent if enrichment failed. */
+  /** Effective cargo (hull + skills + fitted modules). Absent when the ship has
+   *  no cargo-expander fitting (base hull is then correct). */
   effective_cargo_capacity?: number;
+  /** True when fitting enrichment ERRORED — effective volume is unknown. */
+  effective_cargo_unavailable?: boolean;
 }
 
 /**

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -88,9 +88,13 @@ export interface Ship {
   /** Base hull cargo (without skills/modules). */
   cargo_capacity: number;
   /** Effective cargo (hull + skills + fitted modules); same value the optimizer
-   *  uses. Absent when the backend couldn't enrich the entry — fall back to
-   *  `cargo_capacity` with a "Basis" label. */
+   *  uses. Absent when the ship has no cargo-expander fitting — then the base
+   *  `cargo_capacity` ("Basis") is the correct value. */
   effective_cargo_capacity?: number;
+  /** True when the backend's fitting enrichment ERRORED for this ship (ESI/
+   *  network), so the effective volume is genuinely unknown. The UI shows a
+   *  visible "unknown" marker rather than passing off the base hull as fitted. */
+  effective_cargo_unavailable?: boolean;
 }
 
 export interface TradingFilters {

--- a/frontend/tests/hooks/useAuth.test.tsx
+++ b/frontend/tests/hooks/useAuth.test.tsx
@@ -29,7 +29,7 @@ function mockFetchSession(authenticated: boolean) {
         portrait_url: "https://images.evetech.net/characters/90000001/portrait?size=128",
       }
     : null;
-  return vi.fn(async (url: string, _init?: RequestInit) => {
+  return vi.fn(async (url: string) => {
     if (url.includes("/auth/session")) {
       return { ok: true, json: async () => ({ authenticated, character }) } as Response;
     }

--- a/frontend/tests/lib/api-client-failloud.test.ts
+++ b/frontend/tests/lib/api-client-failloud.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  fetchCharacterShips,
+  fetchRegions,
+  searchItems,
+} from "@/lib/api-client";
+
+function mockJson(body: unknown, status = 200) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+describe("api-client fail-loud behaviour", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("fetchCharacterShips", () => {
+    it("carries effective_cargo_capacity and the enrichment-error flag through", async () => {
+      mockJson({
+        ships: [
+          {
+            type_id: 16242,
+            type_name: "Catalyst",
+            cargo_capacity: 450,
+            effective_cargo_capacity: 712,
+          },
+          {
+            type_id: 650,
+            type_name: "Bestower",
+            cargo_capacity: 19000,
+            effective_cargo_unavailable: true,
+          },
+        ],
+        count: 2,
+      });
+
+      const ships = await fetchCharacterShips();
+
+      expect(ships[0].effective_cargo_capacity).toBe(712);
+      expect(ships[0].effective_cargo_unavailable).toBeUndefined();
+      expect(ships[1].effective_cargo_capacity).toBeUndefined();
+      expect(ships[1].effective_cargo_unavailable).toBe(true);
+    });
+
+    it("throws on a malformed response instead of silently returning []", async () => {
+      mockJson({ count: 0 }); // no `ships` array
+      await expect(fetchCharacterShips()).rejects.toThrow(/ships/);
+    });
+  });
+
+  describe("fetchRegions", () => {
+    it("throws on a malformed response instead of silently returning []", async () => {
+      mockJson({ count: 0 }); // no `regions` array
+      await expect(fetchRegions()).rejects.toThrow(/regions/);
+    });
+  });
+
+  describe("searchItems", () => {
+    it("throws on a malformed response instead of silently returning []", async () => {
+      mockJson({}); // no `items` array
+      await expect(searchItems("trit")).rejects.toThrow(/items/);
+    });
+  });
+});

--- a/scripts/common/check-adr.sh
+++ b/scripts/common/check-adr.sh
@@ -6,8 +6,11 @@ set -euo pipefail
 ADR_DIR="docs/adr"
 
 if [ ! -d "$ADR_DIR" ]; then
-    echo "[check-adr] ERROR: $ADR_DIR Verzeichnis nicht gefunden" >&2
-    exit 1
+    # ADRs were intentionally removed (commit 65fe910). A missing directory is
+    # not an error — there is simply nothing to validate. Skip gracefully so the
+    # pre-commit hook doesn't hard-fail every commit in a repo without ADRs.
+    echo "[check-adr] Kein $ADR_DIR Verzeichnis — überspringe ADR-Konsistenzprüfung."
+    exit 0
 fi
 
 echo "[check-adr] Prüfe ADR-Konsistenz in $ADR_DIR..."


### PR DESCRIPTION
Frontend half of #147 — stop hiding load failures behind degraded defaults in the trading UI. Pairs with the backend half in #148 (the two share a JSON contract; merge together).

## Fail-loud changes

**Tier A**
- **Ships (A3/B2):** `api-client` now carries `effective_cargo_capacity` through (the dropped field that caused the "Basis"-for-everything bug) plus the backend's new `effective_cargo_unavailable` flag. `ShipSelect` shows the fitted volume when known, a visible "fitted unbekannt" marker when enrichment errored, and — on an authenticated fetch failure — **no ships + a loud error** instead of the generic mock fleet presented as yours. Unauthenticated users still get the generic example list (a legitimate default).
- **Wallet (A1):** a failed wallet fetch no longer silently defaults capital to 500M as if it were the real balance — a destructive alert says the value is a placeholder and to set it manually.
- **Skills (A2, frontend half):** dropped the zeroed-default substitution on error; `SkillsDisplay` surfaces the failure. Matches the backend now returning **HTTP 500** instead of 200 + all-zero skills.

**Tier B**
- **Regions (B1):** no silent mock-region fallback; the select shows an error state when the list can't be loaded.

**MED**
- `api-client` throws on malformed (non-array) `regions`/`ships`/`items`/`routes` responses instead of returning `[]` and masking an API-contract break.
- `RegionStalenessIndicator` shows "Datenalter unbekannt" instead of rendering nothing (which reads as "fresh").
- character page shows the real error instead of a generic "Keine Daten verfügbar".

## Contract with #148
- consumes `effective_cargo_unavailable` (omitempty boolean) on `CharacterShip` + `CharacterAssetShip`.
- relies on `GET /characters/:id/skills` returning 500 on ESI failure.

## Verification
- vitest: **66/66** pass (incl. new `tests/lib/api-client-failloud.test.ts`).
- ESLint: clean. Production build (`next build`): clean, 13 routes.
- Deploy + on-prod E2E intentionally **not** done here — gated, see issue.

Also includes a separate commit fixing a pre-existing broken pre-commit hook (`check-adr.sh` hard-failed on the intentionally-removed `docs/adr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
