### PR TITLE
chore(lint): migrate golangci-lint config to v2 + fix findings

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,25 +1,40 @@
-linters:
-  enable:
-    - govet
-    - errcheck
-    - staticcheck
-    - unused
-    - gosimple
-    - ineffassign
-    - typecheck
-    - gocritic
-    - misspell
-
-linters-settings:
-  gocritic:
-    disabled-checks:
-      - commentFormatting
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-
+version: "2"
 run:
   timeout: 3m
+linters:
+  enable:
+    # NOTE: misspell is intentionally NOT enabled. This codebase is bilingual
+    # (heavily German comments/docs) and misspell only knows English, so it
+    # produces false positives on German domain terms (e.g. "Konfiguration",
+    # "Verifikation"). It never actually ran before (v1 config didn't load under
+    # golangci-lint v2), so nothing depended on it.
+    - gocritic
+  settings:
+    gocritic:
+      disabled-checks:
+        - commentFormatting
+        # exitAfterDefer fires on log.Fatal-after-defer in main()/CLI entrypoints;
+        # the deferred Close is benign there (the process exits, OS reclaims FDs).
+        - exitAfterDefer
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/backend/internal/database/market.go
+++ b/backend/internal/database/market.go
@@ -89,7 +89,7 @@ func (r *MarketRepository) upsertBatch(ctx context.Context, orders []MarketOrder
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	// Prepare batch
 	batch := &pgx.Batch{}
@@ -267,7 +267,7 @@ func (r *MarketRepository) UpsertPriceHistory(ctx context.Context, history []Pri
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	query := `
 		INSERT INTO price_history (

--- a/backend/internal/handlers/character_test.go
+++ b/backend/internal/handlers/character_test.go
@@ -48,7 +48,7 @@ func TestCharacterHandler_GetCharacterSkills_Success(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	// Execute request with locals
-	resp, err := app.Test(req, -1)
+	_, err := app.Test(req, -1)
 	require.NoError(t, err)
 
 	// Manually set locals (simulating AuthMiddleware)
@@ -63,7 +63,7 @@ func TestCharacterHandler_GetCharacterSkills_Success(t *testing.T) {
 	app2.Get("/api/v1/characters/:characterId/skills", handler.GetCharacterSkills)
 
 	req2 := httptest.NewRequest("GET", "/api/v1/characters/12345/skills", nil)
-	resp, err = app2.Test(req2, -1)
+	resp, err := app2.Test(req2, -1)
 	require.NoError(t, err)
 
 	// Verify response

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -60,6 +60,7 @@ func New(healthChecker database.HealthChecker, sdeQuerier database.SDEQuerier, m
 }
 
 // NewWithConcrete creates a handler from concrete types (backward compatibility wrapper)
+//
 // Deprecated: Use New with interfaces instead
 func NewWithConcrete(db *database.DB, sdeRepo *database.SDERepository, marketRepo *database.MarketRepository, esiClient *esi.Client) *Handler {
 	marketService := services.NewMarketService(marketRepo, esiClient)

--- a/backend/internal/handlers/trading.go
+++ b/backend/internal/handlers/trading.go
@@ -51,12 +51,6 @@ func NewTradingHandler(
 	}
 }
 
-// Context keys for character information (must match keys in services)
-const (
-	contextKeyCharacterID = "character_id"
-	contextKeyAccessToken = "access_token"
-)
-
 // CalculateRoutes handles POST /api/v1/trading/routes/calculate
 // Supports optional authentication for skill-aware cargo calculations
 // Supports optional volume filtering for liquidity-based route selection
@@ -112,8 +106,8 @@ func (h *TradingHandler) CalculateRoutes(c *fiber.Ctx) error {
 	}
 
 	// Add character context for skill-aware cargo calculations
-	ctx = context.WithValue(ctx, contextKeyCharacterID, characterID)
-	ctx = context.WithValue(ctx, contextKeyAccessToken, accessToken)
+	ctx = context.WithValue(ctx, services.CtxKeyCharacterID, characterID)
+	ctx = context.WithValue(ctx, services.CtxKeyAccessToken, accessToken)
 
 	// Extract deterministic navigation parameters from request
 	var warpSpeed, alignTime *float64

--- a/backend/internal/services/asset_fetcher.go
+++ b/backend/internal/services/asset_fetcher.go
@@ -112,13 +112,7 @@ func (f *ESIAssetFetcher) page(ctx context.Context, base, token string, page int
 	}
 	out := make([]RawAsset, 0, len(raw))
 	for _, a := range raw {
-		out = append(out, RawAsset{
-			ItemID:       a.ItemID,
-			TypeID:       a.TypeID,
-			LocationID:   a.LocationID,
-			Quantity:     a.Quantity,
-			LocationFlag: a.LocationFlag,
-		})
+		out = append(out, RawAsset(a))
 	}
 	return out, pages, expiresAt, nil
 }

--- a/backend/internal/services/fee_service_test.go
+++ b/backend/internal/services/fee_service_test.go
@@ -118,11 +118,6 @@ func TestFeeService_CalculateSalesTax(t *testing.T) {
 	}
 }
 
-// testLogger returns a noop logger for use in tests.
-func testLogger() *logger.Logger {
-	return logger.NewNoop()
-}
-
 // floatEquals checks if two floats are equal within a tolerance
 func floatEquals(a, b, tolerance float64) bool {
 	diff := a - b

--- a/backend/internal/services/portfolio_service.go
+++ b/backend/internal/services/portfolio_service.go
@@ -27,8 +27,8 @@ func NewPortfolioService(routes RouteCalculatorServicer, skills SkillsServicer, 
 // Optimize computes the suggested capital allocation for the request.
 func (s *PortfolioService) Optimize(ctx context.Context, req *models.PortfolioRequest, characterID int, accessToken string) (*models.PortfolioResult, error) {
 	// Route calc needs the character in context for skill-aware cargo/fees.
-	ctx = context.WithValue(ctx, contextKeyCharacterID, characterID)
-	ctx = context.WithValue(ctx, contextKeyAccessToken, accessToken)
+	ctx = context.WithValue(ctx, CtxKeyCharacterID, characterID)
+	ctx = context.WithValue(ctx, CtxKeyAccessToken, accessToken)
 
 	resp, err := s.routes.CalculateWithFilters(ctx, &models.RouteCalculationRequest{
 		RegionID:             req.RegionID,

--- a/backend/internal/services/portfolio_service_test.go
+++ b/backend/internal/services/portfolio_service_test.go
@@ -132,7 +132,7 @@ func TestOptimize_DiversificationScore(t *testing.T) {
 		OptimizeParams{Capital: 1000, CargoCapacity: 1e9, TimeBudgetMin: 1e9, LiquidityCapPct: 100, MaxItemPct: 100})
 	two := opt.Optimize([]Candidate{cand(1, "A", 10, 100, 1, 1e9, 10), cand(2, "B", 10, 100, 1, 1e9, 10)},
 		OptimizeParams{Capital: 1000, CargoCapacity: 1e9, TimeBudgetMin: 1e9, LiquidityCapPct: 100, MaxItemPct: 50})
-	if !(two.DiversificationScore > one.DiversificationScore) {
+	if two.DiversificationScore <= one.DiversificationScore {
 		t.Errorf("two-item portfolio should score higher: one=%d two=%d", one.DiversificationScore, two.DiversificationScore)
 	}
 }

--- a/backend/internal/services/route_service.go
+++ b/backend/internal/services/route_service.go
@@ -44,10 +44,14 @@ func DefaultConfig() Config {
 	}
 }
 
-// Context keys for character information (must match handler keys)
+// contextKey is a dedicated type for context keys so values set in one package
+// can't collide with string keys from another (staticcheck SA1029). The
+// constants are exported so the handlers package shares the exact same keys.
+type contextKey string
+
 const (
-	contextKeyCharacterID = "character_id"
-	contextKeyAccessToken = "access_token"
+	CtxKeyCharacterID contextKey = "character_id"
+	CtxKeyAccessToken contextKey = "access_token"
 )
 
 // RouteService orchestrates route calculation workflow
@@ -131,8 +135,8 @@ func (rs *RouteService) Calculate(ctx context.Context, regionID, shipTypeID int,
 	// trading features); falls back to level 0 (5%, worst case) when no character
 	// context is present (e.g. anonymous explicit-capacity calls).
 	accountingLevel := 0
-	if cid, ok := calcCtx.Value(contextKeyCharacterID).(int); ok {
-		if token, ok := calcCtx.Value(contextKeyAccessToken).(string); ok && cid > 0 && token != "" {
+	if cid, ok := calcCtx.Value(CtxKeyCharacterID).(int); ok {
+		if token, ok := calcCtx.Value(CtxKeyAccessToken).(string); ok && cid > 0 && token != "" {
 			if sk, err := rs.skillsService.GetCharacterSkills(calcCtx, cid, token); err == nil && sk != nil {
 				accountingLevel = sk.Accounting
 			}
@@ -354,8 +358,8 @@ func (rs *RouteService) getRegionName(ctx context.Context, regionID int) (string
 // Requires character authentication in context.
 func (rs *RouteService) applyCharacterSkills(ctx context.Context, baseCapacity float64, shipTypeID int) (float64, float64, float64, float64, float64) {
 	// Extract character_id (required - no fallback)
-	characterID := ctx.Value(contextKeyCharacterID)
-	accessToken := ctx.Value(contextKeyAccessToken)
+	characterID := ctx.Value(CtxKeyCharacterID)
+	accessToken := ctx.Value(CtxKeyAccessToken)
 
 	if characterID == nil || accessToken == nil {
 		// This should never happen if AuthMiddleware is properly configured

--- a/backend/internal/services/route_service_validation_test.go
+++ b/backend/internal/services/route_service_validation_test.go
@@ -98,11 +98,12 @@ func TestGetMinRouteSecurityStatus_EdgeCases(t *testing.T) {
 			}
 
 			var result string
-			if minSec >= 0.5 {
+			switch {
+			case minSec >= 0.5:
 				result = "high"
-			} else if minSec > 0 {
+			case minSec > 0:
 				result = "low"
-			} else {
+			default:
 				result = "null"
 			}
 

--- a/backend/internal/services/skills_service.go
+++ b/backend/internal/services/skills_service.go
@@ -237,8 +237,8 @@ func (s *SkillsService) fetchStandingsFromESI(ctx context.Context, characterID i
 // EVE Broker Fee formula uses highest faction and corp standings
 // Note: Agent standings are ignored - not relevant for broker fees
 func (s *SkillsService) extractHighestStandings(standings []esiStanding) (float64, float64) {
-	var maxFactionStanding float64 = 0.0
-	var maxCorpStanding float64 = 0.0
+	maxFactionStanding := 0.0
+	maxCorpStanding := 0.0
 	hasFaction := false
 	hasCorp := false
 

--- a/backend/pkg/evedb/dogma/effects.go
+++ b/backend/pkg/evedb/dogma/effects.go
@@ -272,7 +272,7 @@ func calculateStackingPenalty(n int) float64 {
 	}
 
 	// EVE's stacking formula
-	exponent := -math.Pow(float64(n), 2) / math.Pow(2.67, 2)
+	exponent := -(float64(n) * float64(n)) / (2.67 * 2.67)
 	return math.Exp(exponent)
 }
 


### PR DESCRIPTION
Standalone cleanup: migrate the backend `.golangci.yml` to golangci-lint **v2** and fix everything it surfaces.

## Why
The config was v1-format (no `version:` key), so golangci-lint v2 refused to load it — meaning **the linter silently never ran** in this repo (CI lints via gofmt+vet; the pre-commit step hard-failed and was bypassed). This makes it actually work again.

## What
- **Config**: `golangci-lint migrate` → v2 schema. Tuning: disabled gocritic `exitAfterDefer` (benign `log.Fatal`-after-`defer Close()` in `main()`/CLI entrypoints) and dropped `misspell` (English-only; this codebase is heavily German, so it only yielded false positives like „Konfiguration"/„Verifikation").
- **Real findings fixed (all in code):**
  - **SA1029** context-key collision — the `character_id`/`access_token` keys were duplicated as bare `string` consts in both `handlers` and `services`. Hoisted to a shared typed `contextKey` (`services.CtxKeyCharacterID`/`CtxKeyAccessToken`) used by both sides.
  - **errcheck** (`tx.Rollback`), **ineffassign**, **unused** (`testLogger`), **S1016**, **ST1023** (×2), **QF1001**, **QF1005** (`math.Pow`→multiply), **gocritic** `ifElseChain`→switch and `deprecatedComment` formatting.

## Verification
- `golangci-lint run ./...` → **0 issues**; `golangci-lint config verify` clean.
- `gofmt -l` clean; `GOWORK=off go build/vet/test ./...` → green.

The pre-commit hook (guarded in v0.17.2 to skip when the config wasn't v2-loadable) now runs golangci-lint again automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
