### PR TITLE
feat: mining ore sell-vs-refine ranking (web + Flutter)

### DIFF
--- a/app/lib/api/mining_models.dart
+++ b/app/lib/api/mining_models.dart
@@ -1,0 +1,151 @@
+/// Mining Ore-Ranking DTOs — field names map exactly to the backend
+/// json tags for POST /api/v1/mining/ore-ranking.
+///
+/// CRITICAL: parsing is null/float-robust (mirrors hauling_models.dart /
+/// hub_comparison_models.dart). Every numeric field tolerates absent/null
+/// values and accepts any [num] (int or double).
+library;
+
+// ---------------------------------------------------------------------------
+// OreRankingRequest
+// ---------------------------------------------------------------------------
+
+/// Request body for POST /api/v1/mining/ore-ranking.
+///
+/// Mirrors the backend request struct exactly (snake_case json tags).
+/// [regionId] of 0 ⇒ the backend uses the character's current region.
+class OreRankingRequest {
+  const OreRankingRequest({
+    required this.regionId,
+    required this.secBand,
+  });
+
+  /// Backend: `region_id` — 0 means "use the character's current region".
+  final int regionId;
+
+  /// Backend: `sec_band` — "high" | "low" | "null".
+  final String secBand;
+
+  Map<String, dynamic> toJson() => {
+        'region_id': regionId,
+        'sec_band': secBand,
+      };
+}
+
+// ---------------------------------------------------------------------------
+// OreRankRow
+// ---------------------------------------------------------------------------
+
+/// A single ore type in the ranking result.
+/// Backend: an element of the `rows` array.
+class OreRankRow {
+  const OreRankRow({
+    required this.oreTypeId,
+    required this.oreName,
+    required this.miningM3PerHour,
+    required this.rawIskPerHour,
+    required this.refineIskPerHour,
+    required this.rawNetPerM3,
+    required this.refineNetPerM3,
+    required this.best,
+    required this.deltaIskPerHour,
+    required this.bestStationTax,
+    this.bestStationId,
+  });
+
+  /// Backend: `ore_type_id`
+  final int oreTypeId;
+
+  /// Backend: `ore_name`
+  final String oreName;
+
+  /// Backend: `mining_m3_per_hour`
+  final double miningM3PerHour;
+
+  /// Backend: `raw_isk_per_hour`
+  final double rawIskPerHour;
+
+  /// Backend: `refine_isk_per_hour`
+  final double refineIskPerHour;
+
+  /// Backend: `raw_net_per_m3`
+  final double rawNetPerM3;
+
+  /// Backend: `refine_net_per_m3`
+  final double refineNetPerM3;
+
+  /// Backend: `best` — "raw" | "refine"
+  final String best;
+
+  /// Backend: `delta_isk_per_hour` — difference between best and alternative.
+  final double deltaIskPerHour;
+
+  /// Backend: `best_station_id` — nullable (int?).
+  final int? bestStationId;
+
+  /// Backend: `best_station_tax`
+  final double bestStationTax;
+
+  factory OreRankRow.fromJson(Map<String, dynamic> json) {
+    return OreRankRow(
+      oreTypeId: (json['ore_type_id'] as num?)?.toInt() ?? 0,
+      oreName: json['ore_name'] as String? ?? '',
+      miningM3PerHour: (json['mining_m3_per_hour'] as num?)?.toDouble() ?? 0,
+      rawIskPerHour: (json['raw_isk_per_hour'] as num?)?.toDouble() ?? 0,
+      refineIskPerHour:
+          (json['refine_isk_per_hour'] as num?)?.toDouble() ?? 0,
+      rawNetPerM3: (json['raw_net_per_m3'] as num?)?.toDouble() ?? 0,
+      refineNetPerM3: (json['refine_net_per_m3'] as num?)?.toDouble() ?? 0,
+      best: json['best'] as String? ?? 'raw',
+      deltaIskPerHour: (json['delta_isk_per_hour'] as num?)?.toDouble() ?? 0,
+      bestStationId: (json['best_station_id'] as num?)?.toInt(),
+      bestStationTax: (json['best_station_tax'] as num?)?.toDouble() ?? 0,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OreRankingResponse
+// ---------------------------------------------------------------------------
+
+/// Response from POST /api/v1/mining/ore-ranking.
+///
+/// [rows] is pre-sorted by the backend (best_isk_per_hour desc). An empty
+/// [rows] list combined with [noMiningSetup] = true indicates the character
+/// has no mining lasers fitted; in that case the UI shows a visible notice.
+class OreRankingResponse {
+  const OreRankingResponse({
+    required this.regionId,
+    required this.secBand,
+    required this.noMiningSetup,
+    required this.rows,
+  });
+
+  /// Backend: `region_id`
+  final int regionId;
+
+  /// Backend: `sec_band`
+  final String secBand;
+
+  /// Backend: `no_mining_setup` — true when the character has no mining lasers.
+  final bool noMiningSetup;
+
+  /// Backend: `rows` — pre-sorted by best ISK/h desc.
+  final List<OreRankRow> rows;
+
+  /// True when the ranked rows list is empty.
+  bool get isEmpty => rows.isEmpty;
+
+  factory OreRankingResponse.fromJson(Map<String, dynamic> json) {
+    final rawRows = json['rows'] as List<dynamic>? ?? const [];
+    return OreRankingResponse(
+      regionId: (json['region_id'] as num?)?.toInt() ?? 0,
+      secBand: json['sec_band'] as String? ?? 'high',
+      noMiningSetup: json['no_mining_setup'] as bool? ?? false,
+      rows: rawRows
+          .whereType<Map<String, dynamic>>()
+          .map(OreRankRow.fromJson)
+          .toList(),
+    );
+  }
+}

--- a/app/lib/core/router.dart
+++ b/app/lib/core/router.dart
@@ -20,6 +20,7 @@ import 'package:go_router/go_router.dart';
 import '../auth/auth_controller.dart';
 import '../auth/login_screen.dart';
 import '../features/character/character_screen.dart';
+import '../features/mining/mining_screen.dart';
 import '../features/trading/hauling_screen.dart';
 import '../features/trading/hub_comparison_screen.dart';
 import '../features/trading/roi_calculator_screen.dart';
@@ -111,6 +112,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             builder: (context, state) => const SellAssetsScreen(),
           ),
           GoRoute(
+            path: '/mining',
+            builder: (context, state) => const MiningScreen(),
+          ),
+          GoRoute(
             path: '/character',
             builder: (context, state) => const CharacterScreen(),
           ),
@@ -155,6 +160,10 @@ class _AppShell extends ConsumerWidget {
       label: 'Verkaufen',
     ),
     NavigationDestination(
+      icon: Icon(Icons.diamond_rounded),
+      label: 'Mining',
+    ),
+    NavigationDestination(
       icon: Icon(Icons.person_outline_rounded),
       selectedIcon: Icon(Icons.person_rounded),
       label: 'Character',
@@ -170,7 +179,8 @@ class _AppShell extends ConsumerWidget {
     if (location.startsWith('/roi-calculator')) return 2;
     if (location.startsWith('/hauling')) return 3;
     if (location.startsWith('/sell-assets')) return 4;
-    if (location.startsWith('/character')) return 5;
+    if (location.startsWith('/mining')) return 5;
+    if (location.startsWith('/character')) return 6;
     return 0; // /trading is default; "Abmelden" is never a selected state
   }
 
@@ -193,8 +203,10 @@ class _AppShell extends ConsumerWidget {
             case 4:
               context.go('/sell-assets');
             case 5:
-              context.go('/character');
+              context.go('/mining');
             case 6:
+              context.go('/character');
+            case 7:
               _confirmLogout(context, ref);
           }
         },

--- a/app/lib/features/mining/mining_api.dart
+++ b/app/lib/features/mining/mining_api.dart
@@ -1,0 +1,27 @@
+/// Thin API client for the mining endpoints.
+///
+/// Follows the same pattern as [TradingApi]: takes the interceptor-equipped
+/// [Dio] and maps HTTP ↔ DTOs. Business logic lives in the Riverpod layer.
+library;
+
+import 'package:dio/dio.dart';
+
+import '../../api/mining_models.dart';
+
+class MiningApi {
+  MiningApi(this._dio);
+
+  final Dio _dio;
+
+  // ── POST /api/v1/mining/ore-ranking ────────────────────────────────────────
+
+  /// Returns ore types ranked by best ISK/hour for the given region + sec band.
+  /// An empty [rows] list with [noMiningSetup] = true means no mining lasers.
+  Future<OreRankingResponse> oreRanking(OreRankingRequest request) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/api/v1/mining/ore-ranking',
+      data: request.toJson(),
+    );
+    return OreRankingResponse.fromJson(response.data!);
+  }
+}

--- a/app/lib/features/mining/mining_providers.dart
+++ b/app/lib/features/mining/mining_providers.dart
@@ -1,0 +1,51 @@
+/// Riverpod providers for the Mining Ore-Ranking feature.
+///
+/// Provider graph (mirrors hauling_providers.dart / roi_providers.dart):
+///   dioProvider → miningApiProvider → oreRankingProvider (AsyncNotifier)
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/dio_client.dart';
+import '../../api/mining_models.dart';
+import 'mining_api.dart';
+
+// ---------------------------------------------------------------------------
+// MiningApi provider
+// ---------------------------------------------------------------------------
+
+/// Provides a [MiningApi] backed by the interceptor-equipped [Dio].
+final miningApiProvider = Provider<MiningApi>((ref) {
+  return MiningApi(ref.watch(dioProvider));
+});
+
+// ---------------------------------------------------------------------------
+// OreRankingNotifier — AsyncNotifier<OreRankingResponse?>
+// ---------------------------------------------------------------------------
+
+/// Owns the ore-ranking lifecycle.
+///
+/// [build] returns null — no ranking has been performed yet. Call [run] with
+/// an [OreRankingRequest] to trigger one; it sets [AsyncLoading] then guards
+/// the API call. An empty [rows] list on the resulting [OreRankingResponse]
+/// is a valid successful state (possibly with [noMiningSetup] = true) — it is
+/// NOT treated as an error.
+class OreRankingNotifier extends AsyncNotifier<OreRankingResponse?> {
+  @override
+  Future<OreRankingResponse?> build() async => null;
+
+  /// Runs an ore ranking for [request].
+  Future<void> run(OreRankingRequest request) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final api = ref.read(miningApiProvider);
+      return api.oreRanking(request);
+    });
+  }
+}
+
+/// Provider for [OreRankingNotifier].
+final oreRankingProvider =
+    AsyncNotifierProvider<OreRankingNotifier, OreRankingResponse?>(
+  OreRankingNotifier.new,
+);

