### PR TITLE
feat: instance-accurate ship dropdown (Iteron cargo fix)

### DIFF
--- a/backend/internal/handlers/fitting_test.go
+++ b/backend/internal/handlers/fitting_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
 	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
 	"github.com/gofiber/fiber/v2"
 )
@@ -25,6 +26,9 @@ func (m *mockFittingService) GetShipFitting(ctx context.Context, characterID int
 	return m.fitting, nil
 }
 func (m *mockFittingService) InvalidateFittingCache(ctx context.Context, characterID int, shipTypeID int) {
+	// No-op for mock
+}
+func (m *mockFittingService) EnrichShipsEffectiveCargo(ctx context.Context, characterID int, ships []models.CharacterAssetShip, accessToken string) {
 	// No-op for mock
 }
 

--- a/backend/internal/handlers/fitting_test.go
+++ b/backend/internal/handlers/fitting_test.go
@@ -31,6 +31,15 @@ func (m *mockFittingService) InvalidateFittingCache(ctx context.Context, charact
 func (m *mockFittingService) EnrichShipsEffectiveCargo(ctx context.Context, characterID int, ships []models.CharacterAssetShip, accessToken string) {
 	// No-op for mock
 }
+func (m *mockFittingService) EffectiveCargoForActiveShip(ctx context.Context, characterID, shipTypeID int, shipItemID int64, accessToken string) (float64, bool) {
+	if m.err != nil {
+		return 0, true
+	}
+	if m.fitting != nil {
+		return m.fitting.Bonuses.EffectiveCargo, false
+	}
+	return 0, false
+}
 
 // TestGetCharacterFitting_Success tests successful fitting retrieval
 func TestGetCharacterFitting_Success(t *testing.T) {

--- a/backend/internal/handlers/trading.go
+++ b/backend/internal/handlers/trading.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
@@ -604,18 +603,6 @@ func applyEffectiveCargoToShip(ship *models.CharacterShip, fit *services.Fitting
 	}
 }
 
-// applyEffectiveCargoToAssetShip is the CharacterAssetShip variant of
-// applyEffectiveCargoToShip (same issue #147 A3 contract).
-func applyEffectiveCargoToAssetShip(ship *models.CharacterAssetShip, fit *services.FittingData, err error) {
-	if err != nil {
-		ship.EffectiveCargoUnavailable = true
-		return
-	}
-	if fit != nil && fit.Bonuses.EffectiveCargo > 0 {
-		ship.EffectiveCargoCapacity = fit.Bonuses.EffectiveCargo
-	}
-}
-
 type esiAssetResponse struct {
 	ItemID       int64  `json:"item_id"`
 	TypeID       int64  `json:"type_id"`
@@ -717,35 +704,14 @@ func (h *TradingHandler) fetchESICharacterShips(ctx context.Context, characterID
 	}, nil
 }
 
-// enrichShipsWithEffectiveCargo fills EffectiveCargoCapacity for each singleton
-// ship in-place. Caps concurrency at 4 to avoid hammering ESI; non-singletons
-// (packaged) and ships with no resolvable fitting keep EffectiveCargoCapacity=0.
+// enrichShipsWithEffectiveCargo fills EffectiveCargoCapacity, EffectiveCargoUnavailable
+// and Name for each ship in-place by delegating to the FittingService, which resolves
+// each singleton's OWN fitting by item_id (not the first instance of the type).
 func (h *TradingHandler) enrichShipsWithEffectiveCargo(ctx context.Context, ships []models.CharacterAssetShip, characterID int, accessToken string) {
 	if h.fittingService == nil {
 		return
 	}
-	const maxConcurrent = 4
-	sem := make(chan struct{}, maxConcurrent)
-	var wg sync.WaitGroup
-	for i := range ships {
-		if !ships[i].IsSingleton {
-			continue
-		}
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(idx int) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			fit, err := h.fittingService.GetShipFitting(ctx, characterID, int(ships[idx].TypeID), accessToken)
-			applyEffectiveCargoToAssetShip(&ships[idx], fit, err)
-			if err != nil {
-				// Fail-loud (issue #147 A3): log the fitting fetch error; the
-				// EffectiveCargoUnavailable flag set above signals it to the client.
-				log.Printf("WARN: effective-cargo enrichment failed for characterID=%d shipTypeID=%d itemID=%d: %v (marking effective_cargo_unavailable)", characterID, ships[idx].TypeID, ships[idx].ItemID, err)
-			}
-		}(i)
-	}
-	wg.Wait()
+	h.fittingService.EnrichShipsEffectiveCargo(ctx, characterID, ships, accessToken)
 }
 
 // setESIAutopilotWaypoint sets a waypoint in the EVE client via ESI UI API

