### PR TITLE
fix(mining): exclude compressed ore variants from the ranking

### DIFF
--- a/backend/pkg/evedb/reprocessing/reprocessing.go
+++ b/backend/pkg/evedb/reprocessing/reprocessing.go
@@ -53,6 +53,9 @@ func ListOres(db *sql.DB) ([]Ore, error) {
 		JOIN groups g ON t.groupID = g._key
 		JOIN categories c ON g.categoryID = c._key
 		WHERE json_extract(c.name,'$.en') = 'Asteroid' AND t.published = 1
+		  -- Exclude compressed forms ("Compressed X", "Batch Compressed X"): they are
+		  -- not mined (raw ore is compressed afterwards) and their tiny volume skews ISK/m³.
+		  AND COALESCE(json_extract(t.name,'$.en'),'') NOT LIKE '%Compressed%'
 		ORDER BY t._key`)
 	if err != nil {
 		return nil, fmt.Errorf("list ores: %w", err)

--- a/backend/pkg/evedb/reprocessing/reprocessing_test.go
+++ b/backend/pkg/evedb/reprocessing/reprocessing_test.go
@@ -1,6 +1,7 @@
 package reprocessing
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
@@ -47,5 +48,26 @@ func TestNetYield(t *testing.T) {
 	want := 0.50 * 1.15 * 1.10 * 1.08
 	if diff := got - want; diff > 1e-9 || diff < -1e-9 {
 		t.Fatalf("want %.6f got %.6f", want, got)
+	}
+}
+
+func TestListOres_ExcludesCompressedVariants(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	ores, err := ListOres(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := map[int64]bool{}
+	for _, o := range ores {
+		in[o.TypeID] = true
+		if strings.Contains(o.Name, "Compressed") {
+			t.Fatalf("compressed variant leaked into ore list: %d %q", o.TypeID, o.Name)
+		}
+	}
+	if !in[1230] || !in[17470] { // base Veldspar + Veldspar II-Grade (raw, mineable) stay
+		t.Fatal("raw Veldspar variants must remain in the list")
+	}
+	if in[62516] || in[28430] { // Compressed Veldspar + Batch Compressed Veldspar II-Grade gone
+		t.Fatal("compressed/batch-compressed variants must be excluded")
 	}
 }


### PR DESCRIPTION
Compressed/Batch-Compressed ore forms aren't mined (you compress raw ore afterwards) and their 0.001 m³ volume (vs 0.1 m³ raw) inflated ISK/m³ ~100×, dominating the ISK/h ranking falsely. `reprocessing.ListOres` now excludes `%Compressed%` names — 451→206 ore types. Test added; golangci 0, all tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)