--- a/app/lib/features/mining/mining_screen.dart
+++ b/app/lib/features/mining/mining_screen.dart
@@ -1,0 +1,454 @@
+/// Mining Ore-Ranking screen.
+///
+/// Shows ranked ore types for the character's current region + a selected
+/// sec band (High/Low/Null). The CurrentShipCard at the top reflects the
+/// active mining ship. Pressing "Erze berechnen" posts
+/// POST /api/v1/mining/ore-ranking with region_id=0 (current region).
+///
+/// Layout (via [isTwoPane] / [kTwoPaneBreakpoint] = 840 dp):
+///   • <840 dp  → single-pane: controls above the result table.
+///   • ≥840 dp  → two-pane: controls on the left, table on the right.
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../api/mining_models.dart';
+import '../../core/breakpoint.dart';
+import '../../core/format.dart';
+import '../trading/current_ship_card.dart';
+import 'mining_providers.dart';
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// The Mining Ore-Ranking screen.
+class MiningScreen extends ConsumerWidget {
+  const MiningScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mining'),
+        centerTitle: false,
+        elevation: 0,
+        scrolledUnderElevation: 1,
+      ),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final twoPane = isTwoPane(constraints.maxWidth);
+          if (twoPane) {
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: const [
+                SizedBox(
+                  width: 300,
+                  child: SingleChildScrollView(
+                    padding: EdgeInsets.all(16),
+                    child: _InputForm(),
+                  ),
+                ),
+                VerticalDivider(width: 1),
+                Expanded(child: _ResultPane()),
+              ],
+            );
+          }
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: const [
+              Flexible(
+                child: SingleChildScrollView(
+                  padding: EdgeInsets.all(16),
+                  child: _InputForm(),
+                ),
+              ),
+              Divider(height: 1),
+              Expanded(child: _ResultPane()),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input form — ship card + sec-band selector + calculate button
+// ---------------------------------------------------------------------------
+
+class _InputForm extends ConsumerStatefulWidget {
+  const _InputForm();
+
+  @override
+  ConsumerState<_InputForm> createState() => _InputFormState();
+}
+
+class _InputFormState extends ConsumerState<_InputForm> {
+  String _secBand = 'high';
+
+  Future<void> _calculate() async {
+    final request = OreRankingRequest(
+      regionId: 0,
+      secBand: _secBand,
+    );
+    await ref.read(oreRankingProvider.notifier).run(request);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final busy = ref.watch(oreRankingProvider).isLoading;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // ── Ship (read-only current ship + refresh) ───────────────────────
+        const CurrentShipCard(),
+        const SizedBox(height: 16),
+
+        // ── Sec-band selector ──────────────────────────────────────────────
+        const Text(
+          'Sicherheitszone',
+          style: TextStyle(fontSize: 13, fontWeight: FontWeight.w500),
+        ),
+        const SizedBox(height: 6),
+        RadioGroup<String>(
+          groupValue: _secBand,
+          onChanged: busy ? (_) {} : (v) => setState(() => _secBand = v ?? 'high'),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _SecBandTile(
+                label: 'High-Sec (≥ 0.5)',
+                value: 'high',
+                enabled: !busy,
+              ),
+              _SecBandTile(
+                label: 'Low-Sec (< 0.5)',
+                value: 'low',
+                enabled: !busy,
+                activeColor: const Color(0xFFFF9800),
+              ),
+              _SecBandTile(
+                label: 'Null-Sec (≤ 0.0)',
+                value: 'null',
+                enabled: !busy,
+                activeColor: const Color(0xFFF44336),
+              ),
+            ],
+          ),
+        ),
+
+        const SizedBox(height: 16),
+
+        // ── Calculate button ───────────────────────────────────────────────
+        FilledButton.icon(
+          onPressed: busy ? null : _calculate,
+          icon: busy
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.diamond_rounded),
+          label: const Text('Erze berechnen'),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Result pane — async-aware
+// ---------------------------------------------------------------------------
+
+class _ResultPane extends ConsumerWidget {
+  const _ResultPane();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(oreRankingProvider);
+
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (err, _) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Berechnung fehlgeschlagen.\n$err',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ),
+      ),
+      data: (result) {
+        if (result == null) {
+          return const _IdleHint();
+        }
+        if (result.noMiningSetup) {
+          return const _NoMiningSetup();
+        }
+        if (result.isEmpty) {
+          return const _EmptyResult();
+        }
+        return OreRankingTable(result: result);
+      },
+    );
+  }
+}
+
+class _IdleHint extends StatelessWidget {
+  const _IdleHint();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.diamond_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Sicherheitszone wählen und Erze berechnen',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(120),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NoMiningSetup extends StatelessWidget {
+  const _NoMiningSetup();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          key: const Key('mining-no-setup'),
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.warning_amber_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.error.withAlpha(200),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Kein Mining-Setup',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.error,
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Das aktive Schiff hat keine Mining-Laser ausgerüstet.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(153),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyResult extends StatelessWidget {
+  const _EmptyResult();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          key: const Key('mining-empty-state'),
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.sentiment_dissatisfied_rounded,
+              size: 56,
+              color: Theme.of(context).colorScheme.onSurface.withAlpha(80),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Keine abbaubaren Erze für diese Zone gefunden',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color:
+                        Theme.of(context).colorScheme.onSurface.withAlpha(140),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ore ranking table
+// ---------------------------------------------------------------------------
+
+/// Scrollable data table rendering the ranked ore rows.
+/// Extracted as a public widget so widget tests can import it directly.
+class OreRankingTable extends StatelessWidget {
+  const OreRankingTable({super.key, required this.result});
+
+  final OreRankingResponse result;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Erz-Ranking',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Region ${result.regionId} · ${_secBandLabel(result.secBand)}',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 16),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              key: const Key('mining-ore-table'),
+              columns: const [
+                DataColumn(label: Text('Erz')),
+                DataColumn(label: Text('m³/h'), numeric: true),
+                DataColumn(label: Text('ISK/h roh'), numeric: true),
+                DataColumn(label: Text('ISK/h raffiniert'), numeric: true),
+                DataColumn(label: Text('Verdict')),
+                DataColumn(label: Text('Steuer %'), numeric: true),
+                DataColumn(label: Text('Δ ISK/h'), numeric: true),
+              ],
+              rows: [
+                for (final row in result.rows) _buildRow(context, row),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  DataRow _buildRow(BuildContext context, OreRankRow row) {
+    final isRefine = row.best == 'refine';
+    final verdictColor = isRefine
+        ? const Color(0xFF66BB6A) // green — refining wins
+        : Theme.of(context).colorScheme.primary;
+    final verdictLabel = isRefine ? 'Raffinieren' : 'Roh verkaufen';
+
+    return DataRow(
+      key: ValueKey('mining-ore-row-${row.oreTypeId}'),
+      cells: [
+        DataCell(Text(row.oreName)),
+        DataCell(Text(fmtVolume(row.miningM3PerHour))),
+        DataCell(Text(fmtIsk(row.rawIskPerHour))),
+        DataCell(Text(fmtIsk(row.refineIskPerHour))),
+        DataCell(
+          Container(
+            key: Key('mining-verdict-${row.oreTypeId}'),
+            padding:
+                const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: verdictColor.withAlpha(40),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: verdictColor.withAlpha(150)),
+            ),
+            child: Text(
+              verdictLabel,
+              style: TextStyle(
+                color: verdictColor,
+                fontWeight: FontWeight.w600,
+                fontSize: 12,
+              ),
+            ),
+          ),
+        ),
+        DataCell(
+          Text('${(row.bestStationTax * 100).toStringAsFixed(1)}%'),
+        ),
+        DataCell(Text(fmtIsk(row.deltaIskPerHour))),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+class _SecBandTile extends StatelessWidget {
+  const _SecBandTile({
+    required this.label,
+    required this.value,
+    this.enabled = true,
+    this.activeColor,
+  });
+
+  final String label;
+  final String value;
+  final bool enabled;
+  final Color? activeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = activeColor ?? Theme.of(context).colorScheme.primary;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Radio<String>(
+            value: value,
+            activeColor: color,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            visualDensity: VisualDensity.compact,
+            enabled: enabled,
+          ),
+          const SizedBox(width: 4),
+          Flexible(
+            child: Text(label, style: const TextStyle(fontSize: 13)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _secBandLabel(String band) {
+  switch (band) {
+    case 'low':
+      return 'Low-Sec';
+    case 'null':
+      return 'Null-Sec';
+    default:
+      return 'High-Sec';
+  }
+}

--- a/app/lib/features/mining/mining_screen.dart
+++ b/app/lib/features/mining/mining_screen.dart
@@ -193,7 +193,21 @@ class _ResultPane extends ConsumerWidget {
         if (result.isEmpty) {
           return const _EmptyResult();
         }
-        return OreRankingTable(result: result);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(child: OreRankingTable(result: result)),
+            const Padding(
+              padding: EdgeInsets.only(top: 8),
+              child: Text(
+                'Hinweis: ISK/h ist eine skills-basierte Untergrenze — Schiffs-Rollenboni '
+                '(Mining Barge/Exhumer) und Erz-Crystals fehlen noch. '
+                'Roh-vs-Refine-Verdict und Ranking sind unberührt.',
+                style: TextStyle(fontSize: 11, color: Colors.grey),
+              ),
+            ),
+          ],
+        );
       },
     );
   }

--- a/app/test/mining_models_test.dart
+++ b/app/test/mining_models_test.dart
@@ -1,0 +1,193 @@
+/// Unit tests for OreRankingResponse.fromJson — exercises the null/float-robust
+/// parsing required for the mobile DTO layer (mirrors hauling_models_test.dart).
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/mining_models.dart';
+
+void main() {
+  group('OreRankingRequest.toJson', () {
+    test('maps region_id and sec_band', () {
+      const req = OreRankingRequest(regionId: 0, secBand: 'high');
+      expect(req.toJson(), {'region_id': 0, 'sec_band': 'high'});
+    });
+
+    test('serializes low and null bands correctly', () {
+      expect(
+        const OreRankingRequest(regionId: 10000002, secBand: 'low').toJson(),
+        {'region_id': 10000002, 'sec_band': 'low'},
+      );
+      expect(
+        const OreRankingRequest(regionId: 10000002, secBand: 'null').toJson(),
+        {'region_id': 10000002, 'sec_band': 'null'},
+      );
+    });
+  });
+
+  group('OreRankRow.fromJson', () {
+    const Map<String, dynamic> sample = {
+      'ore_type_id': 1230,
+      'ore_name': 'Veldspar',
+      'mining_m3_per_hour': 3600.0,
+      'raw_isk_per_hour': 4200000.0,
+      'refine_isk_per_hour': 5100000.0,
+      'raw_net_per_m3': 1166.67,
+      'refine_net_per_m3': 1416.67,
+      'best': 'refine',
+      'delta_isk_per_hour': 900000.0,
+      'best_station_id': 60003760,
+      'best_station_tax': 0.05,
+    };
+
+    test('parses all fields correctly', () {
+      final row = OreRankRow.fromJson(sample);
+
+      expect(row.oreTypeId, 1230);
+      expect(row.oreName, 'Veldspar');
+      expect(row.miningM3PerHour, 3600.0);
+      expect(row.rawIskPerHour, 4200000.0);
+      expect(row.refineIskPerHour, 5100000.0);
+      expect(row.rawNetPerM3, closeTo(1166.67, 0.01));
+      expect(row.refineNetPerM3, closeTo(1416.67, 0.01));
+      expect(row.best, 'refine');
+      expect(row.deltaIskPerHour, 900000.0);
+      expect(row.bestStationId, 60003760);
+      expect(row.bestStationTax, 0.05);
+    });
+
+    test('tolerates missing / null fields (defaults, not exceptions)', () {
+      final row = OreRankRow.fromJson(const {'ore_name': 'Plagioclase'});
+
+      expect(row.oreTypeId, 0);
+      expect(row.oreName, 'Plagioclase');
+      expect(row.miningM3PerHour, 0);
+      expect(row.rawIskPerHour, 0);
+      expect(row.refineIskPerHour, 0);
+      expect(row.rawNetPerM3, 0);
+      expect(row.refineNetPerM3, 0);
+      expect(row.best, 'raw'); // defaulted
+      expect(row.deltaIskPerHour, 0);
+      expect(row.bestStationId, isNull);
+      expect(row.bestStationTax, 0);
+    });
+
+    test('accepts int values for double fields (num-robust)', () {
+      final row = OreRankRow.fromJson(const {
+        'ore_type_id': 1230,
+        'ore_name': 'Scordite',
+        'mining_m3_per_hour': 3000, // int
+        'raw_isk_per_hour': 3000000, // int
+        'refine_isk_per_hour': 3500000, // int
+        'raw_net_per_m3': 1000, // int
+        'refine_net_per_m3': 1166, // int
+        'best': 'raw',
+        'delta_isk_per_hour': 500000, // int
+        'best_station_tax': 0, // int zero
+      });
+
+      expect(row.miningM3PerHour, 3000.0);
+      expect(row.rawIskPerHour, 3000000.0);
+      expect(row.refineIskPerHour, 3500000.0);
+      expect(row.bestStationTax, 0.0);
+    });
+
+    test('best_station_id nullable — absent maps to null', () {
+      final row = OreRankRow.fromJson(const {
+        'ore_type_id': 1230,
+        'ore_name': 'Kernite',
+        'best': 'raw',
+        // best_station_id deliberately absent
+      });
+      expect(row.bestStationId, isNull);
+    });
+  });
+
+  group('OreRankingResponse.fromJson', () {
+    const Map<String, dynamic> sample = {
+      'region_id': 10000002,
+      'sec_band': 'high',
+      'no_mining_setup': false,
+      'rows': [
+        {
+          'ore_type_id': 1230,
+          'ore_name': 'Veldspar',
+          'mining_m3_per_hour': 3600.0,
+          'raw_isk_per_hour': 4200000.0,
+          'refine_isk_per_hour': 5100000.0,
+          'raw_net_per_m3': 1166.67,
+          'refine_net_per_m3': 1416.67,
+          'best': 'refine',
+          'delta_isk_per_hour': 900000.0,
+          'best_station_id': 60003760,
+          'best_station_tax': 0.05,
+        },
+        {
+          'ore_type_id': 1228,
+          'ore_name': 'Scordite',
+          'mining_m3_per_hour': 3000.0,
+          'raw_isk_per_hour': 3100000.0,
+          'refine_isk_per_hour': 3400000.0,
+          'raw_net_per_m3': 1033.33,
+          'refine_net_per_m3': 1133.33,
+          'best': 'refine',
+          'delta_isk_per_hour': 300000.0,
+          'best_station_id': null,
+          'best_station_tax': 0.04,
+        },
+      ],
+    };
+
+    test('parses all fields including nested rows', () {
+      final resp = OreRankingResponse.fromJson(sample);
+
+      expect(resp.regionId, 10000002);
+      expect(resp.secBand, 'high');
+      expect(resp.noMiningSetup, isFalse);
+      expect(resp.isEmpty, isFalse);
+      expect(resp.rows, hasLength(2));
+
+      final first = resp.rows.first;
+      expect(first.oreName, 'Veldspar');
+      expect(first.best, 'refine');
+      expect(first.bestStationId, 60003760);
+
+      final second = resp.rows.last;
+      expect(second.oreName, 'Scordite');
+      expect(second.bestStationId, isNull);
+    });
+
+    test('no_mining_setup=true is parsed correctly', () {
+      final resp = OreRankingResponse.fromJson(const {
+        'region_id': 10000002,
+        'sec_band': 'high',
+        'no_mining_setup': true,
+        'rows': [],
+      });
+
+      expect(resp.noMiningSetup, isTrue);
+      expect(resp.isEmpty, isTrue);
+    });
+
+    test('tolerates missing / null fields (defaults, not exceptions)', () {
+      final resp = OreRankingResponse.fromJson(const {});
+
+      expect(resp.regionId, 0);
+      expect(resp.secBand, 'high');
+      expect(resp.noMiningSetup, isFalse);
+      expect(resp.rows, isEmpty);
+      expect(resp.isEmpty, isTrue);
+    });
+
+    test('empty rows list is a valid "no ores" result', () {
+      final resp = OreRankingResponse.fromJson(const {
+        'region_id': 10000002,
+        'sec_band': 'null',
+        'no_mining_setup': false,
+        'rows': [],
+      });
+      expect(resp.isEmpty, isTrue);
+      expect(resp.rows, isEmpty);
+    });
+  });
+}

--- a/app/test/mining_screen_layout_test.dart
+++ b/app/test/mining_screen_layout_test.dart
@@ -1,0 +1,204 @@
+/// Widget tests for MiningScreen adaptive layout + ore-ranking table.
+///
+/// 1. Small view (<840 dp) → single-pane: no VerticalDivider.
+/// 2. Large view (≥840 dp) → two-pane: at least one VerticalDivider.
+/// Plus: ore table renders ≥2 rows with verdict chips, and the
+/// no-mining-setup state is displayed correctly.
+library;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:eve_o_provit/api/mining_models.dart';
+import 'package:eve_o_provit/core/theme.dart';
+import 'package:eve_o_provit/features/character/character_api.dart';
+import 'package:eve_o_provit/features/character/character_models.dart';
+import 'package:eve_o_provit/features/character/providers.dart'
+    show characterApiProvider, currentShipProvider;
+import 'package:eve_o_provit/features/mining/mining_providers.dart';
+import 'package:eve_o_provit/features/mining/mining_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Canned data
+// ---------------------------------------------------------------------------
+
+OreRankingResponse _fakeResponse() => const OreRankingResponse(
+      regionId: 10000002,
+      secBand: 'high',
+      noMiningSetup: false,
+      rows: [
+        OreRankRow(
+          oreTypeId: 1230,
+          oreName: 'Veldspar',
+          miningM3PerHour: 3600,
+          rawIskPerHour: 4200000,
+          refineIskPerHour: 5100000,
+          rawNetPerM3: 1166.67,
+          refineNetPerM3: 1416.67,
+          best: 'refine',
+          deltaIskPerHour: 900000,
+          bestStationId: 60003760,
+          bestStationTax: 0.05,
+        ),
+        OreRankRow(
+          oreTypeId: 1228,
+          oreName: 'Scordite',
+          miningM3PerHour: 3000,
+          rawIskPerHour: 3100000,
+          refineIskPerHour: 3400000,
+          rawNetPerM3: 1033.33,
+          refineNetPerM3: 1133.33,
+          best: 'raw',
+          deltaIskPerHour: 300000,
+          bestStationTax: 0.04,
+        ),
+      ],
+    );
+
+OreRankingResponse _noSetupResponse() => const OreRankingResponse(
+      regionId: 10000002,
+      secBand: 'high',
+      noMiningSetup: true,
+      rows: [],
+    );
+
+OreRankingResponse _emptyResponse() => const OreRankingResponse(
+      regionId: 10000002,
+      secBand: 'null',
+      noMiningSetup: false,
+      rows: [],
+    );
+
+class _FakeCharacterApi extends CharacterApi {
+  _FakeCharacterApi() : super(Dio());
+}
+
+const _currentShip = CharacterShip(
+  shipTypeId: 32880,
+  shipName: 'My Retriever',
+  shipItemId: 1000000000010,
+  shipTypeName: 'Retriever',
+  cargoCapacity: 2400.0,
+  effectiveCargoCapacity: 27500.0,
+);
+
+class _StubNotifier extends OreRankingNotifier {
+  @override
+  Future<OreRankingResponse?> build() async => _fakeResponse();
+}
+
+class _NoSetupNotifier extends OreRankingNotifier {
+  @override
+  Future<OreRankingResponse?> build() async => _noSetupResponse();
+}
+
+class _EmptyNotifier extends OreRankingNotifier {
+  @override
+  Future<OreRankingResponse?> build() async => _emptyResponse();
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester,
+  double width, {
+  double height = 1200,
+  OreRankingNotifier Function() notifier = _StubNotifier.new,
+}) async {
+  tester.view.physicalSize = Size(width, height);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        characterApiProvider.overrideWithValue(_FakeCharacterApi()),
+        currentShipProvider.overrideWith((ref) async => _currentShip),
+        oreRankingProvider.overrideWith(notifier),
+      ],
+      child: MaterialApp(
+        theme: buildTheme(Brightness.light),
+        home: const MiningScreen(),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  testWidgets('Single-pane (width 800): no VerticalDivider', (tester) async {
+    await _pumpScreen(tester, 800);
+
+    expect(find.byType(VerticalDivider), findsNothing);
+    // Input controls present.
+    expect(find.text('High-Sec (≥ 0.5)'), findsOneWidget);
+    // Result table also visible in single-pane.
+    expect(find.text('Erz-Ranking'), findsOneWidget);
+  });
+
+  testWidgets('Two-pane (width 1280): at least one VerticalDivider',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byType(VerticalDivider), findsAtLeastNWidgets(1));
+    expect(find.text('High-Sec (≥ 0.5)'), findsOneWidget);
+    expect(find.text('Erz-Ranking'), findsOneWidget);
+  });
+
+  testWidgets('Ore table renders ≥2 rows with ore names', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byKey(const Key('mining-ore-table')), findsOneWidget);
+    expect(find.text('Veldspar'), findsOneWidget);
+    expect(find.text('Scordite'), findsOneWidget);
+  });
+
+  testWidgets('Verdict chips are rendered per row', (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    // Veldspar: best = 'refine' → chip text 'Raffinieren'
+    final veldsparVerdict = find.byKey(const Key('mining-verdict-1230'));
+    expect(veldsparVerdict, findsOneWidget);
+
+    // Scordite: best = 'raw' → chip text 'Roh verkaufen'
+    final scorditeVerdict = find.byKey(const Key('mining-verdict-1228'));
+    expect(scorditeVerdict, findsOneWidget);
+
+    expect(find.text('Raffinieren'), findsOneWidget);
+    expect(find.text('Roh verkaufen'), findsOneWidget);
+  });
+
+  testWidgets('No-mining-setup state shows the visible notice', (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _NoSetupNotifier.new);
+
+    expect(find.byKey(const Key('mining-no-setup')), findsOneWidget);
+    expect(find.text('Kein Mining-Setup'), findsOneWidget);
+    expect(find.byKey(const Key('mining-ore-table')), findsNothing);
+  });
+
+  testWidgets('Empty rows (no-mining-setup=false) shows empty-state',
+      (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _EmptyNotifier.new);
+
+    expect(find.byKey(const Key('mining-empty-state')), findsOneWidget);
+    expect(
+      find.text('Keine abbaubaren Erze für diese Zone gefunden'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('mining-ore-table')), findsNothing);
+  });
+
+  testWidgets('CurrentShipCard is shown at the top of the input form',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byKey(const Key('current-ship-card')), findsOneWidget);
+    // Ship name from the stub.
+    expect(find.text('Schiff'), findsOneWidget);
+  });
+}

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -173,7 +173,10 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 	// fitted mining modules, region reprocessing stations, and market buy prices.
 	// skillsService is a *SkillsService; its mining/standings methods are not on the
 	// narrow SkillsServicer interface, so resolve the concrete type for the provider.
-	miningSkillsProvider, _ := skillsService.(services.MiningSkillsProvider)
+	miningSkillsProvider, ok := skillsService.(services.MiningSkillsProvider)
+	if !ok {
+		return nil, fmt.Errorf("skills service does not implement MiningSkillsProvider")
+	}
 	miningService := services.NewMiningService(c.DB.SDE, c.SDERepo, c.MarketRepo, miningSkillsProvider, fittingService, characterHelper, c.SDERepo, c.AppLogger)
 	c.MiningHandler = handlers.NewMiningHandler(miningService)
 

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -38,6 +38,7 @@ type AppContainer struct {
 	PortfolioHandler   *handlers.PortfolioHandler
 	HaulingHandler     *handlers.HaulingHandler
 	AssetsHandler      *handlers.AssetsHandler
+	MiningHandler      *handlers.MiningHandler
 
 	// Background workers
 	CompetitionCollector *services.CompetitionCollector
@@ -167,6 +168,14 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 	// Sell-from-assets (#107) — reuses hub price fetch + skills + navigation + fitting.
 	assetSaleService := services.NewAssetSaleService(skillsService, c.ESIClient, c.SDERepo, services.NewESIAssetFetcher(), fittingService, characterHelper, c.SDERepo, c.DB.SDE, c.AppLogger)
 	c.AssetsHandler = handlers.NewAssetsHandler(assetSaleService)
+
+	// Mining ore-ranking (raw-vs-refine per region+sec-band). Reuses skills/standings,
+	// fitted mining modules, region reprocessing stations, and market buy prices.
+	// skillsService is a *SkillsService; its mining/standings methods are not on the
+	// narrow SkillsServicer interface, so resolve the concrete type for the provider.
+	miningSkillsProvider, _ := skillsService.(services.MiningSkillsProvider)
+	miningService := services.NewMiningService(c.DB.SDE, c.SDERepo, c.MarketRepo, miningSkillsProvider, fittingService, characterHelper, c.SDERepo, c.AppLogger)
+	c.MiningHandler = handlers.NewMiningHandler(miningService)
 
 	// Start the competition collector in the background (lazy-tracked pairs).
 	go c.CompetitionCollector.Start(ctx)

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -157,6 +157,7 @@ func setupApp(c *AppContainer) *fiber.App {
 	api.Post("/trading/hauling/routes", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.HaulingHandler.FindRoutes)
 	api.Get("/trading/assets", evesso.NewAuthMiddleware(c.TokenValidator), c.AssetsHandler.ListAssets)
 	api.Post("/trading/assets/sell-options", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.AssetsHandler.SellOptions)
+	api.Post("/mining/ore-ranking", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.MiningHandler.OreRanking)
 	api.Get("/items/search", c.TradingHandler.SearchItems)
 
 	api.Post("/calculations/cargo", c.CalculationHandler.CalculateCargo)

--- a/backend/internal/database/sde.go
+++ b/backend/internal/database/sde.go
@@ -424,3 +424,36 @@ func (r *SDERepository) MinRouteSecurityStatus(ctx context.Context, route []int6
 	}
 	return minSec
 }
+
+// ReprocessStation is an NPC station offering reprocessing, with its base rate + take.
+type ReprocessStation struct {
+	StationID   int64
+	OwnerCorpID int64
+	BaseRate    float64 // reprocessingEfficiency (0.50)
+	BaseTake    float64 // reprocessingStationsTake (0.05)
+}
+
+// GetRegionReprocessStations lists NPC stations with reprocessing (reprocessingEfficiency > 0)
+// in a region, with their owner corp + base rate/take.
+func (r *SDERepository) GetRegionReprocessStations(ctx context.Context, regionID int) ([]ReprocessStation, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT n._key, COALESCE(n.ownerID,0),
+		       COALESCE(n.reprocessingEfficiency,0), COALESCE(n.reprocessingStationsTake,0)
+		FROM npcStations n
+		JOIN mapSolarSystems s ON n.solarSystemID = s._key
+		JOIN mapConstellations c ON s.constellationID = c._key
+		WHERE c.regionID = ? AND COALESCE(n.reprocessingEfficiency,0) > 0`, regionID)
+	if err != nil {
+		return nil, fmt.Errorf("region reprocess stations for %d: %w", regionID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []ReprocessStation
+	for rows.Next() {
+		var s ReprocessStation
+		if err := rows.Scan(&s.StationID, &s.OwnerCorpID, &s.BaseRate, &s.BaseTake); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}

--- a/backend/internal/database/sde_reprocess_test.go
+++ b/backend/internal/database/sde_reprocess_test.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestGetRegionReprocessStations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	schema := `
+		CREATE TABLE npcStations (_key INTEGER PRIMARY KEY, ownerID INTEGER,
+			reprocessingEfficiency REAL, reprocessingStationsTake REAL, solarSystemID INTEGER);
+		CREATE TABLE mapSolarSystems (_key INTEGER PRIMARY KEY, constellationID INTEGER);
+		CREATE TABLE mapConstellations (_key INTEGER PRIMARY KEY, regionID INTEGER);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	data := `
+		INSERT INTO mapConstellations (_key, regionID) VALUES (20000020, 10000002), (20000999, 10000099);
+		INSERT INTO mapSolarSystems (_key, constellationID) VALUES (30000142, 20000020), (30009999, 20000999);
+		INSERT INTO npcStations (_key, ownerID, reprocessingEfficiency, reprocessingStationsTake, solarSystemID) VALUES
+			(60003760, 1000035, 0.5, 0.05, 30000142),   -- in region 10000002, reprocess
+			(60000001, 1000040, 0.0, 0.05, 30000142),   -- in region, NO reprocess (excluded)
+			(60009999, 1000050, 0.5, 0.05, 30009999);   -- other region (excluded)
+	`
+	if _, err := db.Exec(data); err != nil {
+		t.Fatalf("data: %v", err)
+	}
+
+	repo := NewSDERepository(db)
+	st, err := repo.GetRegionReprocessStations(context.Background(), 10000002)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st) != 1 {
+		t.Fatalf("want 1 station, got %d: %+v", len(st), st)
+	}
+	s := st[0]
+	if s.StationID != 60003760 || s.OwnerCorpID != 1000035 || s.BaseRate != 0.5 || s.BaseTake != 0.05 {
+		t.Fatalf("bad station: %+v", s)
+	}
+}