--- a/backend/internal/handlers/trading.go
+++ b/backend/internal/handlers/trading.go
@@ -572,35 +572,26 @@ func (h *TradingHandler) fetchESICharacterShip(ctx context.Context, characterID 
 	ship.CargoCapacity = capacities.BaseCargoHold
 
 	// Effective cargo (hull + skills + fitted modules) for the dropdown label.
-	// Fail-loud (issue #147 A3): a fitting FETCH ERROR is logged and surfaced via
-	// EffectiveCargoUnavailable so the client renders a visible degraded state
-	// instead of silently falling back to the base hull as if it were effective.
-	// "no fitting / no cargo bonus" (err==nil) is NOT an error and leaves the flag
-	// unset with EffectiveCargoCapacity==0.
+	// Instance-accurate (issue #147 + dropdown follow-up): the active/flown ship is the
+	// DEFAULT prefill in the ROI dropdown, so it must be computed for THIS exact instance
+	// by ship_item_id — not per type / first-instance. A pilot flying one of two same-type
+	// ships otherwise sees the wrong instance's cargo.
+	// Fail-loud (issue #147 A3): on an assets/calc error EffectiveCargoForActiveShip returns
+	// unavailable=true so the client renders a visible degraded state instead of silently
+	// showing the base hull as if it were effective. "no fitting / no cargo bonus" yields
+	// (0, false) and leaves the flag unset with EffectiveCargoCapacity==0.
 	if h.fittingService != nil {
-		fit, ferr := h.fittingService.GetShipFitting(ctx, characterID, int(esiShip.ShipTypeID), accessToken)
-		applyEffectiveCargoToShip(ship, fit, ferr)
-		if ferr != nil {
-			log.Printf("WARN: effective-cargo enrichment failed for characterID=%d shipTypeID=%d: %v (marking effective_cargo_unavailable)", characterID, esiShip.ShipTypeID, ferr)
+		eff, unavail := h.fittingService.EffectiveCargoForActiveShip(ctx, characterID, int(esiShip.ShipTypeID), esiShip.ShipItemID, accessToken)
+		if eff > 0 {
+			ship.EffectiveCargoCapacity = eff
+		}
+		ship.EffectiveCargoUnavailable = unavail
+		if unavail {
+			log.Printf("WARN: effective-cargo enrichment failed for characterID=%d shipTypeID=%d shipItemID=%d (marking effective_cargo_unavailable)", characterID, esiShip.ShipTypeID, esiShip.ShipItemID)
 		}
 	}
 
 	return ship, nil
-}
-
-// applyEffectiveCargoToShip applies a fitting-fetch result to a CharacterShip per
-// the issue #147 A3 contract:
-//   - err != nil               → EffectiveCargoUnavailable=true (explicit "unknown")
-//   - err == nil, fit/bonus ≤ 0 → leave EffectiveCargoCapacity=0, flag unset
-//   - err == nil, bonus > 0     → set EffectiveCargoCapacity
-func applyEffectiveCargoToShip(ship *models.CharacterShip, fit *services.FittingData, err error) {
-	if err != nil {
-		ship.EffectiveCargoUnavailable = true
-		return
-	}
-	if fit != nil && fit.Bonuses.EffectiveCargo > 0 {
-		ship.EffectiveCargoCapacity = fit.Bonuses.EffectiveCargo
-	}
 }
 
 type esiAssetResponse struct {

--- a/backend/internal/handlers/trading_effective_cargo_test.go
+++ b/backend/internal/handlers/trading_effective_cargo_test.go
@@ -3,50 +3,11 @@ package handlers
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
-	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
 	"github.com/stretchr/testify/assert"
 )
-
-// TestApplyEffectiveCargoToShip_FitErrorMarksUnavailable verifies the issue #147
-// A3 contract for the single-ship path: a fitting FETCH ERROR sets
-// EffectiveCargoUnavailable=true (the explicit "unknown" signal) and leaves the
-// capacity at 0 — it must NOT silently fall back to the base hull as if effective.
-func TestApplyEffectiveCargoToShip_FitErrorMarksUnavailable(t *testing.T) {
-	ship := &models.CharacterShip{CargoCapacity: 1000}
-
-	applyEffectiveCargoToShip(ship, nil, errors.New("esi down"))
-
-	assert.True(t, ship.EffectiveCargoUnavailable, "error must set the unavailable flag")
-	assert.Equal(t, 0.0, ship.EffectiveCargoCapacity, "no fabricated effective value on error")
-}
-
-// TestApplyEffectiveCargoToShip_NoFittingIsNotAnError verifies that the legitimate
-// "no fitting / no cargo bonus" case (err==nil) is NOT flagged as unavailable.
-func TestApplyEffectiveCargoToShip_NoFittingIsNotAnError(t *testing.T) {
-	// fit == nil, err == nil
-	ship := &models.CharacterShip{CargoCapacity: 1000}
-	applyEffectiveCargoToShip(ship, nil, nil)
-	assert.False(t, ship.EffectiveCargoUnavailable, "no fitting is not an error")
-	assert.Equal(t, 0.0, ship.EffectiveCargoCapacity)
-
-	// fit present but EffectiveCargo <= 0
-	ship2 := &models.CharacterShip{CargoCapacity: 1000}
-	applyEffectiveCargoToShip(ship2, &services.FittingData{Bonuses: services.FittingBonuses{EffectiveCargo: 0}}, nil)
-	assert.False(t, ship2.EffectiveCargoUnavailable, "zero cargo bonus is not an error")
-	assert.Equal(t, 0.0, ship2.EffectiveCargoCapacity)
-}
-
-// TestApplyEffectiveCargoToShip_SetsEffectiveWhenAvailable verifies the happy path.
-func TestApplyEffectiveCargoToShip_SetsEffectiveWhenAvailable(t *testing.T) {
-	ship := &models.CharacterShip{CargoCapacity: 1000}
-	applyEffectiveCargoToShip(ship, &services.FittingData{Bonuses: services.FittingBonuses{EffectiveCargo: 1450}}, nil)
-	assert.False(t, ship.EffectiveCargoUnavailable)
-	assert.Equal(t, 1450.0, ship.EffectiveCargoCapacity)
-}
 
 // TestEffectiveCargoUnavailable_WireForm guards the exact JSON field name the
 // frontend depends on: effective_cargo_unavailable (omitempty → only present when true).

--- a/backend/internal/handlers/trading_effective_cargo_test.go
+++ b/backend/internal/handlers/trading_effective_cargo_test.go
@@ -48,22 +48,6 @@ func TestApplyEffectiveCargoToShip_SetsEffectiveWhenAvailable(t *testing.T) {
 	assert.Equal(t, 1450.0, ship.EffectiveCargoCapacity)
 }
 
-// TestApplyEffectiveCargoToAssetShip_FitErrorMarksUnavailable mirrors the contract
-// for the concurrent asset-ship list path.
-func TestApplyEffectiveCargoToAssetShip_FitErrorMarksUnavailable(t *testing.T) {
-	ship := &models.CharacterAssetShip{CargoCapacity: 1000, IsSingleton: true}
-	applyEffectiveCargoToAssetShip(ship, nil, errors.New("esi down"))
-	assert.True(t, ship.EffectiveCargoUnavailable)
-	assert.Equal(t, 0.0, ship.EffectiveCargoCapacity)
-}
-
-func TestApplyEffectiveCargoToAssetShip_NoFittingIsNotAnError(t *testing.T) {
-	ship := &models.CharacterAssetShip{CargoCapacity: 1000, IsSingleton: true}
-	applyEffectiveCargoToAssetShip(ship, nil, nil)
-	assert.False(t, ship.EffectiveCargoUnavailable)
-	assert.Equal(t, 0.0, ship.EffectiveCargoCapacity)
-}
-
 // TestEffectiveCargoUnavailable_WireForm guards the exact JSON field name the
 // frontend depends on: effective_cargo_unavailable (omitempty → only present when true).
 func TestEffectiveCargoUnavailable_WireForm(t *testing.T) {

--- a/backend/internal/models/portfolio.go
+++ b/backend/internal/models/portfolio.go
@@ -4,11 +4,12 @@ package models
 type PortfolioRequest struct {
 	RegionID        int      `json:"region_id"`
 	ShipTypeID      int      `json:"ship_type_id"`
-	Capital         float64  `json:"capital"`           // ISK budget
-	TimeBudgetMin   float64  `json:"time_budget_min"`   // available trading minutes/day
-	LiquidityCapPct float64  `json:"liquidity_cap_pct"` // 0..100, max share of daily volume per item
-	MaxItemPct      float64  `json:"max_item_pct"`      // 0..100, max share of capital per item
-	SecZones        []string `json:"sec_zones"`         // "high","low","null"
+	CargoCapacity   float64  `json:"cargo_capacity,omitempty"` // Optional: selected ship instance's effective cargo (m³). When >0, overrides the per-type fitting recompute.
+	Capital         float64  `json:"capital"`                  // ISK budget
+	TimeBudgetMin   float64  `json:"time_budget_min"`          // available trading minutes/day
+	LiquidityCapPct float64  `json:"liquidity_cap_pct"`        // 0..100, max share of daily volume per item
+	MaxItemPct      float64  `json:"max_item_pct"`             // 0..100, max share of capital per item
+	SecZones        []string `json:"sec_zones"`                // "high","low","null"
 } // @name PortfolioRequest
 
 // PortfolioItem is one allocated position in the suggested portfolio.

--- a/backend/internal/models/trading.go
+++ b/backend/internal/models/trading.go
@@ -153,6 +153,7 @@ type CharacterAssetShip struct {
 	ItemID                 int64   `json:"item_id"`
 	TypeID                 int64   `json:"type_id"`
 	TypeName               string  `json:"type_name"`
+	Name                   string  `json:"name,omitempty"` // Custom ship name from ESI /assets/names; falls back to TypeName
 	LocationID             int64   `json:"location_id"`
 	LocationName           string  `json:"location_name"`
 	LocationFlag           string  `json:"location_flag"`

--- a/backend/internal/services/asset_names_test.go
+++ b/backend/internal/services/asset_names_test.go
@@ -1,0 +1,17 @@
+package services
+
+import "testing"
+
+func TestParseAssetNames_MapsAndFallsBack(t *testing.T) {
+	raw := []byte(`[{"item_id":111,"name":"Ix-ITE-1"},{"item_id":222,"name":"None"}]`)
+	names, err := parseAssetNames(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if names[111] != "Ix-ITE-1" {
+		t.Errorf("want Ix-ITE-1, got %q", names[111])
+	}
+	if _, ok := names[222]; ok {
+		t.Errorf(`"None" should be dropped so the caller falls back to the type name`)
+	}
+}

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -45,6 +45,8 @@ func (fakeFitting) GetShipFitting(_ context.Context, _, _ int, _ string) (*Fitti
 	return nil, nil
 }
 func (fakeFitting) InvalidateFittingCache(_ context.Context, _, _ int) {}
+func (fakeFitting) EnrichShipsEffectiveCargo(_ context.Context, _ int, _ []models.CharacterAssetShip, _ string) {
+}
 
 type fakeActiveShip struct{ typeID int }
 

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -47,6 +47,9 @@ func (fakeFitting) GetShipFitting(_ context.Context, _, _ int, _ string) (*Fitti
 func (fakeFitting) InvalidateFittingCache(_ context.Context, _, _ int) {}
 func (fakeFitting) EnrichShipsEffectiveCargo(_ context.Context, _ int, _ []models.CharacterAssetShip, _ string) {
 }
+func (fakeFitting) EffectiveCargoForActiveShip(_ context.Context, _, _ int, _ int64, _ string) (float64, bool) {
+	return 0, false
+}
 
 type fakeActiveShip struct{ typeID int }
 

--- a/backend/internal/services/fitting_asset_names_chunk_test.go
+++ b/backend/internal/services/fitting_asset_names_chunk_test.go
@@ -1,0 +1,60 @@
+package services
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestChunkInt64 verifies FetchAssetNames' batching helper respects ESI's 1000-id
+// limit: ≤size stays a single batch, >size splits into consecutive ≤size batches
+// with no ids lost or duplicated.
+func TestChunkInt64(t *testing.T) {
+	t.Run("at or below size is a single chunk", func(t *testing.T) {
+		ids := []int64{1, 2, 3}
+		got := chunkInt64(ids, assetNamesMaxIDs)
+		if len(got) != 1 || !reflect.DeepEqual(got[0], ids) {
+			t.Fatalf("want single chunk %v, got %v", ids, got)
+		}
+	})
+
+	t.Run("exactly size is a single chunk", func(t *testing.T) {
+		ids := make([]int64, assetNamesMaxIDs)
+		for i := range ids {
+			ids[i] = int64(i)
+		}
+		got := chunkInt64(ids, assetNamesMaxIDs)
+		if len(got) != 1 {
+			t.Fatalf("1000 ids must be one batch, got %d batches", len(got))
+		}
+	})
+
+	t.Run("above size splits into <=size batches", func(t *testing.T) {
+		ids := make([]int64, 2300)
+		for i := range ids {
+			ids[i] = int64(i)
+		}
+		got := chunkInt64(ids, assetNamesMaxIDs)
+		if len(got) != 3 {
+			t.Fatalf("2300 ids → want 3 batches, got %d", len(got))
+		}
+		// No batch exceeds the limit; all ids preserved in order.
+		var flat []int64
+		for _, b := range got {
+			if len(b) > assetNamesMaxIDs {
+				t.Fatalf("batch of %d exceeds limit %d", len(b), assetNamesMaxIDs)
+			}
+			flat = append(flat, b...)
+		}
+		if !reflect.DeepEqual(flat, ids) {
+			t.Fatalf("flattened batches must equal input ids")
+		}
+	})
+
+	t.Run("size <= 0 yields one chunk", func(t *testing.T) {
+		ids := []int64{1, 2, 3}
+		got := chunkInt64(ids, 0)
+		if len(got) != 1 || !reflect.DeepEqual(got[0], ids) {
+			t.Fatalf("size<=0 must be single chunk, got %v", got)
+		}
+	})
+}

--- a/backend/internal/services/fitting_effective_cargo_test.go
+++ b/backend/internal/services/fitting_effective_cargo_test.go
@@ -1,0 +1,43 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/cargo"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
+)
+
+// Reinforced Bulkheads I (typeID 1333) has dogma attr 149 (cargoCapacityMultiplier) = 0.9,
+// which reduces cargo capacity by 10%. Confirmed in SDE typeDogma table.
+const reinforcedBulkheadTypeID = 1333
+
+func TestEffectiveCargoForShipItem_PerInstance(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	s := &FittingService{sdeDB: db}
+	ctx := context.Background()
+
+	skills := &cargo.CharacterSkills{Skills: []struct {
+		SkillID           int64 `json:"skill_id"`
+		ActiveSkillLevel  int   `json:"active_skill_level"`
+		TrainedSkillLevel int   `json:"trained_skill_level"`
+	}{{SkillID: 3340, ActiveSkillLevel: 1, TrainedSkillLevel: 1}}}
+
+	emptyAssets := []esiAsset{{ItemID: 111, TypeID: 657, IsSingleton: true}}
+	empty, unavailEmpty := s.EffectiveCargoForShipItem(ctx, 657, 111, emptyAssets, skills)
+	if unavailEmpty {
+		t.Fatalf("empty ship should not be unavailable")
+	}
+	if empty < 6089 || empty > 6091 {
+		t.Errorf("empty Iteron effective: want ~6090, got %.1f", empty)
+	}
+
+	bulkAssets := []esiAsset{
+		{ItemID: 222, TypeID: 657, IsSingleton: true},
+		{ItemID: 999, TypeID: reinforcedBulkheadTypeID, LocationID: 222, LocationFlag: "LoSlot0"},
+	}
+	bulk, _ := s.EffectiveCargoForShipItem(ctx, 657, 222, bulkAssets, skills)
+	if bulk >= empty {
+		t.Errorf("bulkhead ship cargo should be below the empty ship: empty=%.1f bulk=%.1f", empty, bulk)
+	}
+}

--- a/backend/internal/services/fitting_effective_cargo_test.go
+++ b/backend/internal/services/fitting_effective_cargo_test.go
@@ -41,3 +41,38 @@ func TestEffectiveCargoForShipItem_PerInstance(t *testing.T) {
 		t.Errorf("bulkhead ship cargo should be below the empty ship: empty=%.1f bulk=%.1f", empty, bulk)
 	}
 }
+
+// TestActiveShipEffectiveCargo_IsInstanceScoped guards the dropdown follow-up bug:
+// the active/flown ship (the ROI default prefill) must compute effective cargo for
+// THIS exact instance by ship_item_id, not per type / first-instance. Two same-type
+// ships differing only by their fitting must yield different effective cargo through
+// the same item-scoped seam that EffectiveCargoForActiveShip delegates to.
+func TestActiveShipEffectiveCargo_IsInstanceScoped(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	s := &FittingService{sdeDB: db}
+	ctx := context.Background()
+
+	skills := &cargo.CharacterSkills{Skills: []struct {
+		SkillID           int64 `json:"skill_id"`
+		ActiveSkillLevel  int   `json:"active_skill_level"`
+		TrainedSkillLevel int   `json:"trained_skill_level"`
+	}{{SkillID: 3340, ActiveSkillLevel: 1, TrainedSkillLevel: 1}}}
+
+	// Two same-type (Iteron, 657) instances in the shared asset list: 333 is empty,
+	// 444 carries a Reinforced Bulkhead reducing its cargo.
+	assets := []esiAsset{
+		{ItemID: 333, TypeID: 657, IsSingleton: true},
+		{ItemID: 444, TypeID: 657, IsSingleton: true},
+		{ItemID: 555, TypeID: reinforcedBulkheadTypeID, LocationID: 444, LocationFlag: "LoSlot0"},
+	}
+
+	effEmpty, unavailEmpty := s.EffectiveCargoForShipItem(ctx, 657, 333, assets, skills)
+	effBulk, unavailBulk := s.EffectiveCargoForShipItem(ctx, 657, 444, assets, skills)
+
+	if unavailEmpty || unavailBulk {
+		t.Fatalf("both instances should resolve: empty=%v bulk=%v", unavailEmpty, unavailBulk)
+	}
+	if effBulk >= effEmpty {
+		t.Errorf("active ship must be instance-scoped by item_id: empty=%.1f must exceed bulk=%.1f", effEmpty, effBulk)
+	}
+}

--- a/backend/internal/services/fitting_service.go
+++ b/backend/internal/services/fitting_service.go
@@ -611,6 +611,36 @@ func (s *FittingService) getDefaultFitting(shipTypeID int) *FittingData {
 	}
 }
 
+// fittedItemsForShip collects cargo.FittedItem entries for all modules fitted to a specific
+// ship item. It uses only the asset list (no ESI dogma lookups), making it suitable for
+// lightweight per-instance effective-cargo calculations.
+func (s *FittingService) fittedItemsForShip(ctx context.Context, assets []esiAsset, shipItemID int64) []cargo.FittedItem {
+	items := make([]cargo.FittedItem, 0)
+	for _, asset := range assets {
+		if asset.LocationID == shipItemID && isFittedSlot(asset.LocationFlag) {
+			items = append(items, cargo.FittedItem{TypeID: int64(asset.TypeID), Slot: asset.LocationFlag})
+		}
+	}
+	return items
+}
+
+// EffectiveCargoForShipItem computes the effective cargo hold for a specific ship instance
+// (identified by shipItemID) using the supplied asset list and character skills.
+// Returns (effectiveCargo, unavailable): unavailable is true when the SDE lookup fails.
+func (s *FittingService) EffectiveCargoForShipItem(
+	ctx context.Context, shipTypeID int, shipItemID int64, assets []esiAsset, charSkills *cargo.CharacterSkills,
+) (float64, bool) {
+	items := s.fittedItemsForShip(ctx, assets, shipItemID)
+	caps, err := cargo.GetShipCapacitiesDeterministic(ctx, s.sdeDB, int64(shipTypeID), charSkills, items)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("effective cargo per-item calc failed", "shipTypeID", shipTypeID, "itemID", shipItemID, "error", err)
+		}
+		return 0, true
+	}
+	return caps.EffectiveCargoHold, false
+}
+
 // isFittedSlot checks if a location_flag represents a fitted module slot
 func isFittedSlot(locationFlag string) bool {
 	fittedSlots := map[string]bool{

--- a/backend/internal/services/fitting_service.go
+++ b/backend/internal/services/fitting_service.go
@@ -462,6 +462,21 @@ func (s *FittingService) EnrichShipsEffectiveCargo(ctx context.Context, characte
 	}
 }
 
+// EffectiveCargoForActiveShip computes the effective cargo for a single ship instance by
+// item_id (used for the flown/active ship). Returns (effective, unavailable). On an
+// assets/calc error returns (0, true) so the caller fails loud (falls back to base + flag).
+func (s *FittingService) EffectiveCargoForActiveShip(ctx context.Context, characterID, shipTypeID int, shipItemID int64, accessToken string) (float64, bool) {
+	assets, err := s.fetchESIAssets(ctx, characterID, accessToken)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("active ship effective cargo: assets fetch failed", "error", err)
+		}
+		return 0, true
+	}
+	charSkills := s.characterCargoSkills(ctx, characterID, accessToken)
+	return s.EffectiveCargoForShipItem(ctx, shipTypeID, shipItemID, assets, charSkills)
+}
+
 // fetchESIAssets fetches character assets from ESI /v5/characters/{id}/assets/
 func (s *FittingService) fetchESIAssets(
 	ctx context.Context,
@@ -706,12 +721,45 @@ func parseAssetNames(body []byte) (map[int64]string, error) {
 	return out, nil
 }
 
+// assetNamesMaxIDs is ESI's per-request id cap for /assets/names/ (max 1000 ids).
+const assetNamesMaxIDs = 1000
+
+// chunkInt64 splits ids into consecutive slices of at most size elements.
+// A size <= 0 yields a single chunk with all ids.
+func chunkInt64(ids []int64, size int) [][]int64 {
+	if size <= 0 || len(ids) <= size {
+		return [][]int64{ids}
+	}
+	chunks := make([][]int64, 0, (len(ids)+size-1)/size)
+	for start := 0; start < len(ids); start += size {
+		end := start + size
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunks = append(chunks, ids[start:end])
+	}
+	return chunks
+}
+
 // FetchAssetNames resolves custom names for the given item_ids (best-effort: on any
 // error returns an empty map so labels fall back to the type name — never blocks the list).
+// Requests are chunked to ESI's 1000-id limit; a failed batch contributes nothing.
 func (s *FittingService) FetchAssetNames(ctx context.Context, characterID int, itemIDs []int64, accessToken string) map[int64]string {
 	if len(itemIDs) == 0 {
 		return map[int64]string{}
 	}
+	out := make(map[int64]string, len(itemIDs))
+	for _, batch := range chunkInt64(itemIDs, assetNamesMaxIDs) {
+		for id, name := range s.fetchAssetNamesBatch(ctx, characterID, batch, accessToken) {
+			out[id] = name
+		}
+	}
+	return out
+}
+
+// fetchAssetNamesBatch POSTs a single batch of ≤1000 ids to ESI /assets/names/.
+// Best-effort: returns an empty map on any error.
+func (s *FittingService) fetchAssetNamesBatch(ctx context.Context, characterID int, itemIDs []int64, accessToken string) map[int64]string {
 	bodyBytes, _ := json.Marshal(itemIDs)
 	endpoint := fmt.Sprintf("/latest/characters/%d/assets/names/", characterID)
 	req, err := http.NewRequestWithContext(ctx, "POST", esiconfig.BaseURL+endpoint, bytes.NewReader(bodyBytes))

--- a/backend/internal/services/fitting_service.go
+++ b/backend/internal/services/fitting_service.go
@@ -2,6 +2,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -639,6 +640,69 @@ func (s *FittingService) EffectiveCargoForShipItem(
 		return 0, true
 	}
 	return caps.EffectiveCargoHold, false
+}
+
+// parseAssetNames parses the JSON body from ESI /assets/names/ into a map
+// of item_id → name. Entries with empty name or the sentinel "None" are
+// dropped so callers can fall back to the type name.
+func parseAssetNames(body []byte) (map[int64]string, error) {
+	var rows []struct {
+		ItemID int64  `json:"item_id"`
+		Name   string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &rows); err != nil {
+		return nil, fmt.Errorf("decode asset names: %w", err)
+	}
+	out := make(map[int64]string, len(rows))
+	for _, r := range rows {
+		if r.Name == "" || r.Name == "None" {
+			continue
+		}
+		out[r.ItemID] = r.Name
+	}
+	return out, nil
+}
+
+// FetchAssetNames resolves custom names for the given item_ids (best-effort: on any
+// error returns an empty map so labels fall back to the type name — never blocks the list).
+func (s *FittingService) FetchAssetNames(ctx context.Context, characterID int, itemIDs []int64, accessToken string) map[int64]string {
+	if len(itemIDs) == 0 {
+		return map[int64]string{}
+	}
+	bodyBytes, _ := json.Marshal(itemIDs)
+	endpoint := fmt.Sprintf("/latest/characters/%d/assets/names/", characterID)
+	req, err := http.NewRequestWithContext(ctx, "POST", esiconfig.BaseURL+endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("asset names: build request failed", "error", err)
+		}
+		return map[int64]string{}
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.esiClient.Do(req)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("asset names: esi request failed", "error", err)
+		}
+		return map[int64]string{}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		if s.logger != nil {
+			s.logger.Warn("asset names: non-200", "status", resp.StatusCode)
+		}
+		return map[int64]string{}
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	names, err := parseAssetNames(raw)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("asset names: parse failed", "error", err)
+		}
+		return map[int64]string{}
+	}
+	return names
 }
 
 // isFittedSlot checks if a location_flag represents a fitted module slot

--- a/backend/internal/services/fitting_service.go
+++ b/backend/internal/services/fitting_service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	esiclient "github.com/Sternrassler/eve-esi-client/pkg/client"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
 	"github.com/Sternrassler/eve-o-provit/backend/internal/services/esiconfig"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/cargo"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/navigation"
@@ -199,96 +200,8 @@ func (s *FittingService) fetchFittingFromESI(
 		}
 	}
 
-	// 4. Fetch character skills
-	skills, err := s.skillsService.GetCharacterSkills(ctx, characterID, accessToken)
-	if err != nil {
-		s.logger.Warn("Failed to fetch character skills, using default", "error", err)
-		skills = nil // Will use graceful degradation in deterministic calculation
-	}
-
-	// 5. Convert to cargo.CharacterSkills format (array-based)
-	var charSkills *cargo.CharacterSkills
-	if skills != nil {
-		// Map TradingSkills to ESI CharacterSkills format
-		skillsList := []struct {
-			SkillID           int64 `json:"skill_id"`
-			ActiveSkillLevel  int   `json:"active_skill_level"`
-			TrainedSkillLevel int   `json:"trained_skill_level"`
-		}{}
-
-		// Add Spaceship Command if present
-		if skills.SpaceshipCommand > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3327, ActiveSkillLevel: skills.SpaceshipCommand, TrainedSkillLevel: skills.SpaceshipCommand})
-		}
-
-		// Add Racial Industrial Skills
-		if skills.GallenteIndustrial > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3348, ActiveSkillLevel: skills.GallenteIndustrial, TrainedSkillLevel: skills.GallenteIndustrial})
-		}
-		if skills.CaldariIndustrial > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3346, ActiveSkillLevel: skills.CaldariIndustrial, TrainedSkillLevel: skills.CaldariIndustrial})
-		}
-		if skills.AmarrIndustrial > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3347, ActiveSkillLevel: skills.AmarrIndustrial, TrainedSkillLevel: skills.AmarrIndustrial})
-		}
-		if skills.MinmatarIndustrial > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3349, ActiveSkillLevel: skills.MinmatarIndustrial, TrainedSkillLevel: skills.MinmatarIndustrial})
-		}
-
-		// Add Racial Hauler Skills (Issue #77 - deterministic)
-		if skills.GallenteHauler > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3340, ActiveSkillLevel: skills.GallenteHauler, TrainedSkillLevel: skills.GallenteHauler})
-		}
-		if skills.CaldariHauler > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3341, ActiveSkillLevel: skills.CaldariHauler, TrainedSkillLevel: skills.CaldariHauler})
-		}
-		if skills.AmarrHauler > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3342, ActiveSkillLevel: skills.AmarrHauler, TrainedSkillLevel: skills.AmarrHauler})
-		}
-		if skills.MinmatarHauler > 0 {
-			skillsList = append(skillsList, struct {
-				SkillID           int64 `json:"skill_id"`
-				ActiveSkillLevel  int   `json:"active_skill_level"`
-				TrainedSkillLevel int   `json:"trained_skill_level"`
-			}{SkillID: 3343, ActiveSkillLevel: skills.MinmatarHauler, TrainedSkillLevel: skills.MinmatarHauler})
-		}
-
-		charSkills = &cargo.CharacterSkills{
-			Skills: skillsList,
-		}
-	}
+	// 4. + 5. Fetch character skills and convert to cargo.CharacterSkills format
+	charSkills := s.characterCargoSkills(ctx, characterID, accessToken)
 
 	// 6. Convert fitted modules to cargo.FittedItem format
 	fittedItems := make([]cargo.FittedItem, 0, len(fittedModules))
@@ -417,6 +330,136 @@ func (s *FittingService) fetchFittingFromESI(
 			WarpSpeedAUS:  effectiveWarpSpeed, // Final warp speed in AU/s (for route calculation)
 		},
 	}, nil
+}
+
+// characterCargoSkills fetches the character's skills via SkillsServicer and converts
+// the cargo-relevant ones (Spaceship Command, racial Industrial + Hauler skills) into
+// the array-based cargo.CharacterSkills format used by the deterministic calculators.
+// Returns nil on a skills-fetch failure (the calculators degrade gracefully on nil).
+func (s *FittingService) characterCargoSkills(ctx context.Context, characterID int, accessToken string) *cargo.CharacterSkills {
+	skills, err := s.skillsService.GetCharacterSkills(ctx, characterID, accessToken)
+	if err != nil {
+		s.logger.Warn("Failed to fetch character skills, using default", "error", err)
+		return nil
+	}
+	if skills == nil {
+		return nil
+	}
+
+	// Map TradingSkills to ESI CharacterSkills format
+	skillsList := []struct {
+		SkillID           int64 `json:"skill_id"`
+		ActiveSkillLevel  int   `json:"active_skill_level"`
+		TrainedSkillLevel int   `json:"trained_skill_level"`
+	}{}
+
+	// Add Spaceship Command if present
+	if skills.SpaceshipCommand > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3327, ActiveSkillLevel: skills.SpaceshipCommand, TrainedSkillLevel: skills.SpaceshipCommand})
+	}
+
+	// Add Racial Industrial Skills
+	if skills.GallenteIndustrial > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3348, ActiveSkillLevel: skills.GallenteIndustrial, TrainedSkillLevel: skills.GallenteIndustrial})
+	}
+	if skills.CaldariIndustrial > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3346, ActiveSkillLevel: skills.CaldariIndustrial, TrainedSkillLevel: skills.CaldariIndustrial})
+	}
+	if skills.AmarrIndustrial > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3347, ActiveSkillLevel: skills.AmarrIndustrial, TrainedSkillLevel: skills.AmarrIndustrial})
+	}
+	if skills.MinmatarIndustrial > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3349, ActiveSkillLevel: skills.MinmatarIndustrial, TrainedSkillLevel: skills.MinmatarIndustrial})
+	}
+
+	// Add Racial Hauler Skills (Issue #77 - deterministic)
+	if skills.GallenteHauler > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3340, ActiveSkillLevel: skills.GallenteHauler, TrainedSkillLevel: skills.GallenteHauler})
+	}
+	if skills.CaldariHauler > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3341, ActiveSkillLevel: skills.CaldariHauler, TrainedSkillLevel: skills.CaldariHauler})
+	}
+	if skills.AmarrHauler > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3342, ActiveSkillLevel: skills.AmarrHauler, TrainedSkillLevel: skills.AmarrHauler})
+	}
+	if skills.MinmatarHauler > 0 {
+		skillsList = append(skillsList, struct {
+			SkillID           int64 `json:"skill_id"`
+			ActiveSkillLevel  int   `json:"active_skill_level"`
+			TrainedSkillLevel int   `json:"trained_skill_level"`
+		}{SkillID: 3343, ActiveSkillLevel: skills.MinmatarHauler, TrainedSkillLevel: skills.MinmatarHauler})
+	}
+
+	return &cargo.CharacterSkills{Skills: skillsList}
+}
+
+// EnrichShipsEffectiveCargo fills each singleton ship's EffectiveCargoCapacity (from its
+// OWN fitting by item_id), EffectiveCargoUnavailable (true on a calc error → fail-loud),
+// and Name (custom ESI name, falling back to TypeName). Best-effort: an assets-fetch error
+// leaves the ships unenriched rather than failing the whole list.
+func (s *FittingService) EnrichShipsEffectiveCargo(ctx context.Context, characterID int, ships []models.CharacterAssetShip, accessToken string) {
+	assets, err := s.fetchESIAssets(ctx, characterID, accessToken)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("enrich ships: assets fetch failed", "characterID", characterID, "error", err)
+		}
+		return
+	}
+	charSkills := s.characterCargoSkills(ctx, characterID, accessToken)
+
+	itemIDs := make([]int64, 0, len(ships))
+	for i := range ships {
+		itemIDs = append(itemIDs, ships[i].ItemID)
+	}
+	names := s.FetchAssetNames(ctx, characterID, itemIDs, accessToken)
+
+	for i := range ships {
+		if n := names[ships[i].ItemID]; n != "" {
+			ships[i].Name = n
+		} else {
+			ships[i].Name = ships[i].TypeName
+		}
+		if !ships[i].IsSingleton {
+			continue
+		}
+		eff, unavail := s.EffectiveCargoForShipItem(ctx, int(ships[i].TypeID), ships[i].ItemID, assets, charSkills)
+		if eff > 0 {
+			ships[i].EffectiveCargoCapacity = eff
+		}
+		ships[i].EffectiveCargoUnavailable = unavail
+	}
 }
 
 // fetchESIAssets fetches character assets from ESI /v5/characters/{id}/assets/

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -61,6 +61,11 @@ type FittingServicer interface {
 	// (from its OWN fitting by item_id), EffectiveCargoUnavailable, and Name
 	// (custom ESI name, falling back to TypeName). Best-effort: enriches in place.
 	EnrichShipsEffectiveCargo(ctx context.Context, characterID int, ships []models.CharacterAssetShip, accessToken string)
+
+	// EffectiveCargoForActiveShip computes the effective cargo for a single ship
+	// instance by item_id (the flown/active ship). Returns (effective, unavailable);
+	// (0, true) on an assets/calc error so the caller fails loud.
+	EffectiveCargoForActiveShip(ctx context.Context, characterID, shipTypeID int, shipItemID int64, accessToken string) (float64, bool)
 }
 
 // FeeServicer defines the interface for trading fee calculations

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -56,6 +56,11 @@ type FittingServicer interface {
 
 	// InvalidateFittingCache removes fitting data from Redis cache
 	InvalidateFittingCache(ctx context.Context, characterID int, shipTypeID int)
+
+	// EnrichShipsEffectiveCargo fills each singleton ship's EffectiveCargoCapacity
+	// (from its OWN fitting by item_id), EffectiveCargoUnavailable, and Name
+	// (custom ESI name, falling back to TypeName). Best-effort: enriches in place.
+	EnrichShipsEffectiveCargo(ctx context.Context, characterID int, ships []models.CharacterAssetShip, accessToken string)
 }
 
 // FeeServicer defines the interface for trading fee calculations