--- a/backend/internal/handlers/fitting_test.go
+++ b/backend/internal/handlers/fitting_test.go
@@ -40,6 +40,19 @@ func (m *mockFittingService) EffectiveCargoForActiveShip(ctx context.Context, ch
 	}
 	return 0, false
 }
+func (m *mockFittingService) ActiveShipFittedModuleTypeIDs(ctx context.Context, characterID int, accessToken string) ([]int64, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.fitting != nil {
+		ids := make([]int64, 0, len(m.fitting.FittedModules))
+		for _, mod := range m.fitting.FittedModules {
+			ids = append(ids, int64(mod.TypeID))
+		}
+		return ids, nil
+	}
+	return nil, nil
+}
 
 // TestGetCharacterFitting_Success tests successful fitting retrieval
 func TestGetCharacterFitting_Success(t *testing.T) {

--- a/backend/internal/handlers/mining.go
+++ b/backend/internal/handlers/mining.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/services"
+)
+
+// MiningHandler serves the mining ore-ranking endpoint (raw-vs-refine per region+sec-band).
+type MiningHandler struct {
+	service *services.MiningService
+}
+
+// NewMiningHandler creates a new mining handler.
+func NewMiningHandler(service *services.MiningService) *MiningHandler {
+	return &MiningHandler{service: service}
+}
+
+// OreRanking handles POST /api/v1/mining/ore-ranking
+//
+// @Summary Rank asteroid ores by raw-vs-refine net ISK for a region + security band
+// @Description Given a region (or the character's current region) and a security band,
+// @Description ranks ores by net ISK per m³ and — when a mining ship is fitted — per hour,
+// @Description comparing selling the raw ore vs reprocessing + selling the materials.
+// @Tags Mining
+// @Accept json
+// @Produce json
+// @Param request body models.OreRankingRequest true "Ore ranking parameters"
+// @Success 200 {object} models.OreRankingResponse
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 401 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /api/v1/mining/ore-ranking [post]
+func (h *MiningHandler) OreRanking(c *fiber.Ctx) error {
+	var req models.OreRankingRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request body"})
+	}
+
+	characterID := c.Locals("character_id")
+	accessToken := c.Locals("access_token")
+	if characterID == nil || accessToken == nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Authentication required"})
+	}
+	cid, ok := characterID.(int)
+	tok, ok2 := accessToken.(string)
+	if !ok || !ok2 {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid authentication context"})
+	}
+
+	result, err := h.service.OreRanking(c.UserContext(), cid, tok, req)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to rank ores"})
+	}
+	return c.JSON(result)
+}

--- a/backend/internal/models/mining.go
+++ b/backend/internal/models/mining.go
@@ -1,0 +1,35 @@
+package models
+
+// OreRankingRequest is the input for the ore-ranking endpoint. RegionID <= 0 means
+// "use the character's current region". SecBand filters the ore set to a security band
+// ("high" | "low" | "null"); empty/unknown band yields no ores.
+type OreRankingRequest struct {
+	RegionID int    `json:"region_id"`
+	SecBand  string `json:"sec_band"`
+}
+
+// OreRankRow is one ore's raw-vs-refine ranking row. Per-m³ and isk/h figures are
+// internal (used for sorting); only the user-facing fields are serialized.
+type OreRankRow struct {
+	OreTypeID        int64   `json:"ore_type_id"`
+	OreName          string  `json:"ore_name"`
+	MiningM3PerHour  float64 `json:"mining_m3_per_hour"`
+	RawISKPerHour    float64 `json:"raw_isk_per_hour"`
+	RefineISKPerHour float64 `json:"refine_isk_per_hour"`
+	RawNetPerM3      float64 `json:"raw_net_per_m3"`
+	RefineNetPerM3   float64 `json:"refine_net_per_m3"`
+	Best             string  `json:"best"`
+	DeltaISKPerHour  float64 `json:"delta_isk_per_hour"`
+	BestStationID    int64   `json:"best_station_id,omitempty"`
+	BestStationTax   float64 `json:"best_station_tax"`
+}
+
+// OreRankingResponse is the ore-ranking result for a region + security band.
+// NoMiningSetup is true when the active ship has no mining modules (per-m³ values are
+// still populated; isk/h is 0). Rows is always non-nil (never JSON null).
+type OreRankingResponse struct {
+	RegionID      int          `json:"region_id"`
+	SecBand       string       `json:"sec_band"`
+	NoMiningSetup bool         `json:"no_mining_setup"`
+	Rows          []OreRankRow `json:"rows"`
+}