--- a/backend/internal/services/portfolio_service.go
+++ b/backend/internal/services/portfolio_service.go
@@ -33,6 +33,7 @@ func (s *PortfolioService) Optimize(ctx context.Context, req *models.PortfolioRe
 	resp, err := s.routes.CalculateWithFilters(ctx, &models.RouteCalculationRequest{
 		RegionID:             req.RegionID,
 		ShipTypeID:           req.ShipTypeID,
+		CargoCapacity:        req.CargoCapacity,
 		IncludeVolumeMetrics: true,
 	})
 	if err != nil {

--- a/backend/internal/services/portfolio_service_test.go
+++ b/backend/internal/services/portfolio_service_test.go
@@ -1,9 +1,105 @@
 package services
 
 import (
+	"context"
 	"math"
 	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
 )
+
+// fakeRouteCalculator is a test double for RouteCalculatorServicer that
+// records the last RouteCalculationRequest so tests can assert on forwarded fields.
+type fakeRouteCalculator struct {
+	lastReq *models.RouteCalculationRequest
+	resp    *models.RouteCalculationResponse
+}
+
+func (f *fakeRouteCalculator) Calculate(_ context.Context, _, _ int, _ float64, _, _ *float64) (*models.RouteCalculationResponse, error) {
+	return f.resp, nil
+}
+
+func (f *fakeRouteCalculator) CalculateWithFilters(_ context.Context, req *models.RouteCalculationRequest) (*models.RouteCalculationResponse, error) {
+	f.lastReq = req
+	return f.resp, nil
+}
+
+// fakeSkillsService is a no-op SkillsServicer for portfolio service tests.
+type fakeSkillsService struct{}
+
+func (f *fakeSkillsService) GetCharacterSkills(_ context.Context, _ int, _ string) (*TradingSkills, error) {
+	return &TradingSkills{}, nil
+}
+
+// TestPortfolioService_Optimize_ForwardsCargoCapacityOverride asserts that when
+// PortfolioRequest.CargoCapacity > 0, the value is forwarded verbatim in the
+// RouteCalculationRequest sent to the route calculator. This ensures the
+// selected ship instance's effective cargo overrides the per-type recompute.
+func TestPortfolioService_Optimize_ForwardsCargoCapacityOverride(t *testing.T) {
+	fake := &fakeRouteCalculator{
+		resp: &models.RouteCalculationResponse{
+			Routes:        []models.TradingRoute{},
+			CargoCapacity: 62500,
+		},
+	}
+	svc := NewPortfolioService(fake, &fakeSkillsService{}, logger.NewNoop())
+
+	req := &models.PortfolioRequest{
+		RegionID:        10000002,
+		ShipTypeID:      12345,
+		CargoCapacity:   62500,
+		Capital:         1_000_000,
+		TimeBudgetMin:   480,
+		LiquidityCapPct: 10,
+		MaxItemPct:      50,
+	}
+
+	_, err := svc.Optimize(context.Background(), req, 0, "")
+	if err != nil {
+		t.Fatalf("Optimize returned error: %v", err)
+	}
+	if fake.lastReq == nil {
+		t.Fatal("CalculateWithFilters was not called")
+	}
+	if fake.lastReq.CargoCapacity != 62500 {
+		t.Errorf("CargoCapacity not forwarded: got %v, want 62500", fake.lastReq.CargoCapacity)
+	}
+}
+
+// TestPortfolioService_Optimize_ZeroCargoCapacityNotForced asserts that when
+// PortfolioRequest.CargoCapacity is 0 (unset), the forwarded request also has 0,
+// so the route service falls back to the per-type fitting recompute.
+func TestPortfolioService_Optimize_ZeroCargoCapacityNotForced(t *testing.T) {
+	fake := &fakeRouteCalculator{
+		resp: &models.RouteCalculationResponse{
+			Routes:        []models.TradingRoute{},
+			CargoCapacity: 50000,
+		},
+	}
+	svc := NewPortfolioService(fake, &fakeSkillsService{}, logger.NewNoop())
+
+	req := &models.PortfolioRequest{
+		RegionID:        10000002,
+		ShipTypeID:      12345,
+		Capital:         1_000_000,
+		TimeBudgetMin:   480,
+		LiquidityCapPct: 10,
+		MaxItemPct:      50,
+		// CargoCapacity intentionally zero (omitted)
+	}
+
+	_, err := svc.Optimize(context.Background(), req, 0, "")
+	if err != nil {
+		t.Fatalf("Optimize returned error: %v", err)
+	}
+	if fake.lastReq == nil {
+		t.Fatal("CalculateWithFilters was not called")
+	}
+	if fake.lastReq.CargoCapacity != 0 {
+		t.Errorf("expected CargoCapacity=0 when unset, got %v", fake.lastReq.CargoCapacity)
+	}
+}
 
 func approx(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
 

--- a/docs/superpowers/plans/2026-05-31-instance-accurate-ship-dropdown.md
+++ b/docs/superpowers/plans/2026-05-31-instance-accurate-ship-dropdown.md
@@ -1,0 +1,466 @@
+# Instance-accurate ship dropdown — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** List each owned ship instance individually (custom name + its own fitting's effective cargo) in the ROI dropdown, and feed the selected instance's exact cargo into the optimizer — fixing the type-level arbitrary-instance cargo bug (Iteron shown 4.9k vs in-game 6.09k).
+
+**Architecture:** Backend enriches each `CharacterAssetShip` per item_id (its real fitted modules) and attaches the custom ship name from ESI `/assets/names`. Frontend stops deduping by type_id (dedupe by item_id), labels each option `name (cargo)`, and sends the selected instance's effective cargo as the existing `cargo_capacity` override so the optimizer never recomputes per-type.
+
+**Tech Stack:** Go 1.24 / Fiber backend, SQLite SDE via `pkg/evedb`, Next.js 16 / React / TypeScript frontend, vitest.
+
+Reference spec: `docs/superpowers/specs/2026-05-31-instance-accurate-ship-dropdown-design.md`.
+
+**Verification env:** backend Go tests that touch SDE use `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db` and run with `GOWORK=off`. Commits: hooks need gitleaks on PATH — prefix git commits with `PATH="$HOME/.local/bin:$PATH"`.
+
+---
+
+## Task 1: Per-item fitting resolution (backend core)
+
+Today `fetchFittingFromESI` picks the *first* singleton of a type. Extract the module-resolution + effective-cargo computation so it can run for a *specific* ship item_id, given the already-fetched assets.
+
+**Files:**
+- Modify: `backend/internal/services/fitting_service.go` (refactor `fetchFittingFromESI`; add `EffectiveCargoForShipItem`)
+- Test: `backend/internal/services/fitting_effective_cargo_test.go` (new)
+
+- [ ] **Step 1: Write the failing test** — two same-type ships, different modules → different effective cargo.
+
+`backend/internal/services/fitting_effective_cargo_test.go`:
+```go
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/cargo"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
+)
+
+// Iteron Mark V (657), Gallente Industrial (3340) L1 → 6090 with no modules.
+// A Reinforced Bulkhead (1300, dogma attr 149 < 1) reduces it below base.
+func TestEffectiveCargoForShipItem_PerInstance(t *testing.T) {
+	db := testutil.OpenTestDB(t) // SDE_DB_PATH
+	s := &FittingService{sdeDB: db}
+	ctx := context.Background()
+
+	skills := &cargo.CharacterSkills{Skills: []struct {
+		SkillID           int64 `json:"skill_id"`
+		ActiveSkillLevel  int   `json:"active_skill_level"`
+		TrainedSkillLevel int   `json:"trained_skill_level"`
+	}{{SkillID: 3340, ActiveSkillLevel: 1, TrainedSkillLevel: 1}}}
+
+	// Empty Iteron (item 111): no fitted modules.
+	emptyAssets := []esiAsset{{ItemID: 111, TypeID: 657, IsSingleton: true}}
+	empty, unavailEmpty := s.EffectiveCargoForShipItem(ctx, 657, 111, emptyAssets, skills)
+	if unavailEmpty {
+		t.Fatalf("empty ship should not be unavailable")
+	}
+	if empty < 6089 || empty > 6091 {
+		t.Errorf("empty Iteron effective: want ~6090, got %.1f", empty)
+	}
+
+	// Bulkhead Iteron (item 222) with a Reinforced Bulkhead II (type 1306) in a low slot.
+	bulkAssets := []esiAsset{
+		{ItemID: 222, TypeID: 657, IsSingleton: true},
+		{ItemID: 999, TypeID: 1306, LocationID: 222, LocationFlag: "LoSlot0"},
+	}
+	bulk, _ := s.EffectiveCargoForShipItem(ctx, 657, 222, bulkAssets, skills)
+	if bulk >= empty {
+		t.Errorf("bulkhead ship cargo should be below the empty ship: empty=%.1f bulk=%.1f", empty, bulk)
+	}
+}
+```
+> Verify the Reinforced Bulkhead type id (1306) and that it has dogma attr 149 in the SDE before finalizing; if the chosen module has no cargo modifier in the test DB, pick one that does (query: `SELECT _key,json_extract(name,'$.en') FROM types WHERE json_extract(name,'$.en') LIKE 'Reinforced Bulkhead%';` then confirm attr 149 via typeDogma). Adjust the type id in the test to a confirmed one.
+
+- [ ] **Step 2: Run the test, verify it fails to compile** (`EffectiveCargoForShipItem` undefined).
+
+Run: `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/services/ -run TestEffectiveCargoForShipItem_PerInstance -v`
+Expected: build error `s.EffectiveCargoForShipItem undefined`.
+
+- [ ] **Step 3: Extract a helper and add the method.** In `fitting_service.go`, factor the module-collection loop in `fetchFittingFromESI` (the `for _, asset := range assets { if asset.LocationID == shipItemID && isFittedSlot(...) }` block) into:
+```go
+// fittedItemsForShip collects the cargo.FittedItem list for a specific ship item_id
+// from an already-fetched asset list.
+func (s *FittingService) fittedItemsForShip(ctx context.Context, assets []esiAsset, shipItemID int64) []cargo.FittedItem {
+	items := make([]cargo.FittedItem, 0)
+	for _, asset := range assets {
+		if asset.LocationID == shipItemID && isFittedSlot(asset.LocationFlag) {
+			items = append(items, cargo.FittedItem{TypeID: int64(asset.TypeID), Slot: asset.LocationFlag})
+		}
+	}
+	return items
+}
+
+// EffectiveCargoForShipItem computes the effective cargo for ONE specific ship instance
+// (by item_id) using that ship's own fitted modules. Returns (effective, unavailable);
+// unavailable=true means the calc errored and the caller should fail loud.
+func (s *FittingService) EffectiveCargoForShipItem(
+	ctx context.Context, shipTypeID int, shipItemID int64, assets []esiAsset, charSkills *cargo.CharacterSkills,
+) (float64, bool) {
+	items := s.fittedItemsForShip(ctx, assets, shipItemID)
+	caps, err := cargo.GetShipCapacitiesDeterministic(ctx, s.sdeDB, int64(shipTypeID), charSkills, items)
+	if err != nil {
+		s.logger.Warn("effective cargo per-item calc failed", "shipTypeID", shipTypeID, "itemID", shipItemID, "error", err)
+		return 0, true
+	}
+	return caps.EffectiveCargoHold, false
+}
+```
+Then rewrite the relevant part of `fetchFittingFromESI` to call `s.fittedItemsForShip(ctx, assets, shipItemID)` instead of the inline loop (keep existing behaviour for the single-fitting path). Note `s.logger` may be nil in the test's bare struct — guard with `if s.logger != nil` inside `EffectiveCargoForShipItem`, or set a noop logger in the test. Prefer the nil guard.
+
+- [ ] **Step 4: Run the test, verify it passes.**
+
+Run: `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/services/ -run TestEffectiveCargoForShipItem_PerInstance -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+```bash
+PATH="$HOME/.local/bin:$PATH" git add backend/internal/services/fitting_service.go backend/internal/services/fitting_effective_cargo_test.go
+PATH="$HOME/.local/bin:$PATH" git commit -m "feat(backend): per-ship-item effective cargo computation"
+```
+
+---
+
+## Task 2: Custom ship names from ESI `/assets/names`
+
+**Files:**
+- Modify: `backend/internal/services/fitting_service.go` (add `FetchAssetNames`)
+- Modify: `backend/internal/models/trading.go` (add `Name` to `CharacterAssetShip`)
+- Test: `backend/internal/services/asset_names_test.go` (new)
+
+- [ ] **Step 1: Add the model field.** In `backend/internal/models/trading.go`, `CharacterAssetShip` struct, add after `TypeName`:
+```go
+	Name string `json:"name,omitempty"` // Custom ship name from ESI /assets/names; falls back to TypeName
+```
+
+- [ ] **Step 2: Write the failing test** for the names parser/fallback.
+
+`backend/internal/services/asset_names_test.go`:
+```go
+package services
+
+import "testing"
+
+func TestParseAssetNames_MapsAndFallsBack(t *testing.T) {
+	// ESI /assets/names returns [{item_id, name}]; "None" or empty means unnamed.
+	raw := []byte(`[{"item_id":111,"name":"Ix-ITE-1"},{"item_id":222,"name":"None"}]`)
+	names, err := parseAssetNames(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if names[111] != "Ix-ITE-1" {
+		t.Errorf("want Ix-ITE-1, got %q", names[111])
+	}
+	if _, ok := names[222]; ok {
+		t.Errorf(`"None" should be dropped so the caller falls back to the type name`)
+	}
+}
+```
+
+- [ ] **Step 3: Run it, verify it fails** (`parseAssetNames` undefined).
+
+Run: `GOWORK=off go test ./internal/services/ -run TestParseAssetNames -v`
+Expected: build error.
+
+- [ ] **Step 4: Implement `parseAssetNames` + `FetchAssetNames`** in `fitting_service.go` (model the HTTP call on `fetchESIAssets`, but POST the item_ids):
+```go
+func parseAssetNames(body []byte) (map[int64]string, error) {
+	var rows []struct {
+		ItemID int64  `json:"item_id"`
+		Name   string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &rows); err != nil {
+		return nil, fmt.Errorf("decode asset names: %w", err)
+	}
+	out := make(map[int64]string, len(rows))
+	for _, r := range rows {
+		if r.Name == "" || r.Name == "None" {
+			continue // unnamed -> caller falls back to type name
+		}
+		out[r.ItemID] = r.Name
+	}
+	return out, nil
+}
+
+// FetchAssetNames resolves custom names for the given item_ids (best-effort: on error
+// returns an empty map so labels fall back to the type name — never blocks the list).
+func (s *FittingService) FetchAssetNames(ctx context.Context, characterID int, itemIDs []int64, accessToken string) map[int64]string {
+	if len(itemIDs) == 0 {
+		return map[int64]string{}
+	}
+	bodyBytes, _ := json.Marshal(itemIDs) // ESI accepts up to 1000 ids
+	endpoint := fmt.Sprintf("/latest/characters/%d/assets/names/", characterID)
+	req, err := http.NewRequestWithContext(ctx, "POST", esiconfig.BaseURL+endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		s.logger.Warn("asset names: build request failed", "error", err)
+		return map[int64]string{}
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.esiClient.Do(req)
+	if err != nil {
+		s.logger.Warn("asset names: esi request failed", "error", err)
+		return map[int64]string{}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		s.logger.Warn("asset names: non-200", "status", resp.StatusCode)
+		return map[int64]string{}
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	names, err := parseAssetNames(raw)
+	if err != nil {
+		s.logger.Warn("asset names: parse failed", "error", err)
+		return map[int64]string{}
+	}
+	return names
+}
+```
+Add `"bytes"` to the imports if missing.
+
+- [ ] **Step 5: Run the test, verify it passes.**
+
+Run: `GOWORK=off go test ./internal/services/ -run TestParseAssetNames -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+```bash
+PATH="$HOME/.local/bin:$PATH" git add backend/internal/services/fitting_service.go backend/internal/services/asset_names_test.go backend/internal/models/trading.go
+PATH="$HOME/.local/bin:$PATH" git commit -m "feat(backend): fetch custom ship names from ESI assets/names"
+```
+
+---
+
+## Task 3: Wire per-instance enrichment + names into `/character/ships`
+
+Replace the per-type enrichment with: fetch assets + skills once, enrich each ship by its item_id, attach names.
+
+**Files:**
+- Modify: `backend/internal/handlers/trading.go` (`enrichShipsWithEffectiveCargo` → per-item; attach names)
+- Test: `backend/internal/handlers/trading_ships_instance_test.go` (new, if a handler-level seam exists; otherwise assert via the fitting-service seam already covered in Task 1 and keep this task as the wiring change validated by `go build` + existing handler tests)
+
+- [ ] **Step 1:** Read `enrichShipsWithEffectiveCargo` (~`trading.go:678`). It currently loops ships and calls `GetShipFitting(ctx, characterID, int(ships[idx].TypeID), accessToken)`. Rewrite it to:
+  1. Fetch assets once via the fitting service (expose `FetchESIAssetsPublic` or reuse an existing accessor; if `fetchESIAssets` is unexported, add an exported `FetchAssetsForCharacter(ctx, characterID, token) ([]esiAsset, error)` wrapper in `fitting_service.go`).
+  2. Fetch character skills once (the service already has a skills path used inside `GetShipFitting`; expose it similarly or reuse `skillsService.GetCharacterSkills`).
+  3. For each ship: `eff, unavail := h.fittingService.EffectiveCargoForShipItem(ctx, int(ships[idx].TypeID), ships[idx].ItemID, assets, charSkills)`; set `ships[idx].EffectiveCargoCapacity = eff` (only when `eff > 0`) and `ships[idx].EffectiveCargoUnavailable = unavail`.
+  4. Collect ship item_ids, call `names := h.fittingService.FetchAssetNames(ctx, characterID, itemIDs, accessToken)`, and set `ships[idx].Name = names[ships[idx].ItemID]` falling back to `ships[idx].TypeName` when absent.
+
+  Concrete loop body:
+```go
+itemIDs := make([]int64, 0, len(ships))
+for i := range ships {
+	itemIDs = append(itemIDs, ships[i].ItemID)
+}
+names := h.fittingService.FetchAssetNames(ctx, characterID, itemIDs, accessToken)
+for i := range ships {
+	if !ships[i].IsSingleton {
+		continue
+	}
+	eff, unavail := h.fittingService.EffectiveCargoForShipItem(ctx, int(ships[i].TypeID), ships[i].ItemID, assets, charSkills)
+	if eff > 0 {
+		ships[i].EffectiveCargoCapacity = eff
+	}
+	ships[i].EffectiveCargoUnavailable = unavail
+	if n := names[ships[i].ItemID]; n != "" {
+		ships[i].Name = n
+	} else {
+		ships[i].Name = ships[i].TypeName
+	}
+}
+```
+
+- [ ] **Step 2: Build + run existing handler/service tests.**
+
+Run: `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go build ./... && GOWORK=off go test ./internal/...`
+Expected: builds; existing tests pass (update any test that asserted the old per-type enrichment signature).
+
+- [ ] **Step 3: Commit.**
+```bash
+PATH="$HOME/.local/bin:$PATH" git add backend/internal/handlers/trading.go backend/internal/services/fitting_service.go
+PATH="$HOME/.local/bin:$PATH" git commit -m "feat(backend): enrich character ships per-instance with names + own fitting"
+```
+
+---
+
+## Task 4: Optimizer uses the selected instance's cargo override
+
+**Files:**
+- Modify: `backend/internal/models/portfolio.go` (add `CargoCapacity`)
+- Modify: `backend/internal/services/portfolio_service.go:35` (pass it through)
+- Test: `backend/internal/services/portfolio_cargo_override_test.go` (new) — assert the request built for the route calc carries the override. If `Optimize` has no seam to inspect the route request, assert behaviourally: with a tiny `CargoCapacity`, `upt = CargoCapacity/UnitVolume` shrinks units (existing `cargoCapacity` flows into `OptimizeParams.CargoCapacity`).
+
+- [ ] **Step 1:** Add to `PortfolioRequest` (`portfolio.go`):
+```go
+	CargoCapacity   float64  `json:"cargo_capacity,omitempty"` // Optional: selected ship instance's effective cargo (m³). When >0, overrides the per-type fitting recompute.
+```
+
+- [ ] **Step 2:** In `portfolio_service.go` where it builds the `RouteCalculationRequest` (line ~35), add `CargoCapacity: req.CargoCapacity,`.
+
+- [ ] **Step 3: Write a failing test** proving the override reaches the route calc. Simplest reliable seam: a unit test on `Optimize` with a mocked routes service capturing the request; if such a mock exists in `portfolio_service_test.go`, assert `captured.CargoCapacity == req.CargoCapacity`. Otherwise add the assertion to an existing `Optimize` test that already mocks routes.
+
+- [ ] **Step 4: Run, implement, run** — Expected: PASS.
+
+Run: `GOWORK=off go test ./internal/services/ -run Portfolio -v`
+
+- [ ] **Step 5: Commit.**
+```bash
+PATH="$HOME/.local/bin:$PATH" git add backend/internal/models/portfolio.go backend/internal/services/portfolio_service.go backend/internal/services/portfolio_cargo_override_test.go
+PATH="$HOME/.local/bin:$PATH" git commit -m "feat(backend): portfolio optimize honours cargo_capacity override"
+```
+
+---
+
+## Task 5: Frontend types + api-client carry item_id and name
+
+**Files:**
+- Modify: `frontend/src/types/trading.ts` (`Ship`)
+- Modify: `frontend/src/lib/api-client.ts` (`BackendShipsResponse`, mapping)
+- Test: `frontend/tests/lib/api-client-instances.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test.**
+
+`frontend/tests/lib/api-client-instances.test.ts`:
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { fetchCharacterShips } from "@/lib/api-client";
+
+afterEach(() => vi.restoreAllMocks());
+
+it("carries item_id and name per instance", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({ ships: [
+      { item_id: 111, type_id: 657, type_name: "Iteron Mark V", name: "Ix-ITE-1", cargo_capacity: 5800, effective_cargo_capacity: 6090 },
+      { item_id: 222, type_id: 657, type_name: "Iteron Mark V", name: "Ix-ITE-2", cargo_capacity: 5800, effective_cargo_capacity: 4900 },
+    ], count: 2 }), { status: 200, headers: { "Content-Type": "application/json" } }),
+  );
+  const ships = await fetchCharacterShips();
+  expect(ships.map(s => s.item_id)).toEqual([111, 222]);
+  expect(ships[0].name).toBe("Ix-ITE-1");
+  expect(ships[1].effective_cargo_capacity).toBe(4900);
+});
+```
+
+- [ ] **Step 2: Run, verify it fails** (`item_id`/`name` not mapped).
+
+Run: `cd frontend && npx vitest run tests/lib/api-client-instances.test.ts`
+
+- [ ] **Step 3: Implement.** `types/trading.ts` `Ship`: add `item_id: number;` and `name: string;` (keep `name` as the display name — note `Ship.name` already exists as the ship/type name; reuse it for the instance name and add `item_id`). In `api-client.ts` `BackendShipsResponse.ships[]` add `item_id: number; name?: string;`, and in the map set `item_id: ship.item_id` and `name: ship.name ?? ship.type_name`.
+
+- [ ] **Step 4: Run, verify it passes.**
+
+- [ ] **Step 5: Commit.**
+```bash
+PATH="$HOME/.local/bin:$PATH" git add frontend/src/types/trading.ts frontend/src/lib/api-client.ts frontend/tests/lib/api-client-instances.test.ts
+PATH="$HOME/.local/bin:$PATH" git commit -m "feat(frontend): carry ship item_id + instance name through api-client"
+```
+
+---
+
+## Task 6: ShipSelect lists instances (dedupe by item_id)
+
+**Files:**
+- Modify: `frontend/src/components/trading/ShipSelect.tsx`
+- Modify: `frontend/src/lib/mock-data/ships.ts` (fallback ships need `item_id` = `type_id` and `name`)
+- Test: `frontend/tests/components/ShipSelect.test.tsx` (new)
+
+- [ ] **Step 1: Write the failing test** — two same-type instances both appear, labelled by name+cargo, option value = item_id.
+```tsx
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { ShipSelect } from "@/components/trading/ShipSelect";
+import { vi } from "vitest";
+
+vi.mock("@/lib/api-client", () => ({
+  fetchCharacterShips: vi.fn().mockResolvedValue([
+    { item_id: 111, type_id: 657, name: "Ix-ITE-1", cargo_capacity: 5800, effective_cargo_capacity: 6090 },
+    { item_id: 222, type_id: 657, name: "Ix-ITE-2", cargo_capacity: 5800, effective_cargo_capacity: 4900 },
+  ]),
+  fetchCharacterShip: vi.fn().mockResolvedValue({}),
+}));
+
+it("renders one option per instance, not per type", async () => {
+  render(<ShipSelect value="" onChange={() => {}} authenticated />);
+  expect(await screen.findByText(/Ix-ITE-1/)).toBeInTheDocument();
+  expect(await screen.findByText(/Ix-ITE-2/)).toBeInTheDocument();
+});
+```
+> Match the existing component-test render pattern (Radix Select renders options in a portal; if `findByText` can't see closed-select content, assert via the open state or by querying the items the existing tests use — mirror `tests/components/trading/ShipFittingCard.test.tsx` style).
+
+- [ ] **Step 2: Run, verify it fails** (dedupe-by-type collapses the two).
+
+- [ ] **Step 3: Implement.** In `ShipSelect.tsx`:
+  - Change the dedupe `Set<number>` from `type_id` to `item_id` (`seen.add(s.item_id)`, `seen.has(s.item_id)`; active ship deduped by `item_id`).
+  - Option `key`/`value` = `ship.item_id.toString()`.
+  - Label = `${ship.name} (${cargoDisplay})` (cargoDisplay from the existing effective/unavailable/Basis logic).
+  - The active ship object built from `fetchCharacterShip` must include `item_id` (use `active.ship_item_id`) and `name` (`active.ship_type_name || active.ship_name`).
+  - `onChange` still emits the option value (now item_id). The parent maps item_id→{type_id, effective} (Task 7).
+
+- [ ] **Step 4: Run, verify it passes** + full FE suite (`npx vitest run`).
+
+- [ ] **Step 5: Commit.**
+```bash
+PATH="$HOME/.local/bin:$PATH" git add frontend/src/components/trading/ShipSelect.tsx frontend/src/lib/mock-data/ships.ts frontend/tests/components/ShipSelect.test.tsx
+PATH="$HOME/.local/bin:$PATH" git commit -m "feat(frontend): list ship instances per item_id with name+cargo"
+```
+
+---
+
+## Task 7: ROI page sends the selected instance's cargo override
+
+**Files:**
+- Modify: `frontend/src/types/trading.ts` (`PortfolioRequest` add `cargo_capacity?`)
+- Modify: `frontend/src/app/roi-calculator/page.tsx` (`buildRequest` + selection mapping)
+- Modify: `frontend/src/components/trading/PortfolioInputForm.tsx` (ShipSelect value/onChange now item_id; expose selected ship object up if needed)
+- Test: covered by an updated ROI integration test if present; otherwise a unit test on `buildRequest`.
+
+- [ ] **Step 1:** Add `cargo_capacity?: number;` to the FE `PortfolioRequest` interface.
+
+- [ ] **Step 2:** The ROI page must know the selected ship's effective cargo + type_id from the chosen item_id. Lift the ships list (or a `Map<item_id, Ship>`) to the page, or have `ShipSelect` call `onChange(itemId, ship)` with the full ship. Simplest: `ShipSelect` accepts an `onSelect?(ship: Ship)` and the page stores the selected `Ship`. `buildRequest` then uses:
+```ts
+ship_type_id: selectedShip ? selectedShip.type_id : parseInt(form.ship, 10),
+cargo_capacity:
+  selectedShip?.effective_cargo_capacity != null && selectedShip.effective_cargo_capacity > 0
+    ? selectedShip.effective_cargo_capacity
+    : undefined,
+```
+> When `effective_cargo_unavailable` is set, leave `cargo_capacity` undefined so the backend recomputes (and the UI already shows the "fitted unbekannt" marker).
+
+- [ ] **Step 3: Write/extend the failing test** for `buildRequest` (export it or test via the page) asserting `cargo_capacity` equals the selected instance's effective cargo, and is omitted when unavailable.
+
+- [ ] **Step 4: Run, implement, run** — FE suite green.
+
+- [ ] **Step 5: Commit.**
+```bash
+PATH="$HOME/.local/bin:$PATH" git add frontend/src/types/trading.ts frontend/src/app/roi-calculator/page.tsx frontend/src/components/trading/PortfolioInputForm.tsx frontend/tests/...
+PATH="$HOME/.local/bin:$PATH" git commit -m "feat(frontend): ROI sends selected instance cargo as override"
+```
+
+---
+
+## Task 8: Full verification + PR
+
+- [ ] **Step 1: Backend gates.**
+
+Run: `cd backend && gofmt -l internal pkg && GOWORK=off go vet ./... && GOWORK=off golangci-lint run ./... && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./...`
+Expected: gofmt empty, vet clean, golangci 0 issues, tests pass.
+
+- [ ] **Step 2: Frontend gates.**
+
+Run: `cd frontend && npx vitest run && npx eslint <changed files> && rm -rf .next && npm run build`
+Expected: tests pass, eslint clean, build OK.
+
+- [ ] **Step 3: Push + PR.**
+```bash
+git push -u origin feat/instance-accurate-ship-dropdown
+gh pr create -R Sternrassler/eve-o-provit --base main --title "feat: instance-accurate ship dropdown (#147 follow-up)" --body-file <pr body>
+```
+
+- [ ] **Step 4: After CI green + merge — release** (separate, gated): CHANGELOG entry, `make release VERSION=0.18.0`, tag → prod deploy + smoke-test, then on-prod E2E (the Iteron instances now show their own correct cargo).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** per-instance enrichment (Task 1, 3), custom names (Task 2, 3), item_id dedupe + labels (Task 5, 6), optimizer override (Task 4, 7), fail-loud unavailable (Task 1 returns unavailable; Task 3 sets it; Task 7 omits override when unavailable). All covered.
+- **Open verification during execution:** confirm the Reinforced Bulkhead type id used in Task 1's test actually carries dogma attr 149 in the local SDE; confirm `FittingService` field names (`sdeDB`, `esiClient`, `logger`, `skillsService`) and the skills-fetch accessor for Task 3; confirm the routes-service mock seam for Task 4. These are lookups, not design changes.

--- a/docs/superpowers/specs/2026-05-31-instance-accurate-ship-dropdown-design.md
+++ b/docs/superpowers/specs/2026-05-31-instance-accurate-ship-dropdown-design.md
@@ -1,0 +1,122 @@
+# Instance-accurate ship dropdown — Design
+
+**Date:** 2026-05-31
+**Status:** Approved (design)
+
+## Problem
+
+The ROI ship dropdown is **type-level**: it deduplicates owned ships by `type_id`, and
+the effective cargo for a type is computed from the **first** singleton instance of
+that type found in the character's assets:
+
+```go
+// internal/services/fitting_service.go — fetchFittingFromESI
+for _, asset := range assets {
+    if asset.TypeID == shipTypeID && asset.IsSingleton {
+        shipItemID = asset.ItemID
+        break // ← first instance of the type wins
+    }
+}
+```
+
+A character owning two ships of the same type, fitted differently, sees an **arbitrary**
+instance's effective cargo. A cargo-reducing module on that instance (e.g. Reinforced
+Bulkheads, dogma attr 149 < 1) yields an effective value **below the base hull** — observed
+live: an Iteron Mark V shown as **4.9k m³** while the inspected (empty) hull is **6.09k m³**.
+
+The deterministic cargo calculation itself is **correct** (verified against the local SDE:
+Iteron 657 with Gallente Industrial L1 → exactly 6090 m³). The fault is purely the
+arbitrary instance selection feeding the type-level display + optimizer.
+
+## Goal
+
+List each owned ship **instance** individually (no type dedupe), each with its own custom
+ship name and the correct effective cargo of **its** fitting. Selecting an instance feeds
+that instance's exact cargo into the ROI optimizer.
+
+## Architecture
+
+### Backend (`backend/`)
+
+1. **Per-instance enrichment.** `enrichShipsWithEffectiveCargo` currently calls
+   `GetShipFitting(characterID, shipTypeID)` per ship, which resolves the first instance of
+   the type. Replace with an **item-scoped** computation: an instance-aware variant of
+   `fetchFittingFromESI` that takes the concrete `shipItemID` and aggregates the modules of
+   **that** ship (`asset.LocationID == shipItemID && isFittedSlot(...)`). Each
+   `CharacterAssetShip` gets the effective cargo of its own fitting. The existing
+   `effective_cargo_unavailable` flag stays per-instance (set on a fitting fetch error).
+
+2. **Custom ship names.** One batch ESI call `POST /characters/{id}/assets/names` with the
+   ship item_ids; attach `name` to each `CharacterAssetShip`
+   (`Name string json:"name,omitempty"`). Fallback to the type name when a ship is unnamed
+   or the names call fails (fail-soft for labels — never blocks the list; logged).
+
+3. `/character/ships` already builds one `CharacterAssetShip` per ship asset, so it is
+   already per-instance — the change is making the effective cargo + name per-instance too.
+
+### Frontend (`frontend/`)
+
+4. `Ship` type gains `item_id: number` and `name: string`. `fetchCharacterShips` maps them
+   through.
+
+5. `ShipSelect` deduplicates by **`item_id`** instead of `type_id`. Each option:
+   - label: `name (effective cargo)` — fitted value, or `Basis X` / `Basis X — fitted unbekannt`
+     using the existing per-instance logic;
+   - value: `item_id` (unique).
+   The active/flown ship is merged + deduplicated by `item_id`.
+
+6. ROI page: on submit, pass the **selected instance's** effective cargo as `cargo_capacity`
+   plus its `ship_type_id`. (Selection maps option `item_id` → `{type_id, effective_cargo}`.)
+
+### Optimizer wiring
+
+7. `RouteCalculationRequest.CargoCapacity` already overrides the per-type recompute
+   (`route_service.go:147`: when non-zero, used directly). Add a `cargo_capacity` field to
+   the ROI/portfolio request and have `PortfolioService.Optimize` pass it into
+   `RouteCalculationRequest.CargoCapacity`. Result: the optimizer uses the selected
+   instance's exact cargo and never recomputes per-type → the root cause is gone end-to-end.
+
+## Data flow
+
+```
+ESI assets ──► /character/ships ──► per-instance {item_id, type_id, name,
+                                     effective_cargo_capacity, effective_cargo_unavailable}
+   (assets/names enriches `name`; per-item fitting enriches effective cargo)
+        │
+        ▼
+ShipSelect (one option per item_id, label name+cargo, value item_id)
+        │  user picks an instance
+        ▼
+ROI submit ──► optimize { ship_type_id, cargo_capacity: <instance effective> }
+        │
+        ▼
+PortfolioService.Optimize ──► RouteCalculationRequest.CargoCapacity (override)
+        │
+        ▼
+route_service.Calculate uses cargoCapacity directly (no per-type fitting recompute)
+```
+
+## Error handling (fail-loud, per project principle)
+
+- Per-instance fitting fetch error → that instance's `effective_cargo_unavailable=true` →
+  UI shows `Basis X — fitted unbekannt` (visible, not silent).
+- `/assets/names` failure → fall back to the type name for labels; log; do **not** block
+  the ship list.
+- Malformed `/character/ships` response on the client still throws (existing fail-loud
+  array validation).
+
+## Testing
+
+- **Backend:** two same-type ships with different fittings produce **different** effective
+  cargo (the regression for the Iteron case: empty instance → 6090; bulkhead instance → its
+  reduced value, attributed to its own ship). Names attachment + fallback when names call
+  fails. Optimizer uses the `cargo_capacity` override (no per-type recompute).
+- **Frontend:** `ShipSelect` lists instances without deduping by type; labels with
+  `name (cargo)`; selecting passes the correct `cargo_capacity`. `api-client` carries
+  `item_id`/`name`. Existing fail-loud tests stay green.
+
+## Scope / YAGNI
+
+- Only assembled (singleton) ships, as today; packaged ships excluded.
+- No change to ship-type-level features elsewhere (trading page, hauling) beyond what the
+  shared `Ship` type / `fetchCharacterShips` require to keep compiling.

--- a/frontend/src/app/roi-calculator/page.tsx
+++ b/frontend/src/app/roi-calculator/page.tsx
@@ -19,7 +19,8 @@ import {
   fetchCharacterWallet,
   optimizePortfolio,
 } from "@/lib/api-client";
-import { PortfolioRequest } from "@/types/trading";
+import { PortfolioRequest, Ship } from "@/types/trading";
+import { buildPortfolioRequest } from "@/lib/portfolio-request";
 import { Loader2 } from "lucide-react";
 
 const DEFAULT_REGION = "10000002"; // The Forge
@@ -37,23 +38,6 @@ const defaultForm: PortfolioFormState = {
   allowNullSec: false,
 };
 
-function buildRequest(form: PortfolioFormState): PortfolioRequest {
-  const secZones: string[] = [];
-  if (form.allowHighSec) secZones.push("high");
-  if (form.allowLowSec) secZones.push("low");
-  if (form.allowNullSec) secZones.push("null");
-
-  return {
-    region_id: parseInt(form.region, 10),
-    ship_type_id: parseInt(form.ship, 10),
-    capital: form.capital,
-    time_budget_min: form.timeBudgetMin,
-    liquidity_cap_pct: form.liquidityCapPct,
-    max_item_pct: form.maxItemPct,
-    sec_zones: secZones,
-  };
-}
-
 function ROICalculatorContent() {
   const { isAuthenticated } = useAuth();
   const [form, setForm] = useState<PortfolioFormState>(defaultForm);
@@ -61,6 +45,9 @@ function ROICalculatorContent() {
   const [regionOverride, setRegionOverride] = useState<string | null>(null);
   const [shipOverride, setShipOverride] = useState<string | null>(null);
   const [capitalOverride, setCapitalOverride] = useState<number | null>(null);
+  // The ship instance currently picked in the dropdown (reported by ShipSelect).
+  // Its effective cargo is sent as the optimizer override.
+  const [selectedShip, setSelectedShip] = useState<Ship | null>(null);
 
   // Load the character's current location + ship + wallet to pre-fill the form.
   const { data: characterData } = useQuery({
@@ -101,9 +88,11 @@ function ROICalculatorContent() {
       regionOverride ??
       characterData?.location.region_id?.toString() ??
       DEFAULT_REGION,
+    // The dropdown value is a ship instance's item_id, so the prefill must be
+    // the active ship's item_id (not its type_id) to select the right option.
     ship:
       shipOverride ??
-      characterData?.ship.ship_type_id?.toString() ??
+      characterData?.ship.ship_item_id?.toString() ??
       DEFAULT_SHIP,
     capital:
       capitalOverride ??
@@ -128,7 +117,7 @@ function ROICalculatorContent() {
   });
 
   const handleSubmit = () => {
-    optimizeMutation.mutate(buildRequest(effectiveForm));
+    optimizeMutation.mutate(buildPortfolioRequest(effectiveForm, selectedShip));
   };
 
   const apiError = optimizeMutation.isError
@@ -179,6 +168,7 @@ function ROICalculatorContent() {
           disabled={!isAuthenticated || optimizeMutation.isPending}
           loading={optimizeMutation.isPending}
           authenticated={isAuthenticated}
+          onShipSelect={setSelectedShip}
         />
 
         {/* Results */}

--- a/frontend/src/components/trading/PortfolioInputForm.tsx
+++ b/frontend/src/components/trading/PortfolioInputForm.tsx
@@ -7,6 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2 } from "lucide-react";
+import { Ship } from "@/types/trading";
 
 export interface PortfolioFormState {
   region: string;
@@ -27,6 +28,9 @@ interface PortfolioInputFormProps {
   disabled?: boolean;
   loading?: boolean;
   authenticated?: boolean;
+  /** Forwarded to ShipSelect — reports the selected ship instance so the page
+   *  can send its effective cargo as the optimizer override. */
+  onShipSelect?: (ship: Ship | null) => void;
 }
 
 /**
@@ -41,6 +45,7 @@ export function PortfolioInputForm({
   disabled,
   loading,
   authenticated = false,
+  onShipSelect,
 }: PortfolioInputFormProps) {
   const update = <K extends keyof PortfolioFormState>(
     key: K,
@@ -68,6 +73,7 @@ export function PortfolioInputForm({
         onChange={(v) => update("ship", v)}
         disabled={disabled}
         authenticated={authenticated}
+        onSelect={onShipSelect}
       />
 
       <div className="space-y-2">

--- a/frontend/src/components/trading/ShipSelect.tsx
+++ b/frontend/src/components/trading/ShipSelect.tsx
@@ -66,6 +66,7 @@ export function ShipSelect({
         setShips(characterShips ?? []);
         if (active?.ship_type_id) {
           setActiveShip({
+            item_id: active.ship_item_id,
             type_id: active.ship_type_id,
             name: active.ship_type_name || active.ship_name,
             cargo_capacity: active.cargo_capacity,
@@ -89,12 +90,12 @@ export function ShipSelect({
   const seen = new Set<number>();
   if (activeShip) {
     options.push(activeShip);
-    seen.add(activeShip.type_id);
+    seen.add(activeShip.item_id);
   }
   for (const s of ships) {
-    if (!seen.has(s.type_id)) {
+    if (!seen.has(s.item_id)) {
       options.push(s);
-      seen.add(s.type_id);
+      seen.add(s.item_id);
     }
   }
 
@@ -126,7 +127,7 @@ export function ShipSelect({
                 : `Basis ${cargoFmt}`;
 
             return (
-              <SelectItem key={ship.type_id} value={ship.type_id.toString()}>
+              <SelectItem key={ship.item_id.toString()} value={ship.item_id.toString()}>
                 {ship.name} ({cargoDisplay})
               </SelectItem>
             );

--- a/frontend/src/components/trading/ShipSelect.tsx
+++ b/frontend/src/components/trading/ShipSelect.tsx
@@ -17,6 +17,10 @@ interface ShipSelectProps {
   onChange: (value: string) => void;
   disabled?: boolean;
   authenticated?: boolean;
+  /** Called with the resolved Ship whose item_id matches `value` (or null when
+   *  no option matches). Lets the parent read the selected instance's effective
+   *  cargo for the optimizer override. */
+  onSelect?: (ship: Ship | null) => void;
 }
 
 export function ShipSelect({
@@ -24,6 +28,7 @@ export function ShipSelect({
   onChange,
   disabled,
   authenticated = false,
+  onSelect,
 }: ShipSelectProps) {
   // Unauthenticated users get a generic example list (a legitimate default —
   // there is no character to load). Authenticated users get their real hangar;
@@ -98,6 +103,18 @@ export function ShipSelect({
       seen.add(s.item_id);
     }
   }
+
+  // Surface the currently selected instance to the parent. Keyed on `value` and
+  // the inputs that determine the option list (`ships` + `activeShip`), so the
+  // parent always has the up-to-date selection even as the hangar loads.
+  useEffect(() => {
+    if (!onSelect) return;
+    const selected =
+      options.find((s) => s.item_id.toString() === value) ?? null;
+    onSelect(selected);
+    // `options` is rebuilt every render; depend on its inputs instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, ships, activeShip, onSelect]);
 
   return (
     <div className="space-y-2">

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -28,8 +28,11 @@ interface BackendRegionsResponse {
 
 interface BackendShipsResponse {
   ships: Array<{
+    item_id: number;
     type_id: number;
     type_name: string;
+    /** Instance name (custom ship name set by pilot), absent on older responses. */
+    name?: string;
     cargo_capacity: number;
     effective_cargo_capacity?: number;
     // Set by the backend when fitting enrichment ERRORED (vs. a ship that
@@ -126,8 +129,9 @@ export async function fetchCharacterShips(): Promise<Ship[]> {
   // fitted volume (or a visible "unknown" marker) instead of falling back to
   // the base hull silently.
   return data.ships.map((ship) => ({
+    item_id: ship.item_id,
     type_id: ship.type_id,
-    name: ship.type_name,
+    name: ship.name ?? ship.type_name,
     cargo_capacity: ship.cargo_capacity,
     effective_cargo_capacity: ship.effective_cargo_capacity,
     effective_cargo_unavailable: ship.effective_cargo_unavailable,

--- a/frontend/src/lib/mock-data/ships.ts
+++ b/frontend/src/lib/mock-data/ships.ts
@@ -1,18 +1,18 @@
 import { Ship } from "@/types/trading";
 
 export const ships: Ship[] = [
-  { type_id: 648, name: "Badger", cargo_capacity: 15000 },
-  { type_id: 649, name: "Tayra", cargo_capacity: 18500 },
-  { type_id: 650, name: "Bestower", cargo_capacity: 19000 },
-  { type_id: 651, name: "Wreathe", cargo_capacity: 16500 },
-  { type_id: 652, name: "Iteron Mark V", cargo_capacity: 27500 },
-  { type_id: 653, name: "Mammoth", cargo_capacity: 19500 },
-  { type_id: 654, name: "Sigil", cargo_capacity: 18500 },
-  { type_id: 655, name: "Hoarder", cargo_capacity: 17500 },
+  { item_id: 648, type_id: 648, name: "Badger", cargo_capacity: 15000 },
+  { item_id: 649, type_id: 649, name: "Tayra", cargo_capacity: 18500 },
+  { item_id: 650, type_id: 650, name: "Bestower", cargo_capacity: 19000 },
+  { item_id: 651, type_id: 651, name: "Wreathe", cargo_capacity: 16500 },
+  { item_id: 652, type_id: 652, name: "Iteron Mark V", cargo_capacity: 27500 },
+  { item_id: 653, type_id: 653, name: "Mammoth", cargo_capacity: 19500 },
+  { item_id: 654, type_id: 654, name: "Sigil", cargo_capacity: 18500 },
+  { item_id: 655, type_id: 655, name: "Hoarder", cargo_capacity: 17500 },
 ];
 
 export const authenticatedShips: Ship[] = [
-  { type_id: 648, name: "Badger (Your Ship)", cargo_capacity: 15000 },
-  { type_id: 649, name: "Tayra (Your Ship)", cargo_capacity: 18500 },
-  { type_id: 652, name: "Iteron Mark V (Your Ship)", cargo_capacity: 27500 },
+  { item_id: 648, type_id: 648, name: "Badger (Your Ship)", cargo_capacity: 15000 },
+  { item_id: 649, type_id: 649, name: "Tayra (Your Ship)", cargo_capacity: 18500 },
+  { item_id: 652, type_id: 652, name: "Iteron Mark V (Your Ship)", cargo_capacity: 27500 },
 ];

--- a/frontend/src/lib/portfolio-request.ts
+++ b/frontend/src/lib/portfolio-request.ts
@@ -1,0 +1,46 @@
+import { PortfolioFormState } from "@/components/trading/PortfolioInputForm";
+import { PortfolioRequest, Ship } from "@/types/trading";
+
+/**
+ * Builds the optimizer request from the form state and the currently selected
+ * ship instance.
+ *
+ * The form's `ship` value is now a ship instance's `item_id` (string), not a
+ * type_id — so the type_id must come from `selectedShip.type_id`. When no ship
+ * is selected (e.g. the unauthenticated default), the fallback ships have
+ * `item_id === type_id`, so `parseInt(form.ship, 10)` still yields a valid
+ * type_id.
+ *
+ * When a ship instance is selected and its effective cargo is known (> 0 and
+ * not flagged unavailable), that value is passed as `cargo_capacity` so the
+ * optimizer uses the exact instance figure instead of a per-type recompute.
+ * Otherwise `cargo_capacity` is omitted and the backend falls back.
+ */
+export function buildPortfolioRequest(
+  form: PortfolioFormState,
+  selectedShip: Ship | null,
+): PortfolioRequest {
+  const secZones: string[] = [];
+  if (form.allowHighSec) secZones.push("high");
+  if (form.allowLowSec) secZones.push("low");
+  if (form.allowNullSec) secZones.push("null");
+
+  const cargoCapacity =
+    selectedShip &&
+    !selectedShip.effective_cargo_unavailable &&
+    selectedShip.effective_cargo_capacity != null &&
+    selectedShip.effective_cargo_capacity > 0
+      ? selectedShip.effective_cargo_capacity
+      : undefined;
+
+  return {
+    region_id: parseInt(form.region, 10),
+    ship_type_id: selectedShip ? selectedShip.type_id : parseInt(form.ship, 10),
+    capital: form.capital,
+    time_budget_min: form.timeBudgetMin,
+    liquidity_cap_pct: form.liquidityCapPct,
+    max_item_pct: form.maxItemPct,
+    sec_zones: secZones,
+    cargo_capacity: cargoCapacity,
+  };
+}

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -167,6 +167,11 @@ export interface PortfolioRequest {
   liquidity_cap_pct: number;
   max_item_pct: number;
   sec_zones: string[]; // e.g. ["high", "low", "null"]
+  /** Selected ship instance's effective cargo (m³). When set, the optimizer
+   *  uses this exact value instead of recomputing per ship type. Omitted when
+   *  the instance's effective cargo is unavailable/unknown (backend falls back
+   *  to the per-type recompute). */
+  cargo_capacity?: number;
 }
 
 export interface PortfolioItem {

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -83,6 +83,7 @@ export interface Region {
 }
 
 export interface Ship {
+  item_id: number;
   type_id: number;
   name: string;
   /** Base hull cargo (without skills/modules). */

--- a/frontend/tests/components/ShipSelect.test.tsx
+++ b/frontend/tests/components/ShipSelect.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ShipSelect } from "@/components/trading/ShipSelect";
+
+// Radix UI Select uses pointer-capture and scrollIntoView APIs that jsdom
+// doesn't implement, causing crashes when the dropdown is opened. Mock the
+// select primitives so we can test the data logic (dedupe by item_id) without
+// fighting jsdom's limitations. Each SelectItem renders its children as a
+// plain div, which lets us query by text content.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button>{children}</button>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder}</span>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="select-content">{children}</div>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => (
+    <div data-testid="select-item" data-value={value}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/api-client", () => ({
+  fetchCharacterShips: vi.fn().mockResolvedValue([
+    {
+      item_id: 111,
+      type_id: 657,
+      name: "Ix-ITE-1",
+      cargo_capacity: 5800,
+      effective_cargo_capacity: 6090,
+    },
+    {
+      item_id: 222,
+      type_id: 657,
+      name: "Ix-ITE-2",
+      cargo_capacity: 5800,
+      effective_cargo_capacity: 4900,
+    },
+  ]),
+  fetchCharacterShip: vi.fn().mockResolvedValue({}),
+}));
+
+describe("ShipSelect", () => {
+  it("renders one option per instance, not per type", async () => {
+    render(<ShipSelect value="" onChange={() => {}} authenticated />);
+
+    // Wait for ships to load and options to render
+    await waitFor(() => {
+      expect(screen.getAllByTestId("select-item").length).toBe(2);
+    });
+
+    // Both named instances of the same type_id must appear
+    expect(screen.getByText(/Ix-ITE-1/)).toBeTruthy();
+    expect(screen.getByText(/Ix-ITE-2/)).toBeTruthy();
+  });
+
+  it("uses item_id as option value (not type_id)", async () => {
+    render(<ShipSelect value="" onChange={() => {}} authenticated />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("select-item").length).toBe(2);
+    });
+
+    const items = screen.getAllByTestId("select-item");
+    const values = items.map((el) => el.getAttribute("data-value"));
+    // item_ids are 111 and 222, NOT the shared type_id 657
+    expect(values).toContain("111");
+    expect(values).toContain("222");
+    expect(values).not.toContain("657");
+  });
+
+  it("would collapse to one option if deduplicated by type_id (sanity check)", async () => {
+    // This test documents WHY the fix matters: two ships with the same type_id
+    // but different item_ids must both appear. If we deduped by type_id only
+    // ONE would show — this test ensures both do.
+    render(<ShipSelect value="" onChange={() => {}} authenticated />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("select-item").length).toBe(2);
+    });
+
+    // Two distinct items rendered — proves item_id dedupe (not type_id dedupe)
+    const items = screen.getAllByTestId("select-item");
+    expect(items).toHaveLength(2);
+  });
+});

--- a/frontend/tests/lib/api-client-instances.test.ts
+++ b/frontend/tests/lib/api-client-instances.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { fetchCharacterShips } from "@/lib/api-client";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("fetchCharacterShips instances", () => {
+  it("carries item_id and name per instance", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ships: [
+        { item_id: 111, type_id: 657, type_name: "Iteron Mark V", name: "Ix-ITE-1", cargo_capacity: 5800, effective_cargo_capacity: 6090 },
+        { item_id: 222, type_id: 657, type_name: "Iteron Mark V", name: "Ix-ITE-2", cargo_capacity: 5800, effective_cargo_capacity: 4900 },
+      ], count: 2 }), { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+    const ships = await fetchCharacterShips();
+    expect(ships.map(s => s.item_id)).toEqual([111, 222]);
+    expect(ships[0].name).toBe("Ix-ITE-1");
+    expect(ships[1].effective_cargo_capacity).toBe(4900);
+  });
+
+  it("falls back to type_name when name is absent", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ships: [
+        { item_id: 333, type_id: 650, type_name: "Nereus", cargo_capacity: 2700 },
+      ], count: 1 }), { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+    const ships = await fetchCharacterShips();
+    expect(ships[0].name).toBe("Nereus");
+  });
+});

--- a/frontend/tests/lib/portfolio-request.test.ts
+++ b/frontend/tests/lib/portfolio-request.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { buildPortfolioRequest } from "@/lib/portfolio-request";
+import { PortfolioFormState } from "@/components/trading/PortfolioInputForm";
+import { Ship } from "@/types/trading";
+
+const baseForm: PortfolioFormState = {
+  region: "10000002",
+  ship: "111", // item_id of the selected instance (NOT a type_id)
+  capital: 500_000_000,
+  timeBudgetMin: 120,
+  liquidityCapPct: 10,
+  maxItemPct: 30,
+  allowHighSec: true,
+  allowLowSec: false,
+  allowNullSec: false,
+};
+
+describe("buildPortfolioRequest", () => {
+  it("sends the selected instance's effective cargo as cargo_capacity and its type_id", () => {
+    const ship: Ship = {
+      item_id: 111,
+      type_id: 657,
+      name: "Ix-ITE-1",
+      cargo_capacity: 5800,
+      effective_cargo_capacity: 6090,
+    };
+
+    const req = buildPortfolioRequest(baseForm, ship);
+
+    expect(req.cargo_capacity).toBe(6090);
+    // type_id must come from the selected ship, not from parseInt(form.ship)
+    expect(req.ship_type_id).toBe(657);
+  });
+
+  it("omits cargo_capacity when the instance's effective cargo is unavailable", () => {
+    const ship: Ship = {
+      item_id: 111,
+      type_id: 657,
+      name: "Ix-ITE-1",
+      cargo_capacity: 5800,
+      effective_cargo_unavailable: true,
+    };
+
+    const req = buildPortfolioRequest(baseForm, ship);
+
+    expect(req.cargo_capacity).toBeUndefined();
+    expect(req.ship_type_id).toBe(657);
+  });
+
+  it("omits cargo_capacity and derives ship_type_id from form.ship when no ship is selected", () => {
+    const form: PortfolioFormState = { ...baseForm, ship: "649" };
+
+    const req = buildPortfolioRequest(form, null);
+
+    expect(req.cargo_capacity).toBeUndefined();
+    // Fallback ships have item_id === type_id, so parseInt is valid here.
+    expect(req.ship_type_id).toBe(649);
+  });
+
+  it("maps security-zone flags to sec_zones", () => {
+    const form: PortfolioFormState = {
+      ...baseForm,
+      allowHighSec: true,
+      allowLowSec: true,
+      allowNullSec: false,
+    };
+
+    const req = buildPortfolioRequest(form, null);
+
+    expect(req.sec_zones).toEqual(["high", "low"]);
+  });
+});


### PR DESCRIPTION
Makes the ROI ship dropdown **instance-accurate**, fixing the cargo discrepancy reported live (Iteron Mark V shown 4.9k m³ vs in-game 6.09k).

## Root cause
The dropdown was type-level: effective cargo for a type was computed from the **first** singleton instance of that type in assets (`fetchFittingFromESI` break-on-first). A character with two same-type ships fitted differently saw an arbitrary one's cargo; a cargo-reducing module (Reinforced Bulkheads, dogma attr 149 < 1) produced an effective value **below base**. The deterministic cargo calc itself was verified correct (Iteron 657 + Gallente Industrial L1 → exactly 6090 against the local SDE).

## What changed
**Backend**
- Each `CharacterAssetShip` is enriched **per item_id** (its own fitted modules) via `EnrichShipsEffectiveCargo` → `EffectiveCargoForShipItem` → `fittedItemsForShip` (assets + skills fetched once; old per-ship ESI fan-out removed).
- Custom ship names from ESI `POST /characters/{id}/assets/names` (batched to the 1000-id limit), with fallback to the type name (fail-soft, never blocks the list).
- The **active/flown ship** (the ROI default) is now instance-accurate too (`EffectiveCargoForActiveShip` by item_id) — review follow-up.
- `PortfolioRequest.cargo_capacity` override is wired into `RouteCalculationRequest.CargoCapacity`, so the optimizer uses the selected instance's exact cargo instead of recomputing per-type.

**Frontend**
- `Ship` carries `item_id` + instance `name`. `ShipSelect` dedupes by **item_id** (not type_id); each option `name (cargo)`, value = item_id.
- ROI page sends the selected instance's `effective_cargo_capacity` as `cargo_capacity` (omitted when `effective_cargo_unavailable` or 0 → backend falls back). Prefill defaults to the active ship's item_id.

## Fail-loud preserved
Per-instance fitting error → `effective_cargo_unavailable=true` → "fitted unbekannt" (visible). Names/assets failures fall back softly + log; never present wrong data as correct.

## Verification
- Backend: gofmt clean, `go vet` clean, **golangci-lint 0 issues**, all tests pass (per-instance divergence proven: empty Iteron → ~6090; same hull + Reinforced Bulkhead → lower).
- Frontend: **75/75** tests, ESLint 0 warnings, production build OK.
- Final adversarial code review (subagent): APPROVE_WITH_NITS; the one Important finding (active-ship path) was fixed in this branch.

Spec + plan: `docs/superpowers/specs/2026-05-31-instance-accurate-ship-dropdown-design.md`, `docs/superpowers/plans/2026-05-31-instance-accurate-ship-dropdown.md`.

Remaining nits (non-blocking, noted in review): `/character/ships` fetches assets twice (ESI-cache-mitigated); ESI base-URL inconsistency (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