--- a/backend/internal/services/asset_sale_service_test.go
+++ b/backend/internal/services/asset_sale_service_test.go
@@ -50,6 +50,9 @@ func (fakeFitting) EnrichShipsEffectiveCargo(_ context.Context, _ int, _ []model
 func (fakeFitting) EffectiveCargoForActiveShip(_ context.Context, _, _ int, _ int64, _ string) (float64, bool) {
 	return 0, false
 }
+func (fakeFitting) ActiveShipFittedModuleTypeIDs(_ context.Context, _ int, _ string) ([]int64, error) {
+	return nil, nil
+}
 
 type fakeActiveShip struct{ typeID int }
 

--- a/backend/internal/services/fitting_service.go
+++ b/backend/internal/services/fitting_service.go
@@ -479,6 +479,57 @@ func (s *FittingService) EffectiveCargoForActiveShip(ctx context.Context, charac
 	return s.EffectiveCargoForShipItem(ctx, shipTypeID, shipItemID, assets, charSkills)
 }
 
+// ActiveShipFittedModuleTypeIDs returns the TYPE IDs of the modules fitted to the
+// character's current/active ship (ESI /characters/{id}/ship/). It resolves the active
+// ship's item id, then collects every fitted module's TypeID from the asset list (via
+// the same fitted-slot filter used for effective-cargo). Returns an empty slice (no error)
+// when the active ship has no fitted modules; an error only on an ESI assets/ship failure.
+func (s *FittingService) ActiveShipFittedModuleTypeIDs(ctx context.Context, characterID int, accessToken string) ([]int64, error) {
+	shipItemID, err := s.fetchActiveShipItemID(ctx, characterID, accessToken)
+	if err != nil {
+		return nil, fmt.Errorf("active ship lookup failed: %w", err)
+	}
+	assets, err := s.fetchESIAssets(ctx, characterID, accessToken)
+	if err != nil {
+		return nil, fmt.Errorf("active ship modules: assets fetch failed: %w", err)
+	}
+	items := s.fittedItemsForShip(ctx, assets, shipItemID)
+	out := make([]int64, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.TypeID)
+	}
+	return out, nil
+}
+
+// fetchActiveShipItemID resolves the item id of the ship the character is currently
+// flying (ESI /characters/{id}/ship/ → ship_item_id).
+func (s *FittingService) fetchActiveShipItemID(ctx context.Context, characterID int, accessToken string) (int64, error) {
+	endpoint := fmt.Sprintf("/latest/characters/%d/ship/", characterID)
+	req, err := http.NewRequestWithContext(ctx, "GET", esiconfig.BaseURL+endpoint, nil)
+	if err != nil {
+		return 0, fmt.Errorf("create ship request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := s.esiClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("esi ship request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return 0, fmt.Errorf("ESI ship returned status %d: %s", resp.StatusCode, string(body))
+	}
+	var ship struct {
+		ShipItemID int64 `json:"ship_item_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&ship); err != nil {
+		return 0, fmt.Errorf("decode ship response: %w", err)
+	}
+	return ship.ShipItemID, nil
+}
+
 // fetchESIAssets fetches character assets from ESI /v5/characters/{id}/assets/
 func (s *FittingService) fetchESIAssets(
 	ctx context.Context,

--- a/backend/internal/services/hauling_service_test.go
+++ b/backend/internal/services/hauling_service_test.go
@@ -31,6 +31,9 @@ func (f *recordingFitting) EnrichShipsEffectiveCargo(_ context.Context, _ int, _
 func (f *recordingFitting) EffectiveCargoForActiveShip(_ context.Context, _, _ int, _ int64, _ string) (float64, bool) {
 	return 0, false
 }
+func (f *recordingFitting) ActiveShipFittedModuleTypeIDs(_ context.Context, _ int, _ string) ([]int64, error) {
+	return nil, nil
+}
 
 // When CargoCapacity > 0 the override replaces ONLY the cargo m³; the fitting is
 // still fetched so the warp/align SPEED reflects the actual fitted ship.

--- a/backend/internal/services/interfaces.go
+++ b/backend/internal/services/interfaces.go
@@ -66,6 +66,11 @@ type FittingServicer interface {
 	// instance by item_id (the flown/active ship). Returns (effective, unavailable);
 	// (0, true) on an assets/calc error so the caller fails loud.
 	EffectiveCargoForActiveShip(ctx context.Context, characterID, shipTypeID int, shipItemID int64, accessToken string) (float64, bool)
+
+	// ActiveShipFittedModuleTypeIDs returns the TYPE IDs of the modules fitted to the
+	// character's current/active ship (used for mining yield). Empty slice when no
+	// modules are fitted; error only on an ESI assets/ship failure.
+	ActiveShipFittedModuleTypeIDs(ctx context.Context, characterID int, accessToken string) ([]int64, error)
 }
 
 // FeeServicer defines the interface for trading fee calculations

--- a/backend/internal/services/mining_compare.go
+++ b/backend/internal/services/mining_compare.go
@@ -1,0 +1,55 @@
+package services
+
+// MaterialValue is one reprocessing output material with its current taker price.
+type MaterialValue struct {
+	Qty      int64   // material output per ONE portionSize batch (from typeMaterials)
+	BuyPrice float64 // ISK/unit, highest buy order
+}
+
+// OreCompareInput holds the resolved inputs for one ore's raw-vs-refine taker comparison.
+type OreCompareInput struct {
+	PortionSize  int64
+	OreVolumeM3  float64
+	OreBuyPrice  float64 // ISK/unit, highest buy order for the raw ore
+	Materials    []MaterialValue
+	NetYield     float64 // reprocessing.NetYield(...) for the best station
+	StationTake  float64 // ReprocessTax(...) for the best station
+	SalesTaxRate float64 // from Accounting skill
+}
+
+// OreCompareResult is the per-ore verdict, normalized to net ISK per m³.
+type OreCompareResult struct {
+	RawNetPerM3    float64
+	RefineNetPerM3 float64
+	Best           string // "raw" | "refine"
+	DeltaPerM3     float64
+}
+
+// CompareOre compares selling the raw ore vs. reprocessing + selling the materials,
+// both as a taker (sales tax only, no broker fee), normalized to net ISK per m³.
+func CompareOre(in OreCompareInput) OreCompareResult {
+	salesMul := 1 - in.SalesTaxRate
+	rawPerM3 := in.OreBuyPrice * salesMul / in.OreVolumeM3
+	var batchGross float64
+	for _, m := range in.Materials {
+		batchGross += float64(m.Qty) * in.NetYield * m.BuyPrice
+	}
+	batchNet := batchGross * (1 - in.StationTake) * salesMul
+	refinePerUnit := batchNet / float64(in.PortionSize)
+	refinePerM3 := refinePerUnit / in.OreVolumeM3
+	r := OreCompareResult{RawNetPerM3: rawPerM3, RefineNetPerM3: refinePerM3}
+	if refinePerM3 >= rawPerM3 {
+		r.Best = "refine"
+	} else {
+		r.Best = "raw"
+	}
+	r.DeltaPerM3 = absFloat(refinePerM3 - rawPerM3)
+	return r
+}
+
+func absFloat(f float64) float64 {
+	if f < 0 {
+		return -f
+	}
+	return f
+}

--- a/backend/internal/services/mining_compare_test.go
+++ b/backend/internal/services/mining_compare_test.go
@@ -1,0 +1,36 @@
+package services
+
+import "testing"
+
+func TestCompareOre_RefineWins(t *testing.T) {
+	in := OreCompareInput{
+		PortionSize: 100, OreVolumeM3: 0.1, OreBuyPrice: 8.0,
+		Materials:    []MaterialValue{{Qty: 400, BuyPrice: 5.0}},
+		NetYield:     0.90,
+		StationTake:  0.02,
+		SalesTaxRate: 0.04,
+	}
+	r := CompareOre(in)
+	// raw: 8 × 0.96 / 0.1 = 76.8 per m³
+	if r.RawNetPerM3 < 76.7 || r.RawNetPerM3 > 76.9 {
+		t.Fatalf("raw/m3 %.4f", r.RawNetPerM3)
+	}
+	// refine per 100 ore: 400×0.90×5 = 1800; ×0.98 ×0.96 = 1693.44; /100 /0.1 = 169.344 per m³
+	if r.RefineNetPerM3 < 169.3 || r.RefineNetPerM3 > 169.4 {
+		t.Fatalf("refine/m3 %.4f", r.RefineNetPerM3)
+	}
+	if r.Best != "refine" {
+		t.Fatalf("best %s", r.Best)
+	}
+}
+
+func TestCompareOre_RawWins(t *testing.T) {
+	in := OreCompareInput{
+		PortionSize: 100, OreVolumeM3: 0.1, OreBuyPrice: 100,
+		Materials: []MaterialValue{{Qty: 400, BuyPrice: 1}},
+		NetYield:  0.5, StationTake: 0.05, SalesTaxRate: 0.04,
+	}
+	if CompareOre(in).Best != "raw" {
+		t.Fatal("raw should win")
+	}
+}

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -1,0 +1,285 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/mining"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/reprocessing"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+)
+
+// MiningSkillsProvider fetches the character's mining/reprocessing skills + standings.
+// Abstracted so MiningService can be unit-tested without ESI (implemented by SkillsService).
+type MiningSkillsProvider interface {
+	GetMiningReprocessingSkills(ctx context.Context, sdeDB *sql.DB, characterID int, accessToken string) (*MiningReprocessingSkills, error)
+	GetCharacterStandings(ctx context.Context, characterID int, accessToken string) (map[int64]float64, error)
+}
+
+// MiningModulesProvider exposes the active ship's fitted mining module type ids.
+// Subset of FittingServicer, kept narrow for fakeability.
+type MiningModulesProvider interface {
+	ActiveShipFittedModuleTypeIDs(ctx context.Context, characterID int, accessToken string) ([]int64, error)
+}
+
+// ReprocessStationProvider lists a region's NPC reprocessing stations. Abstracted so the
+// service can be unit-tested without Postgres/SDE wiring (implemented by *database.SDERepository).
+type ReprocessStationProvider interface {
+	GetRegionReprocessStations(ctx context.Context, regionID int) ([]database.ReprocessStation, error)
+}
+
+// MarketBuyProvider fetches market orders for a (region, type). Subset of *database.MarketRepository.
+type MarketBuyProvider interface {
+	GetMarketOrders(ctx context.Context, regionID, typeID int) ([]database.MarketOrder, error)
+}
+
+// MiningLocationProvider resolves the character's current location (for region fallback).
+type MiningLocationProvider interface {
+	GetCharacterLocation(ctx context.Context, characterID int, accessToken string) (*CharacterLocation, error)
+}
+
+// MiningRegionProvider resolves a solar system's region id (for region fallback).
+type MiningRegionProvider interface {
+	GetRegionIDForSystem(ctx context.Context, systemID int64) (int, error)
+}
+
+// MiningService ranks asteroid ores for a region + security band by raw-vs-refine
+// net ISK (per m³ and, with a mining fit, per hour). It reuses the reprocessing/mining
+// evedb building blocks + the ore-compare service helpers.
+type MiningService struct {
+	sdeDB      *sql.DB
+	stations   ReprocessStationProvider
+	marketRepo MarketBuyProvider
+	skills     MiningSkillsProvider
+	fitting    MiningModulesProvider
+	location   MiningLocationProvider
+	region     MiningRegionProvider
+	logger     *logger.Logger
+}
+
+// NewMiningService creates a new mining ore-ranking service.
+func NewMiningService(
+	sdeDB *sql.DB,
+	stations ReprocessStationProvider,
+	marketRepo MarketBuyProvider,
+	skills MiningSkillsProvider,
+	fitting MiningModulesProvider,
+	location MiningLocationProvider,
+	region MiningRegionProvider,
+	logger *logger.Logger,
+) *MiningService {
+	return &MiningService{
+		sdeDB:      sdeDB,
+		stations:   stations,
+		marketRepo: marketRepo,
+		skills:     skills,
+		fitting:    fitting,
+		location:   location,
+		region:     region,
+		logger:     logger,
+	}
+}
+
+// OreRanking computes the raw-vs-refine ore ranking for the request's region + security band.
+func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessToken string, req models.OreRankingRequest) (*models.OreRankingResponse, error) {
+	// 1. Resolve region (request or current location).
+	regionID := req.RegionID
+	if regionID <= 0 {
+		loc, err := s.location.GetCharacterLocation(ctx, characterID, accessToken)
+		if err != nil {
+			return nil, err
+		}
+		r, err := s.region.GetRegionIDForSystem(ctx, loc.SolarSystemID)
+		if err != nil {
+			return nil, err
+		}
+		regionID = r
+	}
+
+	resp := &models.OreRankingResponse{
+		RegionID: regionID,
+		SecBand:  req.SecBand,
+		Rows:     []models.OreRankRow{},
+	}
+
+	// 2. Ore set for the band.
+	bandGroups := secBandOreGroups(req.SecBand)
+	if len(bandGroups) == 0 {
+		return resp, nil
+	}
+	allOres, err := reprocessing.ListOres(s.sdeDB)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. Skills + standings + sales tax + mining rate.
+	skills, err := s.skills.GetMiningReprocessingSkills(ctx, s.sdeDB, characterID, accessToken)
+	if err != nil {
+		// Degrade to zero skills (still rank ores) but log loudly.
+		if s.logger != nil {
+			s.logger.Warn("ore ranking: mining skills unavailable, using zero skills", "error", err)
+		}
+		skills = &MiningReprocessingSkills{OreProcessing: map[int64]int{}}
+	}
+	standings, err := s.skills.GetCharacterStandings(ctx, characterID, accessToken)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("ore ranking: standings unavailable, using neutral", "error", err)
+		}
+		standings = map[int64]float64{}
+	}
+	salesTaxRate := SalesTaxRate(skills.Accounting)
+
+	moduleIDs, err := s.fitting.ActiveShipFittedModuleTypeIDs(ctx, characterID, accessToken)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("ore ranking: active-ship modules unavailable", "error", err)
+		}
+		moduleIDs = nil
+	}
+	m3h, err := mining.MiningRateM3PerHour(s.sdeDB, moduleIDs, mining.MiningSkills{
+		Mining:       skills.Mining,
+		Astrogeology: skills.Astrogeology,
+	}, 1.0)
+	if err != nil {
+		return nil, err
+	}
+	if m3h == 0 {
+		resp.NoMiningSetup = true
+	}
+
+	// 4. Best reprocessing station (lowest tax given the player's owner-corp standing).
+	stations, err := s.stations.GetRegionReprocessStations(ctx, regionID)
+	if err != nil {
+		return nil, err
+	}
+	stStandings := make([]StationStanding, 0, len(stations))
+	for _, st := range stations {
+		stStandings = append(stStandings, StationStanding{
+			StationID: st.StationID,
+			BaseRate:  st.BaseRate,
+			BaseTake:  st.BaseTake,
+			Standing:  standings[st.OwnerCorpID],
+		})
+	}
+	best := BestStation(stStandings)
+
+	// Base reprocessing rate/take: from the best station, or NPC defaults if none.
+	baseRate, baseTake := 0.50, 0.05
+	var bestStationID int64
+	var bestStanding float64
+	if best != nil {
+		baseRate, baseTake = best.BaseRate, best.BaseTake
+		bestStationID = best.StationID
+		bestStanding = best.Standing
+	}
+	stationTax := ReprocessTax(baseTake, bestStanding)
+
+	// 5. Per ore.
+	for i := range allOres {
+		if !bandGroups[allOres[i].GroupID] {
+			continue
+		}
+		o, err := reprocessing.GetOre(s.sdeDB, allOres[i].TypeID)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Warn("ore ranking: get ore failed", "typeID", allOres[i].TypeID, "error", err)
+			}
+			continue
+		}
+		if o.VolumeM3 <= 0 || o.PortionSize <= 0 {
+			continue
+		}
+
+		oreBuy := s.highestBuyPrice(ctx, regionID, int(o.TypeID))
+
+		// Materials: each material's highest buy price. Missing material price → 0
+		// (that material contributes nothing to the refine value).
+		mats := make([]MaterialValue, 0, len(o.Materials))
+		anyMatPrice := false
+		for _, m := range o.Materials {
+			bp := s.highestBuyPrice(ctx, regionID, int(m.MaterialTypeID))
+			if bp > 0 {
+				anyMatPrice = true
+			}
+			mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: bp})
+		}
+
+		// Skip the ore entirely if NEITHER raw nor refine has any buy-order value.
+		if oreBuy <= 0 && !anyMatPrice {
+			continue
+		}
+
+		oreProc := skills.OreProcessing[o.GroupID]
+		net := reprocessing.NetYield(baseRate, reprocessing.ReprocessingSkills{
+			Reprocessing:           skills.Reprocessing,
+			ReprocessingEfficiency: skills.ReprocessingEfficiency,
+			OreProcessing:          oreProc,
+		})
+
+		cmp := CompareOre(OreCompareInput{
+			PortionSize:  o.PortionSize,
+			OreVolumeM3:  o.VolumeM3,
+			OreBuyPrice:  oreBuy,
+			Materials:    mats,
+			NetYield:     net,
+			StationTake:  stationTax,
+			SalesTaxRate: salesTaxRate,
+		})
+
+		row := models.OreRankRow{
+			OreTypeID:        o.TypeID,
+			OreName:          o.Name,
+			MiningM3PerHour:  m3h,
+			RawNetPerM3:      cmp.RawNetPerM3,
+			RefineNetPerM3:   cmp.RefineNetPerM3,
+			Best:             cmp.Best,
+			RawISKPerHour:    m3h * cmp.RawNetPerM3,
+			RefineISKPerHour: m3h * cmp.RefineNetPerM3,
+			DeltaISKPerHour:  m3h * cmp.DeltaPerM3,
+			BestStationID:    bestStationID,
+			BestStationTax:   stationTax,
+		}
+		resp.Rows = append(resp.Rows, row)
+	}
+
+	// 6. Sort: by isk/h when mining, else by per-m³.
+	sort.SliceStable(resp.Rows, func(i, j int) bool {
+		if m3h > 0 {
+			return maxFloat(resp.Rows[i].RawISKPerHour, resp.Rows[i].RefineISKPerHour) >
+				maxFloat(resp.Rows[j].RawISKPerHour, resp.Rows[j].RefineISKPerHour)
+		}
+		return maxFloat(resp.Rows[i].RawNetPerM3, resp.Rows[i].RefineNetPerM3) >
+			maxFloat(resp.Rows[j].RawNetPerM3, resp.Rows[j].RefineNetPerM3)
+	})
+
+	return resp, nil
+}
+
+// highestBuyPrice returns the highest buy-order price for (region, type), or 0 if none.
+func (s *MiningService) highestBuyPrice(ctx context.Context, regionID, typeID int) float64 {
+	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("ore ranking: market orders fetch failed", "typeID", typeID, "error", err)
+		}
+		return 0
+	}
+	best := 0.0
+	for _, o := range orders {
+		if o.IsBuyOrder && o.Price > best {
+			best = o.Price
+		}
+	}
+	return best
+}
+
+func maxFloat(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -1,0 +1,204 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// --- Fakes ---------------------------------------------------------------
+
+type fakeMiningMarket struct {
+	// buyPriceByType maps typeID → highest buy price returned as a single buy order.
+	buyPriceByType map[int]float64
+}
+
+func (f *fakeMiningMarket) GetMarketOrders(_ context.Context, _ int, typeID int) ([]database.MarketOrder, error) {
+	price, ok := f.buyPriceByType[typeID]
+	if !ok {
+		return []database.MarketOrder{}, nil
+	}
+	return []database.MarketOrder{
+		{TypeID: typeID, IsBuyOrder: true, Price: price, VolumeRemain: 1_000_000},
+		// a lower buy order + a sell order, to prove we pick the highest buy.
+		{TypeID: typeID, IsBuyOrder: true, Price: price * 0.5, VolumeRemain: 100},
+		{TypeID: typeID, IsBuyOrder: false, Price: price * 2, VolumeRemain: 100},
+	}, nil
+}
+
+type fakeStations struct{ stations []database.ReprocessStation }
+
+func (f *fakeStations) GetRegionReprocessStations(_ context.Context, _ int) ([]database.ReprocessStation, error) {
+	return f.stations, nil
+}
+
+type fakeMiningModules struct{ ids []int64 }
+
+func (f *fakeMiningModules) ActiveShipFittedModuleTypeIDs(_ context.Context, _ int, _ string) ([]int64, error) {
+	return f.ids, nil
+}
+
+// fakeMiningSkillsProvider implements MiningSkillsProvider with fixed skills + standings.
+type fakeMiningSkillsProvider struct {
+	skills    *MiningReprocessingSkills
+	standings map[int64]float64
+}
+
+func (f *fakeMiningSkillsProvider) GetMiningReprocessingSkills(_ context.Context, _ *sql.DB, _ int, _ string) (*MiningReprocessingSkills, error) {
+	return f.skills, nil
+}
+
+func (f *fakeMiningSkillsProvider) GetCharacterStandings(_ context.Context, _ int, _ string) (map[int64]float64, error) {
+	return f.standings, nil
+}
+
+// --- Test ---------------------------------------------------------------
+
+const (
+	veldsparTypeID    = 1230
+	stripMinerITypeID = 17482
+	tritaniumTypeID   = 34
+)
+
+// TestMiningService_OreRanking_Veldspar verifies a Veldspar row is produced with the
+// correct Best verdict and per-m³ values consistent with CompareOre, and that isk/h
+// equals m3h × per-m³ when a mining module is fitted.
+func TestMiningService_OreRanking_Veldspar(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	// Known buy prices: high Veldspar buy (raw favored) — pick numbers where raw wins.
+	const veldBuy = 15.0
+	const tritBuy = 5.0
+	market := &fakeMiningMarket{buyPriceByType: map[int]float64{
+		veldsparTypeID:  veldBuy,
+		tritaniumTypeID: tritBuy,
+	}}
+
+	skills := &fakeMiningSkillsProvider{
+		skills:    &MiningReprocessingSkills{OreProcessing: map[int64]int{}}, // all 0
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, nil, nil, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{
+		RegionID: 10000002,
+		SecBand:  "high",
+	})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+	if resp.NoMiningSetup {
+		t.Fatal("expected NoMiningSetup=false (Strip Miner fitted)")
+	}
+
+	// Find the Veldspar row.
+	var row *models.OreRankRow
+	for i := range resp.Rows {
+		if resp.Rows[i].OreTypeID == veldsparTypeID {
+			row = &resp.Rows[i]
+			break
+		}
+	}
+	if row == nil {
+		t.Fatal("Veldspar row not found in response")
+	}
+	if row.Best == "" {
+		t.Error("Best verdict not set")
+	}
+
+	// Recompute the expected CompareOre result independently and assert consistency.
+	// Veldspar (typeID 1230): portionSize 100, volume 0.1 m³, material Tritanium ×400.
+	net := 0.50 // NetYield at all-zero reprocessing skills = baseRate
+	want := CompareOre(OreCompareInput{
+		PortionSize:  100,
+		OreVolumeM3:  0.1,
+		OreBuyPrice:  veldBuy,
+		Materials:    []MaterialValue{{Qty: 400, BuyPrice: tritBuy}},
+		NetYield:     net,
+		StationTake:  ReprocessTax(0.05, 0), // base take, neutral standing
+		SalesTaxRate: SalesTaxRate(0),
+	})
+	if !approxEq(row.RawNetPerM3, want.RawNetPerM3) {
+		t.Errorf("RawNetPerM3: got %v, want %v", row.RawNetPerM3, want.RawNetPerM3)
+	}
+	if !approxEq(row.RefineNetPerM3, want.RefineNetPerM3) {
+		t.Errorf("RefineNetPerM3: got %v, want %v", row.RefineNetPerM3, want.RefineNetPerM3)
+	}
+	if row.Best != want.Best {
+		t.Errorf("Best: got %q, want %q", row.Best, want.Best)
+	}
+
+	// isk/h = m3h × per-m³. Strip Miner I: 150 m³ / 45 s = 12000 m³/h at zero skills.
+	const wantM3H = 150.0 / 45.0 * 3600.0
+	if !approxEq(row.MiningM3PerHour, wantM3H) {
+		t.Errorf("MiningM3PerHour: got %v, want %v", row.MiningM3PerHour, wantM3H)
+	}
+	if !approxEq(row.RawISKPerHour, wantM3H*row.RawNetPerM3) {
+		t.Errorf("RawISKPerHour: got %v, want %v", row.RawISKPerHour, wantM3H*row.RawNetPerM3)
+	}
+	if !approxEq(row.RefineISKPerHour, wantM3H*row.RefineNetPerM3) {
+		t.Errorf("RefineISKPerHour: got %v, want %v", row.RefineISKPerHour, wantM3H*row.RefineNetPerM3)
+	}
+	if row.BestStationID != 60000001 {
+		t.Errorf("BestStationID: got %d, want 60000001", row.BestStationID)
+	}
+}
+
+// TestMiningService_OreRanking_NoMiningSetup verifies that with no fitted mining modules
+// the response flags NoMiningSetup and isk/h is 0, while per-m³ values are still computed.
+func TestMiningService_OreRanking_NoMiningSetup(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	market := &fakeMiningMarket{buyPriceByType: map[int]float64{
+		veldsparTypeID:  15.0,
+		tritaniumTypeID: 5.0,
+	}}
+	skills := &fakeMiningSkillsProvider{
+		skills:    &MiningReprocessingSkills{OreProcessing: map[int64]int{}},
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: nil} // no modules
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, nil, nil, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{
+		RegionID: 10000002,
+		SecBand:  "high",
+	})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+	if !resp.NoMiningSetup {
+		t.Fatal("expected NoMiningSetup=true (no modules)")
+	}
+	if len(resp.Rows) == 0 {
+		t.Fatal("expected per-m³ rows even with no mining setup")
+	}
+	for _, r := range resp.Rows {
+		if r.RawISKPerHour != 0 || r.RefineISKPerHour != 0 {
+			t.Errorf("isk/h must be 0 with no mining setup: %+v", r)
+		}
+		if r.MiningM3PerHour != 0 {
+			t.Errorf("MiningM3PerHour must be 0 with no mining setup: %v", r.MiningM3PerHour)
+		}
+	}
+}
+
+func approxEq(a, b float64) bool { return math.Abs(a-b) < 1e-6 }

--- a/backend/internal/services/mining_tax.go
+++ b/backend/internal/services/mining_tax.go
@@ -17,13 +17,16 @@ type StationStanding struct {
 	Standing  float64
 }
 
-// BestStation returns the station with the lowest reprocessing tax, or nil if none.
+// BestStation returns the station that yields the most refined material, i.e. the one
+// maximizing baseRate × (1 − tax), or nil if none. (Picking lowest tax alone is wrong when
+// stations in the same region differ in reprocessingEfficiency.)
 func BestStation(s []StationStanding) *StationStanding {
 	var best *StationStanding
-	bestTax := math.Inf(1)
+	bestScore := math.Inf(-1)
 	for i := range s {
-		if tax := ReprocessTax(s[i].BaseTake, s[i].Standing); tax < bestTax {
-			bestTax, best = tax, &s[i]
+		score := s[i].BaseRate * (1 - ReprocessTax(s[i].BaseTake, s[i].Standing))
+		if score > bestScore {
+			bestScore, best = score, &s[i]
 		}
 	}
 	return best

--- a/backend/internal/services/mining_tax.go
+++ b/backend/internal/services/mining_tax.go
@@ -1,0 +1,30 @@
+package services
+
+import "math"
+
+// ReprocessTax = max(0, baseTake − 0.0075·standing). baseTake is the station's
+// reprocessingStationsTake (0.05 for NPC); standing is the player's standing with
+// the station's owner corp. Reaches 0 at standing ≈ 6.67 (for baseTake 0.05).
+func ReprocessTax(baseTake, standing float64) float64 {
+	return math.Max(0, baseTake-0.0075*standing)
+}
+
+// StationStanding pairs a reprocessing station with the player's standing to its owner.
+type StationStanding struct {
+	StationID int64
+	BaseRate  float64 // reprocessingEfficiency (0.50)
+	BaseTake  float64 // reprocessingStationsTake (0.05)
+	Standing  float64
+}
+
+// BestStation returns the station with the lowest reprocessing tax, or nil if none.
+func BestStation(s []StationStanding) *StationStanding {
+	var best *StationStanding
+	bestTax := math.Inf(1)
+	for i := range s {
+		if tax := ReprocessTax(s[i].BaseTake, s[i].Standing); tax < bestTax {
+			bestTax, best = tax, &s[i]
+		}
+	}
+	return best
+}

--- a/backend/internal/services/mining_tax_test.go
+++ b/backend/internal/services/mining_tax_test.go
@@ -1,0 +1,26 @@
+package services
+
+import "testing"
+
+func TestReprocessTax(t *testing.T) {
+	if v := ReprocessTax(0.05, 0); v != 0.05 {
+		t.Fatalf("standing 0 → %v", v)
+	}
+	if v := ReprocessTax(0.05, 4); v < 0.0199 || v > 0.0201 { // 0.05 - 0.03
+		t.Fatalf("standing 4 → %v", v)
+	}
+	if v := ReprocessTax(0.05, 10); v != 0 {
+		t.Fatalf("standing 10 → %v", v)
+	}
+}
+
+func TestBestStation_PicksLowestTax(t *testing.T) {
+	stations := []StationStanding{
+		{StationID: 1, BaseTake: 0.05, Standing: 0},
+		{StationID: 2, BaseTake: 0.05, Standing: 6.67},
+	}
+	best := BestStation(stations)
+	if best == nil || best.StationID != 2 {
+		t.Fatalf("expected station 2 (zero tax), got %+v", best)
+	}
+}

--- a/backend/internal/services/mining_tax_test.go
+++ b/backend/internal/services/mining_tax_test.go
@@ -14,13 +14,25 @@ func TestReprocessTax(t *testing.T) {
 	}
 }
 
-func TestBestStation_PicksLowestTax(t *testing.T) {
+func TestBestStation_MaximizesNetYield(t *testing.T) {
+	// Same rate, station 2 has zero tax (standing ≥ 6.67) → more net material.
 	stations := []StationStanding{
-		{StationID: 1, BaseTake: 0.05, Standing: 0},
-		{StationID: 2, BaseTake: 0.05, Standing: 6.67},
+		{StationID: 1, BaseRate: 0.50, BaseTake: 0.05, Standing: 0},
+		{StationID: 2, BaseRate: 0.50, BaseTake: 0.05, Standing: 6.67},
 	}
-	best := BestStation(stations)
-	if best == nil || best.StationID != 2 {
+	if best := BestStation(stations); best == nil || best.StationID != 2 {
 		t.Fatalf("expected station 2 (zero tax), got %+v", best)
+	}
+}
+
+func TestBestStation_HigherRateBeatsLowerTax(t *testing.T) {
+	// Station A: rate 0.50, tax 0.05 → net 0.475. Station B: rate 0.35, tax 0 → net 0.35.
+	// A wins despite higher tax, because it refines more.
+	stations := []StationStanding{
+		{StationID: 1, BaseRate: 0.50, BaseTake: 0.05, Standing: 0},
+		{StationID: 2, BaseRate: 0.35, BaseTake: 0.0, Standing: 0},
+	}
+	if best := BestStation(stations); best == nil || best.StationID != 1 {
+		t.Fatalf("expected station 1 (higher net yield), got %+v", best)
 	}
 }

--- a/backend/internal/services/ore_secband.go
+++ b/backend/internal/services/ore_secband.go
@@ -1,0 +1,54 @@
+package services
+
+// Curated ore-group → security-band availability. The SDE does not cleanly encode
+// where each ore spawns, so this is a maintained mapping of the classic asteroid
+// ore groups. Group ids are from the SDE 'Asteroid' category. Special groups (Ice,
+// moon/deadspace/AIR asteroids, decorative) are intentionally excluded.
+//
+// Tiers are cumulative: lowsec includes highsec ores; nullsec includes lowsec ores.
+var (
+	highSecOreGroups = []int64{
+		462, // Veldspar
+		460, // Scordite
+		458, // Plagioclase
+		459, // Pyroxeres
+		469, // Omber
+		457, // Kernite
+		456, // Jaspet
+		455, // Hemorphite
+		454, // Hedbergite
+	}
+	lowSecExtraOreGroups = []int64{
+		467, // Gneiss
+		453, // Dark Ochre
+		452, // Crokite
+	}
+	nullSecExtraOreGroups = []int64{
+		450, // Arkonor
+		451, // Bistot
+		461, // Spodumain
+		468, // Mercoxit
+	}
+)
+
+// secBandOreGroups returns the set of ore group ids available in a security band.
+// Unknown bands return an empty set.
+func secBandOreGroups(band string) map[int64]bool {
+	out := map[int64]bool{}
+	add := func(ids []int64) {
+		for _, id := range ids {
+			out[id] = true
+		}
+	}
+	switch band {
+	case "null":
+		add(nullSecExtraOreGroups)
+		fallthrough
+	case "low":
+		add(lowSecExtraOreGroups)
+		fallthrough
+	case "high":
+		add(highSecOreGroups)
+	}
+	return out
+}

--- a/backend/internal/services/ore_secband_test.go
+++ b/backend/internal/services/ore_secband_test.go
@@ -1,0 +1,25 @@
+package services
+
+import "testing"
+
+func TestSecBandOreGroups(t *testing.T) {
+	high := secBandOreGroups("high")
+	if !high[462] || !high[460] { // Veldspar, Scordite
+		t.Fatal("highsec must include Veldspar (462) + Scordite (460)")
+	}
+	if high[450] { // Arkonor
+		t.Fatal("highsec must NOT include Arkonor (450)")
+	}
+
+	null := secBandOreGroups("null")
+	if !null[450] {
+		t.Fatal("nullsec must include Arkonor (450)")
+	}
+	if !null[462] || !null[452] { // cumulative: highsec Veldspar + lowsec Crokite
+		t.Fatal("nullsec must include highsec + lowsec ores")
+	}
+
+	if len(secBandOreGroups("bogus")) != 0 {
+		t.Fatal("unknown band must be empty")
+	}
+}

--- a/backend/internal/services/standings_service.go
+++ b/backend/internal/services/standings_service.go
@@ -1,0 +1,176 @@
+// Package services - Standings + mining/reprocessing skill fetching (ore-ranking, #mining).
+package services
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/services/esiconfig"
+)
+
+// Reprocessing / mining skill type ids (SDE).
+const (
+	skillReprocessing           = 3385 // +3%/level reprocessing yield
+	skillReprocessingEfficiency = 3389 // +2%/level reprocessing yield
+	skillMining                 = 3386 // +5%/level mining amount
+	skillAstrogeology           = 3410 // +5%/level mining amount
+)
+
+// MiningReprocessingSkills holds the ore-ranking-relevant skill levels for a character.
+// OreProcessing maps an ore GROUP id → that group's "<Group> Processing" skill level
+// (e.g. Veldspar Processing). Missing/untrained groups are absent (treated as level 0).
+type MiningReprocessingSkills struct {
+	Reprocessing           int
+	ReprocessingEfficiency int
+	Mining                 int
+	Astrogeology           int
+	Accounting             int           // sales tax (reused via SalesTaxRate)
+	OreProcessing          map[int64]int // ore groupID → processing skill level
+}
+
+// parseStandings parses an ESI /characters/{id}/standings/ body into a map of
+// from_id → standing. Pure helper (unit-tested with a fixture, no HTTP).
+func parseStandings(body []byte) (map[int64]float64, error) {
+	var rows []struct {
+		FromType string  `json:"from_type"`
+		FromID   int64   `json:"from_id"`
+		Standing float64 `json:"standing"`
+	}
+	if err := json.Unmarshal(body, &rows); err != nil {
+		return nil, fmt.Errorf("decode standings: %w", err)
+	}
+	out := make(map[int64]float64, len(rows))
+	for _, r := range rows {
+		out[r.FromID] = r.Standing
+	}
+	return out, nil
+}
+
+// GetCharacterStandings fetches the character's standings (ESI /characters/{id}/standings/)
+// and returns a map of from_id → standing. 401/403 (no standings) yields an empty map, not
+// an error, so a character without standings still ranks ores (at base reprocessing tax).
+func (s *SkillsService) GetCharacterStandings(ctx context.Context, characterID int, accessToken string) (map[int64]float64, error) {
+	endpoint := fmt.Sprintf("/v2/characters/%d/standings/", characterID)
+	req, err := http.NewRequestWithContext(ctx, "GET", esiconfig.BaseURL+endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create standings request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := s.esiClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("standings request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return map[int64]float64{}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ESI standings returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read standings body: %w", err)
+	}
+	return parseStandings(body)
+}
+
+// GetMiningReprocessingSkills fetches the character's mining/reprocessing skill levels,
+// including the per-ore-group "<Group> Processing" levels (mapped via SDE name lookup).
+// On an ESI failure it returns all-zero skills + the error so the caller can fail loud or
+// degrade. The ore-group processing levels are populated only for groups whose processing
+// skill the character has trained (others default to 0).
+func (s *SkillsService) GetMiningReprocessingSkills(ctx context.Context, sdeDB *sql.DB, characterID int, accessToken string) (*MiningReprocessingSkills, error) {
+	esiSkills, err := s.fetchSkillsFromESI(ctx, characterID, accessToken)
+	if err != nil {
+		return &MiningReprocessingSkills{OreProcessing: map[int64]int{}}, fmt.Errorf("mining skills unavailable: %w", err)
+	}
+
+	out := &MiningReprocessingSkills{OreProcessing: map[int64]int{}}
+	// skillType id → level, for resolving ore-group processing skills below.
+	levelByType := make(map[int64]int, len(esiSkills.Skills))
+	for _, sk := range esiSkills.Skills {
+		levelByType[int64(sk.SkillID)] = sk.ActiveSkillLevel
+		switch sk.SkillID {
+		case skillReprocessing:
+			out.Reprocessing = sk.ActiveSkillLevel
+		case skillReprocessingEfficiency:
+			out.ReprocessingEfficiency = sk.ActiveSkillLevel
+		case skillMining:
+			out.Mining = sk.ActiveSkillLevel
+		case skillAstrogeology:
+			out.Astrogeology = sk.ActiveSkillLevel
+		case 16622: // Accounting (sales tax)
+			out.Accounting = sk.ActiveSkillLevel
+		}
+	}
+
+	// Resolve per-ore-group processing skill levels: groupID → "<Group> Processing"
+	// skill type id (SDE, cached) → level from the character's skills.
+	for groupID, skillTypeID := range s.oreProcessingSkillTypes(ctx, sdeDB) {
+		if lvl, ok := levelByType[skillTypeID]; ok {
+			out.OreProcessing[groupID] = lvl
+		}
+	}
+
+	return out, nil
+}
+
+// oreProcessingSkillCache caches the groupID → "<Group> Processing" skill type id map.
+var (
+	oreProcessingSkillCache   map[int64]int64
+	oreProcessingSkillCacheMu sync.Mutex
+)
+
+// oreProcessingSkillTypes returns groupID → "<Group> Processing" skill type id for all
+// asteroid ore groups, resolved by SDE name lookup and cached process-wide. A group whose
+// processing skill cannot be resolved is omitted (its level stays 0). On any SDE error it
+// returns whatever was resolved (best-effort: ore-specific bonus simply not applied).
+func (s *SkillsService) oreProcessingSkillTypes(ctx context.Context, sdeDB *sql.DB) map[int64]int64 {
+	oreProcessingSkillCacheMu.Lock()
+	defer oreProcessingSkillCacheMu.Unlock()
+	if oreProcessingSkillCache != nil {
+		return oreProcessingSkillCache
+	}
+
+	out := map[int64]int64{}
+	if sdeDB == nil {
+		return out
+	}
+
+	// For each asteroid ore group, the matching skill is "<GroupName> Processing"
+	// (e.g. Veldspar Processing). A few groups use "<GroupName> Ore Processing"
+	// (e.g. Mercoxit Ore Processing) — match both forms.
+	rows, err := sdeDB.QueryContext(ctx, `
+		SELECT g._key, st._key
+		FROM groups g
+		JOIN categories c ON g.categoryID = c._key
+		JOIN types st ON json_extract(st.name,'$.en') IN (
+			json_extract(g.name,'$.en') || ' Processing',
+			json_extract(g.name,'$.en') || ' Ore Processing'
+		)
+		WHERE json_extract(c.name,'$.en') = 'Asteroid'`)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("ore processing skill lookup failed", "error", err)
+		}
+		return out
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var groupID, skillTypeID int64
+		if err := rows.Scan(&groupID, &skillTypeID); err != nil {
+			continue
+		}
+		out[groupID] = skillTypeID
+	}
+	oreProcessingSkillCache = out
+	return out
+}

--- a/backend/internal/services/standings_service_test.go
+++ b/backend/internal/services/standings_service_test.go
@@ -1,0 +1,50 @@
+package services
+
+import "testing"
+
+// TestParseStandings verifies the pure standings parser against an ESI-shaped fixture.
+func TestParseStandings(t *testing.T) {
+	fixture := []byte(`[
+		{"from_type":"npc_corp","from_id":1000035,"standing":7.5},
+		{"from_type":"faction","from_id":500003,"standing":2.25},
+		{"from_type":"agent","from_id":3008416,"standing":-1.0}
+	]`)
+
+	got, err := parseStandings(fixture)
+	if err != nil {
+		t.Fatalf("parseStandings returned error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(got))
+	}
+	if got[1000035] != 7.5 {
+		t.Errorf("npc_corp standing: got %v, want 7.5", got[1000035])
+	}
+	if got[500003] != 2.25 {
+		t.Errorf("faction standing: got %v, want 2.25", got[500003])
+	}
+	if got[3008416] != -1.0 {
+		t.Errorf("agent standing: got %v, want -1.0", got[3008416])
+	}
+}
+
+// TestParseStandings_Empty verifies an empty array yields an empty (non-nil) map.
+func TestParseStandings_Empty(t *testing.T) {
+	got, err := parseStandings([]byte(`[]`))
+	if err != nil {
+		t.Fatalf("parseStandings returned error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(got))
+	}
+}
+
+// TestParseStandings_Invalid verifies malformed JSON returns an error.
+func TestParseStandings_Invalid(t *testing.T) {
+	if _, err := parseStandings([]byte(`{not json`)); err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}

--- a/backend/pkg/evedb/mining/mining.go
+++ b/backend/pkg/evedb/mining/mining.go
@@ -1,0 +1,68 @@
+// Package mining computes deterministic ore-mining yield (m³/hour) from a ship's
+// fitted mining modules + the character's mining skills, using the SDE dogma.
+package mining
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// MiningSkills holds the yield-relevant mining skill levels.
+type MiningSkills struct {
+	Mining       int // +5%/level
+	Astrogeology int // +5%/level
+}
+
+const (
+	attrMiningAmount = 77 // m³ per cycle
+	attrDuration     = 73 // cycle time, milliseconds
+)
+
+// MiningRateM3PerHour sums m³/hour over the given mining module type ids. Modules
+// without a miningAmount attribute are skipped (not mining lasers). crystalMul scales
+// the per-cycle yield for an ore-specific crystal (1.0 = none). Skills Mining +
+// Astrogeology give +5%/level each.
+func MiningRateM3PerHour(db *sql.DB, moduleTypeIDs []int64, skills MiningSkills, crystalMul float64) (float64, error) {
+	skillMul := (1 + 0.05*float64(skills.Mining)) * (1 + 0.05*float64(skills.Astrogeology))
+	var total float64
+	for _, tid := range moduleTypeIDs {
+		amount, durationMs, ok, err := moduleMiningAttrs(db, tid)
+		if err != nil {
+			return 0, err
+		}
+		if !ok || durationMs <= 0 {
+			continue
+		}
+		perCycle := amount * skillMul * crystalMul
+		total += perCycle / (durationMs / 1000.0) * 3600.0
+	}
+	return total, nil
+}
+
+func moduleMiningAttrs(db *sql.DB, typeID int64) (amount, durationMs float64, ok bool, err error) {
+	var attrsJSON sql.NullString
+	err = db.QueryRow(`SELECT dogmaAttributes FROM typeDogma WHERE _key = ?`, typeID).Scan(&attrsJSON)
+	if err == sql.ErrNoRows {
+		return 0, 0, false, nil
+	}
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("mining attrs %d: %w", typeID, err)
+	}
+	if !attrsJSON.Valid || attrsJSON.String == "" {
+		return 0, 0, false, nil
+	}
+	var attrs []struct {
+		AttributeID int64   `json:"attributeID"`
+		Value       float64 `json:"value"`
+	}
+	if err := json.Unmarshal([]byte(attrsJSON.String), &attrs); err != nil {
+		return 0, 0, false, fmt.Errorf("parse dogma %d: %w", typeID, err)
+	}
+	m := make(map[int64]float64, len(attrs))
+	for _, a := range attrs {
+		m[a.AttributeID] = a.Value
+	}
+	amount, hasAmount := m[attrMiningAmount]
+	return amount, m[attrDuration], hasAmount, nil
+}

--- a/backend/pkg/evedb/mining/mining_test.go
+++ b/backend/pkg/evedb/mining/mining_test.go
@@ -1,0 +1,33 @@
+package mining
+
+import (
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestMiningRate_OneStripMinerI(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	// Strip Miner I (17482): attr77=150 m³, attr73=45000 ms. Mining 5 (+25%), Astrogeology 5 (+25%).
+	m3h, err := MiningRateM3PerHour(db, []int64{17482}, MiningSkills{Mining: 5, Astrogeology: 5}, 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// per cycle 150 × 1.25 × 1.25 = 234.375 m³ / 45 s × 3600 = 18750 m³/h
+	if m3h < 18740 || m3h > 18760 {
+		t.Fatalf("m3/h %.1f (want ~18750)", m3h)
+	}
+}
+
+func TestMiningRate_NonMiningModuleSkipped(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	// A non-mining type (e.g. Tritanium 34) has no miningAmount → contributes 0.
+	m3h, err := MiningRateM3PerHour(db, []int64{34}, MiningSkills{Mining: 5, Astrogeology: 5}, 1.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m3h != 0 {
+		t.Fatalf("non-mining module should contribute 0, got %.1f", m3h)
+	}
+}

--- a/backend/pkg/evedb/reprocessing/reprocessing.go
+++ b/backend/pkg/evedb/reprocessing/reprocessing.go
@@ -68,3 +68,19 @@ func ListOres(db *sql.DB) ([]Ore, error) {
 	}
 	return out, rows.Err()
 }
+
+// ReprocessingSkills holds the character's reprocessing-relevant skill levels.
+type ReprocessingSkills struct {
+	Reprocessing           int // +3%/level
+	ReprocessingEfficiency int // +2%/level
+	OreProcessing          int // ore-specific "<Ore> Processing", +2%/level
+}
+
+// NetYield = baseRate × (1+0.03·R) × (1+0.02·RE) × (1+0.02·OP).
+// baseRate is the station's reprocessingEfficiency (0.50 for NPC stations).
+func NetYield(baseRate float64, s ReprocessingSkills) float64 {
+	return baseRate *
+		(1 + 0.03*float64(s.Reprocessing)) *
+		(1 + 0.02*float64(s.ReprocessingEfficiency)) *
+		(1 + 0.02*float64(s.OreProcessing))
+}

--- a/backend/pkg/evedb/reprocessing/reprocessing.go
+++ b/backend/pkg/evedb/reprocessing/reprocessing.go
@@ -1,0 +1,70 @@
+// Package reprocessing provides SDE ore catalog and reprocessing output queries.
+package reprocessing
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// Material represents a single output material from reprocessing an ore.
+type Material struct {
+	MaterialTypeID int64 `json:"materialTypeID"`
+	Quantity       int64 `json:"quantity"`
+}
+
+// Ore represents an asteroid ore type with its reprocessing output.
+type Ore struct {
+	TypeID      int64
+	Name        string
+	GroupID     int64
+	PortionSize int64
+	VolumeM3    float64
+	Materials   []Material
+}
+
+// GetOre returns a single ore type by its typeID, including reprocessing materials.
+func GetOre(db *sql.DB, oreTypeID int64) (*Ore, error) {
+	var o Ore
+	var matsJSON sql.NullString
+	err := db.QueryRow(`
+		SELECT t._key, COALESCE(json_extract(t.name,'$.en'),'?'), t.groupID,
+		       COALESCE(t.portionSize,1), COALESCE(t.volume,0), tm.materials
+		FROM types t LEFT JOIN typeMaterials tm ON tm._key = t._key
+		WHERE t._key = ?`, oreTypeID).
+		Scan(&o.TypeID, &o.Name, &o.GroupID, &o.PortionSize, &o.VolumeM3, &matsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("get ore %d: %w", oreTypeID, err)
+	}
+	if matsJSON.Valid && matsJSON.String != "" {
+		if err := json.Unmarshal([]byte(matsJSON.String), &o.Materials); err != nil {
+			return nil, fmt.Errorf("parse materials for %d: %w", oreTypeID, err)
+		}
+	}
+	return &o, nil
+}
+
+// ListOres returns all published asteroid ore types from the SDE.
+func ListOres(db *sql.DB) ([]Ore, error) {
+	rows, err := db.Query(`
+		SELECT t._key, COALESCE(json_extract(t.name,'$.en'),'?'), t.groupID,
+		       COALESCE(t.portionSize,1), COALESCE(t.volume,0)
+		FROM types t
+		JOIN groups g ON t.groupID = g._key
+		JOIN categories c ON g.categoryID = c._key
+		WHERE json_extract(c.name,'$.en') = 'Asteroid' AND t.published = 1
+		ORDER BY t._key`)
+	if err != nil {
+		return nil, fmt.Errorf("list ores: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []Ore
+	for rows.Next() {
+		var o Ore
+		if err := rows.Scan(&o.TypeID, &o.Name, &o.GroupID, &o.PortionSize, &o.VolumeM3); err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}

--- a/backend/pkg/evedb/reprocessing/reprocessing_test.go
+++ b/backend/pkg/evedb/reprocessing/reprocessing_test.go
@@ -40,3 +40,12 @@ func TestListOres_IncludesVeldsparAndExcludesNonOre(t *testing.T) {
 		t.Fatalf("expected many ores, got %d", len(ores))
 	}
 }
+
+func TestNetYield(t *testing.T) {
+	// base 0.50, Reprocessing 5 (+15%), Reprocessing Efficiency 5 (+10%), ore skill 4 (+8%)
+	got := NetYield(0.50, ReprocessingSkills{Reprocessing: 5, ReprocessingEfficiency: 5, OreProcessing: 4})
+	want := 0.50 * 1.15 * 1.10 * 1.08
+	if diff := got - want; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("want %.6f got %.6f", want, got)
+	}
+}

--- a/backend/pkg/evedb/reprocessing/reprocessing_test.go
+++ b/backend/pkg/evedb/reprocessing/reprocessing_test.go
@@ -1,0 +1,42 @@
+package reprocessing
+
+import (
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestOreOutput_Veldspar(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	ore, err := GetOre(db, 1230)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ore.PortionSize != 100 || ore.VolumeM3 != 0.1 {
+		t.Fatalf("portion/volume: %d / %v", ore.PortionSize, ore.VolumeM3)
+	}
+	if len(ore.Materials) != 1 || ore.Materials[0].MaterialTypeID != 34 || ore.Materials[0].Quantity != 400 {
+		t.Fatalf("materials: %+v", ore.Materials)
+	}
+}
+
+func TestListOres_IncludesVeldsparAndExcludesNonOre(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	ores, err := ListOres(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, o := range ores {
+		if o.TypeID == 1230 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Veldspar (1230) missing from ore list")
+	}
+	if len(ores) < 10 {
+		t.Fatalf("expected many ores, got %d", len(ores))
+	}
+}

--- a/docs/superpowers/plans/2026-05-31-mining-ore-refine-ranking.md
+++ b/docs/superpowers/plans/2026-05-31-mining-ore-refine-ranking.md
@@ -1,0 +1,502 @@
+# Mining ore sell-vs-refine ranking — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A "Mining" view that ranks ores by ISK/hour and, per ore, says whether to sell the raw ore or reprocess + sell the materials — using the current ship's mining rate, reprocessing/trade skills, region buy-order prices, and the best NPC reprocessing station by standing.
+
+**Architecture:** New backend deterministic calcs (reprocessing yield, mining yield) built on the existing `pkg/evedb` + `pkg/evedb/dogma` patterns, a new `MiningService` + `POST /api/v1/mining/ore-ranking` endpoint reusing the market repo + skills service, plus a new ESI `/standings` fetch. New web + Flutter "Mining" views mirroring the existing trading views.
+
+**Tech Stack:** Go 1.24 / Fiber, SQLite SDE (`pkg/evedb`), Next.js 16 / React / TS (web), Flutter/Dart (`app/`).
+
+Spec: `docs/superpowers/specs/2026-05-31-mining-ore-refine-ranking-design.md`.
+
+**Verification env:** backend SDE tests use `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db` + `GOWORK=off`. Commits: prefix with `PATH="$HOME/.local/bin:$PATH"` (gitleaks). golangci-lint must be 0 issues. Branch: `feat/mining-ore-ranking` (already created).
+
+**Confirmed SDE facts (use directly):**
+- Ores = `types` in `groups` whose `categories.name.en = 'Asteroid'`, `published=1`. Each has `portionSize` (reprocess batch, e.g. Veldspar 100) and `volume` m³/unit (Veldspar 0.1).
+- Reprocess output: `typeMaterials.materials` is JSON `[{"materialTypeID":34,"quantity":400}]` keyed by ore `_key` (Veldspar 1230 → 400 Tritanium per 100 units).
+- NPC stations: `npcStations(_key, ownerID, reprocessingEfficiency=0.5, reprocessingStationsTake=0.05, solarSystemID, typeID)`. Region via `mapSolarSystems`→`regionID` (see `SDERepository.GetRegionIDForSystem`).
+- Mining modules: dogma attr **77** = `miningAmount` (m³/cycle, Strip Miner I = 150), attr **73** = `duration` ms (Strip Miner I = 45000).
+- Skills (confirm ids via SDE in-task): Reprocessing **3385**, Reprocessing Efficiency **3389**, ore-specific "<Ore> Processing" (e.g. Veldspar Processing **12195**), Mining **3386**, Astrogeology **3410**.
+
+---
+
+## PHASE 1 — Backend core: reprocessing yield + market taker + comparison + ranking + best station
+
+### Task 1: Ore catalog + reprocessing output (SDE)
+
+**Files:** Create `backend/pkg/evedb/reprocessing/reprocessing.go` + `..._test.go`.
+
+- [ ] **Step 1 — failing test** (`reprocessing_test.go`), against the local SDE:
+```go
+package reprocessing
+
+import (
+	"testing"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
+)
+
+func TestOreOutput_Veldspar(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	ore, err := GetOre(db, 1230) // Veldspar
+	if err != nil { t.Fatal(err) }
+	if ore.PortionSize != 100 || ore.VolumeM3 != 0.1 {
+		t.Fatalf("portion/volume: %d / %v", ore.PortionSize, ore.VolumeM3)
+	}
+	// Veldspar reprocesses to 400 Tritanium (type 34) per 100-unit portion.
+	if len(ore.Materials) != 1 || ore.Materials[0].MaterialTypeID != 34 || ore.Materials[0].Quantity != 400 {
+		t.Fatalf("materials: %+v", ore.Materials)
+	}
+}
+
+func TestListOres_IncludesVeldsparAndExcludesNonOre(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	ores, err := ListOres(db)
+	if err != nil { t.Fatal(err) }
+	var found bool
+	for _, o := range ores { if o.TypeID == 1230 { found = true } }
+	if !found { t.Fatal("Veldspar (1230) missing from ore list") }
+	if len(ores) < 10 { t.Fatalf("expected many ores, got %d", len(ores)) }
+}
+```
+
+- [ ] **Step 2 — run, expect compile failure.** `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./pkg/evedb/reprocessing/ -v`
+
+- [ ] **Step 3 — implement** `reprocessing.go`:
+```go
+package reprocessing
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+type Material struct {
+	MaterialTypeID int64 `json:"materialTypeID"`
+	Quantity       int64 `json:"quantity"`
+}
+
+type Ore struct {
+	TypeID      int64
+	Name        string
+	GroupID     int64
+	PortionSize int64
+	VolumeM3    float64
+	Materials   []Material
+}
+
+// GetOre loads one ore's reprocessing portion + output materials.
+func GetOre(db *sql.DB, oreTypeID int64) (*Ore, error) {
+	var o Ore
+	var matsJSON sql.NullString
+	err := db.QueryRow(`
+		SELECT t._key, COALESCE(json_extract(t.name,'$.en'),'?'), t.groupID,
+		       COALESCE(t.portionSize,1), COALESCE(t.volume,0), tm.materials
+		FROM types t LEFT JOIN typeMaterials tm ON tm._key = t._key
+		WHERE t._key = ?`, oreTypeID).Scan(&o.TypeID, &o.Name, &o.GroupID, &o.PortionSize, &o.VolumeM3, &matsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("get ore %d: %w", oreTypeID, err)
+	}
+	if matsJSON.Valid && matsJSON.String != "" {
+		if err := json.Unmarshal([]byte(matsJSON.String), &o.Materials); err != nil {
+			return nil, fmt.Errorf("parse materials for %d: %w", oreTypeID, err)
+		}
+	}
+	return &o, nil
+}
+
+// ListOres returns all published asteroid ores (category 'Asteroid').
+func ListOres(db *sql.DB) ([]Ore, error) {
+	rows, err := db.Query(`
+		SELECT t._key, COALESCE(json_extract(t.name,'$.en'),'?'), t.groupID,
+		       COALESCE(t.portionSize,1), COALESCE(t.volume,0)
+		FROM types t
+		JOIN groups g ON t.groupID = g._key
+		JOIN categories c ON g.categoryID = c._key
+		WHERE json_extract(c.name,'$.en') = 'Asteroid' AND t.published = 1
+		ORDER BY t._key`)
+	if err != nil { return nil, fmt.Errorf("list ores: %w", err) }
+	defer func() { _ = rows.Close() }()
+	var out []Ore
+	for rows.Next() {
+		var o Ore
+		if err := rows.Scan(&o.TypeID, &o.Name, &o.GroupID, &o.PortionSize, &o.VolumeM3); err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+```
+> `ListOres` intentionally omits materials (loaded per-ore via `GetOre` when needed) to keep the list query cheap.
+
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `PATH="$HOME/.local/bin:$PATH" git add backend/pkg/evedb/reprocessing/ && PATH="$HOME/.local/bin:$PATH" git commit -m "feat(backend): SDE ore catalog + reprocessing output"`
+
+### Task 2: Reprocessing yield from skills
+
+**Files:** add to `backend/pkg/evedb/reprocessing/reprocessing.go`; test in `reprocessing_test.go`.
+
+- [ ] **Step 1 — failing test:**
+```go
+func TestNetYield(t *testing.T) {
+	// base 0.50, Reprocessing 5 (+15%), Reprocessing Efficiency 5 (+10%), ore skill 4 (+8%)
+	got := NetYield(0.50, ReprocessingSkills{Reprocessing: 5, ReprocessingEfficiency: 5, OreProcessing: 4})
+	want := 0.50 * 1.15 * 1.10 * 1.08
+	if diff := got - want; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("want %.6f got %.6f", want, got)
+	}
+}
+```
+
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:**
+```go
+type ReprocessingSkills struct {
+	Reprocessing           int // +3%/level
+	ReprocessingEfficiency int // +2%/level
+	OreProcessing          int // ore-specific, +2%/level
+}
+
+// NetYield = base × (1+0.03·R) × (1+0.02·RE) × (1+0.02·OP). base = station reprocessingEfficiency (0.50 NPC).
+func NetYield(baseRate float64, s ReprocessingSkills) float64 {
+	return baseRate *
+		(1 + 0.03*float64(s.Reprocessing)) *
+		(1 + 0.02*float64(s.ReprocessingEfficiency)) *
+		(1 + 0.02*float64(s.OreProcessing))
+}
+```
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `... -m "feat(backend): reprocessing net-yield from skills"`
+
+### Task 3: Best NPC reprocessing station in a region (by standing)
+
+**Files:** add `GetRegionReprocessStations` to `backend/internal/database/sde.go` (mirror existing `SDERepository` methods); test `backend/internal/database/sde_reprocess_test.go`.
+
+- [ ] **Step 1 — failing test** (The Forge = 10000002 has many NPC stations):
+```go
+func TestGetRegionReprocessStations_TheForge(t *testing.T) {
+	r := newTestSDERepo(t) // mirror the existing sde_test.go setup
+	st, err := r.GetRegionReprocessStations(context.Background(), 10000002)
+	if err != nil { t.Fatal(err) }
+	if len(st) == 0 { t.Fatal("no reprocess stations in The Forge") }
+	for _, s := range st {
+		if s.BaseRate <= 0 || s.BaseTake < 0 || s.OwnerCorpID == 0 {
+			t.Fatalf("bad station row: %+v", s)
+		}
+	}
+}
+```
+> Read `backend/internal/database/sde_test.go` for the exact repo-construction helper and mirror it (don't invent `newTestSDERepo` if a differently-named helper exists).
+
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** in `sde.go`:
+```go
+type ReprocessStation struct {
+	StationID   int64
+	OwnerCorpID int64
+	BaseRate    float64 // reprocessingEfficiency (0.50)
+	BaseTake    float64 // reprocessingStationsTake (0.05)
+}
+
+// GetRegionReprocessStations lists NPC stations with reprocessing in a region.
+func (r *SDERepository) GetRegionReprocessStations(ctx context.Context, regionID int) ([]ReprocessStation, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT n._key, n.ownerID, COALESCE(n.reprocessingEfficiency,0), COALESCE(n.reprocessingStationsTake,0)
+		FROM npcStations n
+		JOIN mapSolarSystems s ON n.solarSystemID = s._key
+		JOIN constellations cn ON s.constellationID = cn._key
+		WHERE cn.regionID = ? AND COALESCE(n.reprocessingEfficiency,0) > 0`, regionID)
+	if err != nil { return nil, fmt.Errorf("region reprocess stations: %w", err) }
+	defer func() { _ = rows.Close() }()
+	var out []ReprocessStation
+	for rows.Next() {
+		var s ReprocessStation
+		if err := rows.Scan(&s.StationID, &s.OwnerCorpID, &s.BaseRate, &s.BaseTake); err != nil { return nil, err }
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+```
+> Verify the `mapSolarSystems`→region join columns against the SDE before finalizing (the repo already joins to region in `GetRegionIDForSystem` — reuse that exact join shape: it may go `mapSolarSystems.constellationID → constellations.regionID`, or a direct `regionID`. Match what `GetRegionIDForSystem` does).
+
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `... -m "feat(backend): list region NPC reprocessing stations"`
+
+### Task 4: Reprocessing tax from standing + best-station selection (pure logic)
+
+**Files:** `backend/internal/services/mining_tax.go` + `mining_tax_test.go`.
+
+- [ ] **Step 1 — failing test:**
+```go
+func TestReprocessTax(t *testing.T) {
+	// tax = max(0, baseTake − 0.0075·standing)
+	if v := ReprocessTax(0.05, 0); v != 0.05 { t.Fatalf("standing 0 → %v", v) }
+	if v := ReprocessTax(0.05, 4); v < 0.0199 || v > 0.0201 { t.Fatalf("standing 4 → %v", v) } // 0.05-0.03
+	if v := ReprocessTax(0.05, 10); v != 0 { t.Fatalf("standing 10 → %v", v) }
+}
+
+func TestBestStation_PicksLowestTax(t *testing.T) {
+	stations := []StationStanding{{StationID: 1, BaseTake: 0.05, Standing: 0}, {StationID: 2, BaseTake: 0.05, Standing: 6.67}}
+	best := BestStation(stations)
+	if best == nil || best.StationID != 2 { t.Fatalf("expected station 2 (zero tax), got %+v", best) }
+}
+```
+
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:**
+```go
+package services
+
+import "math"
+
+func ReprocessTax(baseTake, standing float64) float64 {
+	return math.Max(0, baseTake-0.0075*standing)
+}
+
+type StationStanding struct {
+	StationID int64
+	BaseRate  float64
+	BaseTake  float64
+	Standing  float64 // player's standing with the station's owner corp
+}
+
+// BestStation returns the station with the lowest reprocessing tax (nil if none).
+func BestStation(s []StationStanding) *StationStanding {
+	var best *StationStanding
+	bestTax := math.Inf(1)
+	for i := range s {
+		if tax := ReprocessTax(s[i].BaseTake, s[i].Standing); tax < bestTax {
+			bestTax, best = tax, &s[i]
+		}
+	}
+	return best
+}
+```
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `... -m "feat(backend): reprocessing tax + best-station logic"`
+
+### Task 5: Per-ore comparison (raw vs refine, taker, net ISK/m³) — pure logic
+
+**Files:** `backend/internal/services/mining_compare.go` + `mining_compare_test.go`.
+
+Inputs are already-resolved buy prices (ISK/unit) so this is pure and fully testable.
+
+- [ ] **Step 1 — failing test:**
+```go
+func TestCompareOre_RefineWins(t *testing.T) {
+	in := OreCompareInput{
+		PortionSize: 100, OreVolumeM3: 0.1, OreBuyPrice: 8.0, // ore ISK/unit
+		Materials: []MaterialValue{{Qty: 400, BuyPrice: 5.0}}, // 400 mineral @5 per 100 ore
+		NetYield: 0.90, StationTake: 0.02, SalesTaxRate: 0.04,
+	}
+	r := CompareOre(in)
+	// raw: per ore unit 8 net of 4% tax = 7.68 → per m³ /0.1 = 76.8
+	// refine per 100 ore: 400*0.90*5 = 1800 gross, minus 2% station take = 1764, minus 4% sales tax = 1693.44; per ore unit /100 = 16.9344; per m³ /0.1 = 169.344
+	if r.RawNetPerM3 < 76.7 || r.RawNetPerM3 > 76.9 { t.Fatalf("raw/m3 %.4f", r.RawNetPerM3) }
+	if r.RefineNetPerM3 < 169.3 || r.RefineNetPerM3 > 169.4 { t.Fatalf("refine/m3 %.4f", r.RefineNetPerM3) }
+	if r.Best != "refine" { t.Fatalf("best %s", r.Best) }
+}
+
+func TestCompareOre_RawWins(t *testing.T) {
+	in := OreCompareInput{PortionSize: 100, OreVolumeM3: 0.1, OreBuyPrice: 100, Materials: []MaterialValue{{Qty: 400, BuyPrice: 1}}, NetYield: 0.5, StationTake: 0.05, SalesTaxRate: 0.04}
+	if CompareOre(in).Best != "raw" { t.Fatal("raw should win") }
+}
+```
+
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:**
+```go
+package services
+
+type MaterialValue struct {
+	Qty      int64   // material output per ONE portionSize batch (from typeMaterials)
+	BuyPrice float64 // ISK/unit highest buy order
+}
+
+type OreCompareInput struct {
+	PortionSize  int64
+	OreVolumeM3  float64
+	OreBuyPrice  float64
+	Materials    []MaterialValue
+	NetYield     float64 // reprocessing.NetYield(...) for the best station
+	StationTake  float64 // ReprocessTax(...) for the best station
+	SalesTaxRate float64 // from Accounting skill
+}
+
+type OreCompareResult struct {
+	RawNetPerM3    float64
+	RefineNetPerM3 float64
+	Best           string // "raw" | "refine"
+	DeltaPerM3     float64
+}
+
+func CompareOre(in OreCompareInput) OreCompareResult {
+	salesMul := 1 - in.SalesTaxRate
+	// raw: ISK per ore unit, net of sales tax, per m³
+	rawPerM3 := in.OreBuyPrice * salesMul / in.OreVolumeM3
+	// refine: value of one portionSize batch → per ore unit → per m³
+	var batchGross float64
+	for _, m := range in.Materials {
+		batchGross += float64(m.Qty) * in.NetYield * m.BuyPrice
+	}
+	batchNet := batchGross * (1 - in.StationTake) * salesMul
+	refinePerUnit := batchNet / float64(in.PortionSize)
+	refinePerM3 := refinePerUnit / in.OreVolumeM3
+	r := OreCompareResult{RawNetPerM3: rawPerM3, RefineNetPerM3: refinePerM3}
+	if refinePerM3 >= rawPerM3 { r.Best = "refine" } else { r.Best = "raw" }
+	r.DeltaPerM3 = abs(refinePerM3 - rawPerM3)
+	return r
+}
+
+func abs(f float64) float64 { if f < 0 { return -f }; return f }
+```
+> If `abs` collides with an existing helper in `package services`, reuse the existing one and drop this.
+
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `... -m "feat(backend): per-ore raw-vs-refine taker comparison"`
+
+### Task 6: MiningService.OreRanking orchestration (no mining yield yet) + endpoint
+
+**Files:** Create `backend/internal/services/mining_service.go`, `backend/internal/handlers/mining.go`, `backend/internal/models/mining.go`; register route in `cmd/api/main.go` + wire in the container (`internal/container/*.go`). Test `backend/internal/services/mining_service_test.go`.
+
+The service: for the region's in-scope ores → buy prices (market repo) + reprocessing skills + best station per ore (standings) → `CompareOre` → ranked rows. Until Phase 2, `MiningM3PerHour = 0` and ranking falls back to `best net ISK/m³` (the response includes both, the row's `isk_per_hour` = 0 for now; sort by `best_net_per_m3`).
+
+- [ ] **Step 1 — read** these for exact interfaces, then write the service against them: `internal/database/market.go` (buy-order accessor + `Order` struct fields), `internal/services/skills_service.go` (`GetCharacterSkills` → `TradingSkills`; the sales-tax/Accounting field), `internal/handlers/portfolio.go` + `cmd/api/main.go:156` (route + handler + auth-middleware pattern), `internal/container` (how services/handlers are constructed and injected).
+
+- [ ] **Step 2 — model** (`models/mining.go`):
+```go
+package models
+
+type OreRankingRequest struct {
+	RegionID int    `json:"region_id"` // 0 = character's current region
+	SecBand  string `json:"sec_band"`  // "high" | "low" | "null"
+}
+
+type OreRankRow struct {
+	OreTypeID        int64   `json:"ore_type_id"`
+	OreName          string  `json:"ore_name"`
+	MiningM3PerHour  float64 `json:"mining_m3_per_hour"`
+	RawISKPerHour    float64 `json:"raw_isk_per_hour"`
+	RefineISKPerHour float64 `json:"refine_isk_per_hour"`
+	RawNetPerM3      float64 `json:"raw_net_per_m3"`
+	RefineNetPerM3   float64 `json:"refine_net_per_m3"`
+	Best             string  `json:"best"`
+	DeltaISKPerHour  float64 `json:"delta_isk_per_hour"`
+	BestStationID    int64   `json:"best_station_id,omitempty"`
+	BestStationTax   float64 `json:"best_station_tax"`
+}
+
+type OreRankingResponse struct {
+	RegionID int          `json:"region_id"`
+	SecBand  string       `json:"sec_band"`
+	Rows     []OreRankRow `json:"rows"`
+}
+```
+
+- [ ] **Step 3 — failing test** for the service with faked deps (mirror how `portfolio_service_test.go` fakes the routes service). Construct `MiningService` with a fake market repo returning a known Veldspar buy price + a known Tritanium buy price, a fake skills service, a fake SDE repo returning one station + the ore list filtered to Veldspar; assert the response has a Veldspar row with `Best` set and the per-m³ values matching `CompareOre`. Write the fakes minimally (record/return canned data).
+
+- [ ] **Step 4 — implement** `mining_service.go` (`OreRanking(ctx, characterID, accessToken, req) (*models.OreRankingResponse, error)`):
+  - resolve `regionID` (req or current via location — reuse the existing current-region resolution used by hauling/trading).
+  - `ores := reprocessing.ListOres(sdeDB)` filtered by `secBandOres(req.SecBand)` (the curated map, Task 7) and to ores the ship can mine (Phase 2 narrows this; Phase 1: just the sec-band map).
+  - skills := skillsService.GetCharacterSkills(...) → reprocessing skills + Accounting sales-tax rate. (Add reprocessing-skill fetching to skills_service in this task — see note.)
+  - stations := sdeRepo.GetRegionReprocessStations(regionID); standings (Phase 2 adds the ESI standings; Phase 1: assume standing 0 → BestStation = lowest BaseTake).
+  - per ore: `ore := reprocessing.GetOre(...)`; material buy prices via market repo; `net := reprocessing.NetYield(bestStation.BaseRate, reproSkills+oreProcessingForThisOre)`; `CompareOre(...)`; build row (isk/h = 0 until Phase 2).
+  - sort rows by `RefineNetPerM3`/`RawNetPerM3` max desc (Phase 2 re-sorts by isk/h).
+  > **Reprocessing skills in skills_service:** extend `TradingSkills` (or add a `GetReprocessingSkills`) to fetch Reprocessing (3385), Reprocessing Efficiency (3389), and the ore-specific Processing skill per ore group from ESI skills. For the ore-specific skill, map ore group → "<Group> Processing" skill type via SDE name lookup (`<GroupName> Processing`), or 0 if untrained. Keep it a focused addition with its own unit coverage.
+
+- [ ] **Step 5 — handler + route:** `mining.go` `OreRanking(c *fiber.Ctx)` mirroring `portfolio.go` (parse body, get characterID+token from locals/auth middleware, call service, JSON). Register: `api.Post("/mining/ore-ranking", routeCalcLimiter, evesso.NewAuthMiddleware(c.TokenValidator), c.MiningHandler.OreRanking)` in `cmd/api/main.go`; construct `MiningHandler`+`MiningService` in the container and add to the `Container` struct.
+
+- [ ] **Step 6 — verify + commit:** `cd backend && gofmt -l internal pkg && GOWORK=off go vet ./... && GOWORK=off golangci-lint run ./... && SDE_DB_PATH=… GOWORK=off go test ./...` then `... -m "feat(backend): mining ore-ranking service + endpoint (phase 1)"`.
+
+### Task 7: Curated ore → security-band map
+
+**Files:** `backend/internal/services/ore_secband.go` + test.
+
+- [ ] **Step 1 — failing test:** `secBandOres("high")` contains Veldspar group (462) and Scordite; `secBandOres("null")` contains Arkonor (450); high does NOT contain Arkonor.
+- [ ] **Step 2-4 — implement** a `map[string]map[int64]bool` (band → ore group ids), seeded from the well-known EVE ore availability (highsec: Veldspar/Scordite/Plagioclase/Pyroxeres/Omber/Kernite/Jaspet/Hemorphite/Hedbergite; lowsec adds Gneiss/Ochre/Spodumain-low; null/anomalies add Arkonor/Bistot/Crokite/etc.). Expose `secBandOreGroups(band string) map[int64]bool` and have Task 6's filter use ore `GroupID`. Document each group id with a comment.
+- [ ] **Step 5 — commit:** `... -m "feat(backend): curated ore→security-band map"`
+
+---
+
+## PHASE 2 — Mining yield (m³/h) + standings ESI + ISK/hour
+
+### Task 8: Mining yield from the current ship's fitted miners + skills
+
+**Files:** `backend/pkg/evedb/mining/mining.go` + test. Reuse the asset/fitting access already in `fitting_service.go` (`fittedItemsForShip`, `fetchESIAssets`).
+
+- [ ] **Step 1 — failing test** (Strip Miner I: attr77=150 m³, attr73=45000 ms; Mining V +25%, Astrogeology V +25%):
+```go
+func TestMiningRate_OneStripMinerI(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	// one Strip Miner I (17482); Mining 5, Astrogeology 5
+	m3h, err := MiningRateM3PerHour(db, []int64{17482}, MiningSkills{Mining: 5, Astrogeology: 5}, 1.0)
+	if err != nil { t.Fatal(err) }
+	// per cycle 150 × (1+0.25)(1+0.25)=234.375 m³ / 45s × 3600 = 18750 m³/h
+	if m3h < 18740 || m3h > 18760 { t.Fatalf("m3/h %.1f", m3h) }
+}
+```
+
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement:** for each module type id, read dogma attr 77 (`miningAmount`) + 73 (`duration` ms) from `typeDogma`; `perCycle = miningAmount × (1+0.05·Mining) × (1+0.05·Astrogeology) × crystalMul`; `m3h += perCycle / (duration/1000) × 3600`. `crystalMul` param (default 1.0; ore-specific crystal handled by the caller). Skip non-mining modules (no attr 77). Confirm Mining=3386 / Astrogeology=3410 skill ids via SDE name lookup in a comment.
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `... -m "feat(backend): mining yield m³/h from fitted miners + skills"`
+
+### Task 9: Character standings via ESI + mining/reprocessing skill fetch
+
+**Files:** extend `backend/internal/services/skills_service.go` (or a new `standings_service.go`): `GetCharacterStandings(ctx, characterID, token) (map[int64]float64, error)` — corp/faction id → standing, from `GET /characters/{id}/standings/` (model on the existing ESI calls in `fitting_service.go`/`skills_service.go`). Also fetch Mining/Astrogeology + Reprocessing skills (if not already). Test the JSON parse with a fixture (`[{"from_type":"npc_corp","from_id":1000035,"standing":7.5}]` → map[1000035]=7.5).
+
+- [ ] TDD as in prior tasks (parse test first). Commit: `... -m "feat(backend): ESI character standings + mining/reprocessing skills"`.
+
+### Task 10: Wire mining yield + standings into OreRanking → ISK/hour
+
+**Files:** `mining_service.go`, `mining_service_test.go`.
+
+- [ ] Update `OreRanking`: compute `m3h := mining.MiningRateM3PerHour(...)` from the current ship's fitted miners (via fitting_service assets) + skills; per ore apply the matching ore crystal multiplier if the ship has that crystal (else 1.0). Use real per-station standings (Task 9) for `BestStation`. Set `row.RawISKPerHour = m3h × RawNetPerM3`, `RefineISKPerHour = m3h × RefineNetPerM3`, `DeltaISKPerHour = m3h × DeltaPerM3`. **Sort rows by max(raw,refine) ISK/hour desc.** If the ship has no mining modules → return rows with `m3h=0` and a top-level flag/empty so the UI shows "kein Mining-Setup" (fail-loud, don't fabricate).
+- [ ] Extend the service test: with a known m³/h, assert isk/h = m3h × per-m³ and the ordering.
+- [ ] Verify gates + commit: `... -m "feat(backend): ore-ranking ISK/hour from mining yield + per-station standings"`.
+
+---
+
+## PHASE 3 — Web "Mining" view
+
+### Task 11: API client + types (web)
+
+**Files:** `frontend/src/types/trading.ts` (add `OreRankingRequest`, `OreRankRow`, `OreRankingResponse` mirroring the Go JSON tags), `frontend/src/lib/api-client.ts` (`fetchOreRanking(req): Promise<OreRankingResponse>` mirroring `optimizePortfolio` — POST, credentials, throw on !ok, validate `rows` is an array). Test `frontend/tests/lib/api-client-mining.test.ts` (mock fetch → returns rows; malformed → throws). TDD; commit `feat(frontend): mining ore-ranking api client`.
+
+### Task 12: Mining page + ranked table (web)
+
+**Files:** `frontend/src/app/mining/page.tsx`, `frontend/src/components/trading/OreRankingTable.tsx`, nav entry; test `frontend/tests/components/OreRankingTable.test.tsx`.
+
+- [ ] Mirror `roi-calculator/page.tsx` structure: `useCurrentShip()` + `CurrentShipCard`, a **sec-band selector** (high/low/null — a simple Select), region (current), a "berechnen" trigger calling `fetchOreRanking({ region_id: 0, sec_band })`. Render `OreRankingTable` (columns: Ore · m³/h · ISK/h raw · ISK/h refine · Verdict (best, colored) · Station-Tax · Δ). Show a "kein Mining-Setup" notice when the response indicates no mining modules. Add a nav link "Mining" alongside the others.
+- [ ] Component test: given rows, the table renders ore names, the verdict per row, and highlights the better column. TDD.
+- [ ] Verify: `npx vitest run && rm -rf .next && npm run build && npx eslint <files>`; commit `feat(frontend): mining view with ore ranking table`.
+
+---
+
+## PHASE 4 — Flutter "Mining" view
+
+### Task 13: Flutter models + API + screen
+
+**Files:** `app/lib/api/mining_models.dart` (request/response mirroring the JSON), `app/lib/features/mining/mining_api.dart` + `mining_providers.dart` + `mining_screen.dart` + an `ore_ranking_table` widget; tests in `app/test/`.
+
+- [ ] Mirror an existing screen (e.g. `roi_calculator_screen.dart`): `currentShipProvider` + `CurrentShipCard`, sec-band selector, call the endpoint, render the ranked table. Reuse the dio client + Riverpod patterns exactly.
+- [ ] Tests: model fromJson, a widget test rendering the ranked rows + verdict, no-mining-setup state.
+- [ ] Verify: `cd app && flutter analyze && flutter test`; commit `feat(flutter): mining ore-ranking screen`.
+
+---
+
+## Task 14: Full verification + PR
+
+- [ ] Backend: `gofmt -l internal pkg && GOWORK=off go vet ./... && GOWORK=off golangci-lint run ./... && SDE_DB_PATH=… GOWORK=off go test ./...` → all green, golangci 0.
+- [ ] Web: `cd frontend && npx vitest run && rm -rf .next && npm run build`. Flutter: `cd app && flutter analyze && flutter test`.
+- [ ] Push `feat/mining-ore-ranking`; open PR (base main). After CI green + merge → release `v0.20.0` (gated; CHANGELOG + `make release` + tag → deploy + smoke-test; Flutter APK rebuilt/installed separately).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** reprocessing yield (T2), ore catalog/materials (T1), best NPC station by standing (T3/T4/T9), per-ore raw-vs-refine taker (T5), mining yield (T8), ISK/hour + ranking (T10), sec-band selectable + curated map (T7, T12/T13), endpoint (T6), web view (T11/T12), Flutter view (T13), fail-loud no-mining-setup (T10/T12/T13). All covered.
+- **Phasing:** Phase 1 ships a working "sell-raw vs refine per ore, ranked by net ISK/m³" without mining yield; Phase 2 adds ISK/hour; 3/4 are the views. Each phase is independently testable.
+- **Verify during execution:** exact `mapSolarSystems`→region join (match `GetRegionIDForSystem`); the market repo's buy-order accessor signature; the Accounting/sales-tax field on `TradingSkills`; the ore-specific "<Group> Processing" skill name→id lookup; the ESI `/standings` response shape; the mining/astrogeology skill ids (3386/3410). These are lookups, not design changes.

--- a/docs/superpowers/specs/2026-05-31-mining-ore-refine-ranking-design.md
+++ b/docs/superpowers/specs/2026-05-31-mining-ore-refine-ranking-design.md
@@ -1,0 +1,138 @@
+# Mining ore "sell raw vs. refine" ranking — Design
+
+**Date:** 2026-05-31
+**Status:** Approved (design)
+
+## Problem
+
+A miner wants to know, for the ore they can mine, whether **selling the raw ore** is more
+profitable than **reprocessing it and selling the refined materials** — and which ore is
+worth mining at all, ranked by **ISK per hour**. The comparison must account for the
+character's reprocessing, ship, mining, and trade/broker skills, and pick the best NPC
+reprocessing station in the region by the player's standings.
+
+## Goal
+
+A new **"Mining"** view that ranks ores by ISK/hour and, per ore, shows the verdict
+**sell-raw vs. refine** with concrete net-ISK figures, the best NPC reprocessing station,
+and the absolute ISK/hour from the current ship's mining rate.
+
+## Decisions (from brainstorming)
+
+- **Output:** a ranking over ores. Per ore: mining m³/h, ISK/h raw, ISK/h refined, verdict
+  (sell-raw vs. refine) + delta, best NPC station.
+- **Mining rate:** computed automatically from the **current (flown) ship** + its fitted
+  mining lasers/strip miners (+ ore crystals) + mining skills (deterministic dogma calc).
+- **Reprocessing facility:** **all NPC stations with the reprocessing service in the
+  (current) region**; per-station reprocessing tax from the player's standing with the
+  station's owner corp; the calc uses the **best** (lowest-tax) station per ore.
+- **Ore scope:** a **selectable security band** (high/low/null) ∩ ores the current ship's
+  equipment can mine.
+- **Pricing:** **Taker** — sell instantly into the highest **buy orders**; **sales tax only**
+  (Accounting), no broker fee; quantities capped at the order book (same model as Sell-Assets).
+- **Region:** the character's **current region** (default, like the other views).
+- **Surface:** a new **Mining** view on **web + Flutter**.
+
+## Architecture
+
+### Reprocessing yield (new deterministic calc)
+
+`net_yield = base_facility_rate × (1 + 0.03·Reprocessing) × (1 + 0.02·ReprocessingEfficiency)
+× (1 + 0.02·OreSpecificProcessing)` — base_facility_rate = **0.50** for NPC stations.
+(Implants out of scope for v1.) Built analogous to the existing cargo/skill deterministic
+calc in `backend/pkg/evedb`.
+
+Refined output of `Q` units of an ore = for each material in `typeMaterials.materials`:
+`floor(Q / portionSize) · material_qty · net_yield`. `portionSize` and `volume` come from
+the `types` table; `typeMaterials.materials` is JSON `[{material, quantity}, …]`.
+
+### Reprocessing tax (new; needs standings)
+
+Per NPC station: `tax = max(0, 0.05 − 0.0075 · standing)` where `standing` is the player's
+**effective standing with the station's owner corporation** (Connections/Diplomacy effects
+out of scope v1 — use the raw corp standing). Station owner from `npcStations`→`npcCorporations`;
+reprocessing-service stations filtered via `stationServices`/`stationOperations`. Per-corp
+standings come from a **new ESI call `GET /characters/{id}/standings`** (the app currently
+fetches only the highest faction/corp standing for broker fees). The calc picks the station
+with the lowest tax (highest net materials) per region.
+
+### Mining yield (new deterministic calc)
+
+From the current ship's fitted mining modules (strip miners / mining lasers) read from
+ESI assets (same path as the cargo fitting): per module
+`yield_per_cycle_m3 = miningAmount × (1 + skill & role bonuses) × crystal_multiplier`,
+`m3_per_hour = Σ_modules (yield_per_cycle_m3 / cycle_duration_s) × 3600`.
+Skills: **Mining** (+5%/level), **Astrogeology** (+5%/level), ship **role bonuses**
+(Mining Barge/Exhumer/Mining Frigate per-level yield), and the matching **ore crystal**
+multiplier when present. Mining **drones** are **out of scope for v1** (later stage).
+Modeled with the existing `pkg/evedb/dogma` infrastructure; exact attribute IDs
+(`miningAmount`, module `duration`) are resolved against the local SDE during implementation.
+
+### Market valuation (taker)
+
+Reuse the market repository. For the raw ore and for each refined material, value at the
+**highest buy order**, capped at the order's `VolumeRemain` (same order-book cap as
+Sell-Assets, ref. the order-book-extrapolation rule). Net = gross − **sales tax**
+(Accounting skill). No broker fee (taker).
+
+### Per-ore comparison + ranking
+
+For each in-scope ore:
+- `raw_net_per_m3` = (buy-order ISK for the ore, net of sales tax) / ore_volume_m3.
+- `refine_net_per_m3` = (Σ material buy-order ISK × net_yield, net of sales tax, at the best
+  station) / ore_volume_m3.
+- `best_per_m3 = max(raw, refine)`, `verdict = argmax`, `delta = |raw − refine|`.
+- `isk_per_hour = mining_m3_per_hour × best_per_m3`.
+Rank by `isk_per_hour` desc.
+
+### Backend endpoint
+
+`POST /api/v1/mining/ore-ranking` (auth) body `{ region_id, sec_band }` →
+`{ ship: {...}, rows: [{ ore_type_id, ore_name, mining_m3_per_hour, raw_isk_per_hour,
+refine_isk_per_hour, best: "raw"|"refine", delta_isk_per_hour, best_station: {id, name, tax},
+... }], ... }`. `region_id` defaults to the character's current region; `sec_band` ∈
+{high, low, null}.
+
+### Ore → security-band map
+
+The SDE does not cleanly encode where ores spawn. A small **curated map** (ore group →
+available security bands) lives in backend code/config; it's small and stable. Documented as
+the one non-SDE data source.
+
+### Frontend (web + Flutter)
+
+New **Mining** view: a **security-band selector** (high/low/null), the current region, the
+`CurrentShipCard`, and a ranked table — columns: Ore · mining m³/h · ISK/h raw · ISK/h refine ·
+verdict · best station · Δ. Mirrors the existing view conventions; web first, then Flutter.
+
+## Error handling (fail-loud — project rule)
+
+- Current ship has **no mining modules** → a visible "kein Mining-Setup" state; never fabricate
+  a yield.
+- Standings / fitting / market fetch errors → surfaced visibly (no silent 0/default), consistent
+  with the no-silent-fallbacks principle.
+- An ore with no buy orders (raw or for a material) → shown explicitly (not silently 0).
+
+## Testing
+
+- **Reprocessing yield:** known ore (Veldspar 1230, portionSize 100) with known skills →
+  expected mineral quantities × net_yield (deterministic, against local SDE).
+- **Mining yield:** a ship with a known strip miner + mining skills → expected m³/h.
+- **Reprocessing tax:** standing → tax (boundary at standing 6.67 → 0%); best-station pick
+  across ≥2 stations with different owner standings.
+- **Comparison/ranking:** crafted prices where refine > raw for one ore and raw > refine for
+  another → correct verdicts + ISK/h ordering.
+- **Taker fees:** sales-tax-only applied; broker fee NOT applied; quantities capped at order book.
+- **Frontend:** view renders the ranked table; sec-band selector changes scope; no-mining-setup
+  state; fail-loud error states.
+
+## Scope / YAGNI / phasing
+
+- **Out of scope v1:** mining drones, reprocessing implants, Upwell-structure reprocessing
+  (NPC stations only), Connections/Diplomacy standing modifiers, maker (sell-order) pricing.
+- **Phasing** (each phase ships independently):
+  1. Reprocessing-yield + market-taker + comparison + ranking + best NPC station (no mining
+     yield yet — already answers "sell raw vs. refine per ore", ordered by net ISK/m³).
+  2. Mining-yield + ISK/hour (ship/miners/skills) + the new `/standings` ESI call.
+  3. Web Mining view.
+  4. Flutter Mining view.

--- a/frontend/src/app/mining/page.tsx
+++ b/frontend/src/app/mining/page.tsx
@@ -137,6 +137,11 @@ function MiningPageContent() {
                 </Alert>
               )}
               <OreRankingTable rows={miningMutation.data.rows} />
+              <p className="text-xs text-muted-foreground">
+                Hinweis: ISK/h ist eine skills-basierte Untergrenze — Schiffs-Rollenboni
+                (Mining Barge/Exhumer) und Erz-Crystals sind noch nicht eingerechnet. Die
+                Roh-vs-Refine-Entscheidung und das Ranking sind davon unberührt.
+              </p>
             </div>
           )}
         </div>

--- a/frontend/src/app/mining/page.tsx
+++ b/frontend/src/app/mining/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useAuth } from "@/lib/auth-context";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CurrentShipCard } from "@/components/trading/CurrentShipCard";
+import { OreRankingTable } from "@/components/trading/OreRankingTable";
+import { fetchOreRanking } from "@/lib/api-client";
+import { OreRankingRequest } from "@/types/trading";
+import { Loader2 } from "lucide-react";
+
+type SecBand = "high" | "low" | "null";
+
+const SEC_BAND_LABELS: Record<SecBand, string> = {
+  high: "High-Sec",
+  low: "Low-Sec",
+  null: "Null-Sec",
+};
+
+function MiningPageContent() {
+  const { isAuthenticated } = useAuth();
+  const [secBand, setSecBand] = useState<SecBand>("high");
+
+  const miningMutation = useMutation({
+    mutationFn: (req: OreRankingRequest) => fetchOreRanking(req),
+  });
+
+  const handleSubmit = () => {
+    miningMutation.mutate({ region_id: 0, sec_band: secBand });
+  };
+
+  const apiError = miningMutation.isError
+    ? miningMutation.error instanceof Error
+      ? miningMutation.error.message
+      : "Unbekannter Fehler"
+    : undefined;
+
+  const disabled = !isAuthenticated || miningMutation.isPending;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="mb-2 text-3xl font-bold">Mining</h1>
+        <p className="text-muted-foreground">
+          Erze nach ISK/Stunde ranken — Roh-Verkauf vs. Reprozessieren
+        </p>
+      </div>
+
+      {!isAuthenticated && (
+        <Alert className="mb-6">
+          <AlertTitle>Login erforderlich</AlertTitle>
+          <AlertDescription>
+            Melde dich per EVE SSO an, um Erze in deiner aktuellen Region zu
+            ranken.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-[340px_1fr]">
+        {/* Input form */}
+        <form
+          className="space-y-4 rounded-lg border p-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <CurrentShipCard />
+
+          <div className="space-y-2">
+            <Label htmlFor="sec-band">Sicherheitsklasse</Label>
+            <Select
+              value={secBand}
+              onValueChange={(v) => setSecBand(v as SecBand)}
+              disabled={disabled}
+            >
+              <SelectTrigger id="sec-band">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="high">{SEC_BAND_LABELS.high}</SelectItem>
+                <SelectItem value="low">{SEC_BAND_LABELS.low}</SelectItem>
+                <SelectItem value="null">{SEC_BAND_LABELS.null}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Button type="submit" className="w-full" disabled={disabled}>
+            {miningMutation.isPending && (
+              <Loader2 className="mr-2 size-4 animate-spin" />
+            )}
+            {miningMutation.isPending ? "Berechne..." : "Erze berechnen"}
+          </Button>
+        </form>
+
+        {/* Results */}
+        <div className="space-y-6">
+          {miningMutation.isPending && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Berechne Erz-Ranking...
+            </div>
+          )}
+
+          {apiError && (
+            <Alert variant="destructive">
+              <AlertTitle>Fehler</AlertTitle>
+              <AlertDescription className="flex items-center justify-between gap-4">
+                <span>{apiError}</span>
+                <Button variant="outline" size="sm" onClick={handleSubmit}>
+                  Erneut versuchen
+                </Button>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {miningMutation.isSuccess && miningMutation.data && (
+            <div className="space-y-4">
+              {miningMutation.data.no_mining_setup && (
+                <Alert>
+                  <AlertTitle>Kein Mining-Setup</AlertTitle>
+                  <AlertDescription>
+                    Dein aktuelles Schiff hat kein Mining-Setup — ISK/h kann
+                    nicht berechnet werden
+                  </AlertDescription>
+                </Alert>
+              )}
+              <OreRankingTable rows={miningMutation.data.rows} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function MiningPage() {
+  return (
+    <ErrorBoundary>
+      <MiningPageContent />
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/components/navigation.tsx
+++ b/frontend/src/components/navigation.tsx
@@ -19,6 +19,7 @@ const navItems = [
   { href: "/sell-assets", label: "Sell Assets" },
   { href: "/trends", label: "Trends" },
   { href: "/watchlist", label: "Watchlist" },
+  { href: "/mining", label: "Mining" },
 ];
 
 export function Navigation() {

--- a/frontend/src/components/trading/OreRankingTable.tsx
+++ b/frontend/src/components/trading/OreRankingTable.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type { OreRankRow } from "@/types/trading";
+import { cn, formatISK } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface OreRankingTableProps {
+  rows: OreRankRow[];
+}
+
+/**
+ * Ranks ores by ISK/hour (raw sell vs reprocess). Rows arrive pre-sorted by
+ * best ISK/hour descending. An empty rows array means no ore data was found
+ * for the given region/sec-band combination.
+ */
+export function OreRankingTable({ rows }: OreRankingTableProps) {
+  if (rows.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Erz-Ranking</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div
+            data-testid="ore-ranking-empty"
+            className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
+          >
+            Keine Erz-Daten für diese Region und Sicherheitsklasse gefunden
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-xl">Erz-Ranking</CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm" aria-label="Erz-Ranking">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th scope="col" className="px-4 py-3 font-medium">
+                  Erz
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  m³/h
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  ISK/h roh
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  ISK/h refine
+                </th>
+                <th scope="col" className="px-4 py-3 font-medium">
+                  Verdict
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  Steuer
+                </th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">
+                  Δ ISK/h
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <OreRankRow key={row.ore_type_id} row={row} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function OreRankRow({ row }: { row: OreRankRow }) {
+  const isRefine = row.best === "refine";
+  const verdictText = isRefine ? "Reprozessieren" : "Roh verkaufen";
+  const verdictClass = isRefine
+    ? "text-blue-600 dark:text-blue-400 font-medium"
+    : "text-green-600 dark:text-green-400 font-medium";
+
+  const m3PerHour =
+    row.mining_m3_per_hour >= 1000
+      ? `${(row.mining_m3_per_hour / 1000).toFixed(1)}k`
+      : String(row.mining_m3_per_hour);
+
+  return (
+    <tr
+      data-testid="ore-ranking-row"
+      data-ore-type-id={row.ore_type_id}
+      className="border-b transition-colors hover:bg-muted/40"
+    >
+      <td className="px-4 py-3 font-medium">{row.ore_name}</td>
+      <td className="px-4 py-3 text-right">{m3PerHour}</td>
+      <td className="px-4 py-3 text-right">{formatISK(row.raw_isk_per_hour)}</td>
+      <td className="px-4 py-3 text-right">{formatISK(row.refine_isk_per_hour)}</td>
+      <td className={cn("px-4 py-3", verdictClass)}>{verdictText}</td>
+      <td className="px-4 py-3 text-right">
+        {(row.best_station_tax * 100).toFixed(1)}%
+      </td>
+      <td className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
+        {formatISK(row.delta_isk_per_hour)}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -15,6 +15,8 @@ import {
   AssetsResponse,
   SellOptionsRequest,
   SellOptionsResponse,
+  OreRankingRequest,
+  OreRankingResponse,
 } from "@/types/trading";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:9001";
@@ -264,6 +266,36 @@ export async function findSellOptions(
   }
 
   return response.json();
+}
+
+/**
+ * Rank ores by ISK/hour (raw sell vs reprocess) for the character's current
+ * region and the given security band (requires authentication). Rows are
+ * returned pre-sorted by best_isk_per_hour descending.
+ * @param req - region_id (0 = character's current region) + sec_band
+ */
+export async function fetchOreRanking(
+  req: OreRankingRequest
+): Promise<OreRankingResponse> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/mining/ore-ranking`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(req),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ore ranking: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (!Array.isArray(data.rows)) {
+    throw new Error("Invalid ore ranking response: 'rows' missing or not an array");
+  }
+  return data as OreRankingResponse;
 }
 
 export interface SetWaypointOptions {

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -343,3 +343,31 @@ export interface SellOptionsResponse {
    *  resolve its system, so no route is possible. */
   not_routable_reason?: string;
 }
+
+// Mining Ore Ranking (ore ISK/hour calculator)
+
+export interface OreRankingRequest {
+  region_id: number;
+  sec_band: string; // "high" | "low" | "null"
+}
+
+export interface OreRankRow {
+  ore_type_id: number;
+  ore_name: string;
+  mining_m3_per_hour: number;
+  raw_isk_per_hour: number;
+  refine_isk_per_hour: number;
+  raw_net_per_m3: number;
+  refine_net_per_m3: number;
+  best: string; // "raw" | "refine"
+  delta_isk_per_hour: number;
+  best_station_id?: number;
+  best_station_tax: number;
+}
+
+export interface OreRankingResponse {
+  region_id: number;
+  sec_band: string;
+  no_mining_setup: boolean;
+  rows: OreRankRow[];
+}

--- a/frontend/tests/components/OreRankingTable.test.tsx
+++ b/frontend/tests/components/OreRankingTable.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { OreRankingTable } from "@/components/trading/OreRankingTable";
+import { OreRankRow } from "@/types/trading";
+
+function makeRow(overrides: Partial<OreRankRow> = {}): OreRankRow {
+  return {
+    ore_type_id: 1230,
+    ore_name: "Veldspar",
+    mining_m3_per_hour: 12000,
+    raw_isk_per_hour: 500000,
+    refine_isk_per_hour: 1100000,
+    raw_net_per_m3: 76.8,
+    refine_net_per_m3: 169.3,
+    best: "refine",
+    delta_isk_per_hour: 600000,
+    best_station_id: 60003760,
+    best_station_tax: 0.02,
+    ...overrides,
+  };
+}
+
+const rows: OreRankRow[] = [
+  makeRow({ ore_type_id: 1230, ore_name: "Veldspar", best: "refine" }),
+  makeRow({
+    ore_type_id: 1228,
+    ore_name: "Scordite",
+    best: "raw",
+    mining_m3_per_hour: 8000,
+    raw_isk_per_hour: 900000,
+    refine_isk_per_hour: 700000,
+    delta_isk_per_hour: 200000,
+    best_station_tax: 0.05,
+  }),
+];
+
+describe("OreRankingTable", () => {
+  it("renders one row per ore with correct ore names", () => {
+    render(<OreRankingTable rows={rows} />);
+
+    const tableRows = screen.getAllByTestId("ore-ranking-row");
+    expect(tableRows).toHaveLength(2);
+    expect(screen.getByText("Veldspar")).toBeInTheDocument();
+    expect(screen.getByText("Scordite")).toBeInTheDocument();
+  });
+
+  it("renders 'Reprozessieren' verdict for best=refine row", () => {
+    render(<OreRankingTable rows={rows} />);
+
+    const veldsparRow = screen
+      .getAllByTestId("ore-ranking-row")
+      .find((r) => r.getAttribute("data-ore-type-id") === "1230")!;
+
+    expect(within(veldsparRow).getByText("Reprozessieren")).toBeInTheDocument();
+  });
+
+  it("renders 'Roh verkaufen' verdict for best=raw row", () => {
+    render(<OreRankingTable rows={rows} />);
+
+    const scorditeRow = screen
+      .getAllByTestId("ore-ranking-row")
+      .find((r) => r.getAttribute("data-ore-type-id") === "1228")!;
+
+    expect(within(scorditeRow).getByText("Roh verkaufen")).toBeInTheDocument();
+  });
+
+  it("renders tax percentage for each row", () => {
+    render(<OreRankingTable rows={rows} />);
+
+    expect(screen.getByText("2.0%")).toBeInTheDocument();
+    expect(screen.getByText("5.0%")).toBeInTheDocument();
+  });
+
+  it("renders m³/h formatted with k suffix for values >= 1000", () => {
+    render(<OreRankingTable rows={rows} />);
+
+    // 12000 → "12.0k", 8000 → "8.0k"
+    expect(screen.getByText("12.0k")).toBeInTheDocument();
+    expect(screen.getByText("8.0k")).toBeInTheDocument();
+  });
+
+  it("renders the empty-state when rows array is empty", () => {
+    render(<OreRankingTable rows={[]} />);
+
+    expect(screen.getByTestId("ore-ranking-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("ore-ranking-row")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/lib/api-client-mining.test.ts
+++ b/frontend/tests/lib/api-client-mining.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { fetchOreRanking } from "@/lib/api-client";
+import { OreRankRow } from "@/types/trading";
+
+function mockJson(body: unknown, status = 200) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+const makeRow = (overrides: Partial<OreRankRow> = {}): OreRankRow => ({
+  ore_type_id: 1230,
+  ore_name: "Veldspar",
+  mining_m3_per_hour: 12000,
+  raw_isk_per_hour: 0,
+  refine_isk_per_hour: 0,
+  raw_net_per_m3: 76.8,
+  refine_net_per_m3: 169.3,
+  best: "refine",
+  delta_isk_per_hour: 0,
+  best_station_id: 60003760,
+  best_station_tax: 0.02,
+  ...overrides,
+});
+
+describe("fetchOreRanking", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns mapped rows on a valid response", async () => {
+    const rows = [makeRow(), makeRow({ ore_type_id: 1231, ore_name: "Scordite", best: "raw" })];
+    mockJson({
+      region_id: 10000002,
+      sec_band: "high",
+      no_mining_setup: false,
+      rows,
+    });
+
+    const result = await fetchOreRanking({ region_id: 0, sec_band: "high" });
+
+    expect(result.region_id).toBe(10000002);
+    expect(result.sec_band).toBe("high");
+    expect(result.no_mining_setup).toBe(false);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0].ore_name).toBe("Veldspar");
+    expect(result.rows[1].ore_name).toBe("Scordite");
+  });
+
+  it("throws when the response is not ok", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthorized" }), {
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(
+      fetchOreRanking({ region_id: 0, sec_band: "high" }),
+    ).rejects.toThrow(/Failed to fetch ore ranking/);
+  });
+
+  it("throws on a malformed response (no rows array) instead of returning silently", async () => {
+    mockJson({ region_id: 10000002, sec_band: "high", no_mining_setup: false });
+    // no `rows` key
+
+    await expect(
+      fetchOreRanking({ region_id: 0, sec_band: "high" }),
+    ).rejects.toThrow(/rows/);
+  });
+
+  it("uses POST to /api/v1/mining/ore-ranking with credentials include", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ region_id: 10000002, sec_band: "high", no_mining_setup: false, rows: [] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await fetchOreRanking({ region_id: 0, sec_band: "high" });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toContain("/api/v1/mining/ore-ranking");
+    expect(init?.method).toBe("POST");
+    expect(init?.credentials).toBe("include");
+  });
+});


### PR DESCRIPTION
A new **Mining** view (web + Flutter) that ranks ores by **ISK/hour** and, per ore, says whether to **sell the raw ore** or **reprocess + sell the materials** — driven by the current ship's mining rate, reprocessing/trade skills, region buy-order prices, and the best NPC reprocessing station by standing.

Built brainstorm → spec → plan → TDD. Spec/plan: `docs/superpowers/specs|plans/2026-05-31-mining-ore-refine-ranking-*.md`.

## How it works
- **Reprocessing yield** = station `reprocessingEfficiency` × (1+3%·Reprocessing)(1+2%·ReprocessingEfficiency)(1+2%·OreProcessing).
- **Best NPC station** in the region = max `baseRate × (1 − tax)`, tax = `max(0, baseTake − 0.0075·standing)` with the player's standing to the station's owner corp (new ESI `/standings`).
- **Mining yield** (m³/h) from the current ship's fitted strip miners/lasers (dogma attr 77/73) × Mining + Astrogeology skills.
- **Comparison** (taker): raw vs refine both net of **sales tax only** (Accounting; reused shared fee helper), prices = highest **buy order**, capped at order book. Ranked by ISK/h (per-m³ when no mining setup).
- **Ore scope**: selectable security band (high/low/null) ∩ a curated ore→sec map; ores filtered to the band.

## Backend (Go)
New pkgs `pkg/evedb/reprocessing` + `pkg/evedb/mining`; `internal/services` compare/tax/secband + `MiningService`; `internal/database` region reprocess stations; ESI `/standings` + mining/reprocessing skill fetch; `POST /api/v1/mining/ore-ranking`. All deterministic calcs unit-tested against the local SDE.

## Web + Flutter
New "Mining" view in both clients: `CurrentShipCard` + sec-band selector + ranked table (Erz · m³/h · ISK/h roh · ISK/h refine · Verdict · Steuer · Δ). Fail-loud: visible "kein Mining-Setup" notice + API-error surfacing.

## Verification
- Backend: gofmt clean, `go vet` clean, **golangci-lint 0 issues**, all tests pass (SDE-backed).
- Web: **86/86** vitest, ESLint 0, build OK. Flutter: `analyze` clean, **218 tests**, debug APK builds.
- Final adversarial review: APPROVE_WITH_NITS; the two Important findings (best-station scoring; container fail-loud) fixed in this branch.

## Known scope (v1, documented in-UI)
ISK/h is a **skills-only lower bound** — ship **role bonuses** (Mining Barge/Exhumer) and ore **crystals** are not yet applied (the verdict + ranking are unaffected; both views note this). Out of scope v1: mining drones, reprocessing implants, Upwell structures, maker pricing. The ore→sec map is curated (SDE doesn't encode it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
