### PR TITLE
feat(mining): show reprocess + sell locations in ore ranking

### DIFF
--- a/app/lib/api/mining_models.dart
+++ b/app/lib/api/mining_models.dart
@@ -33,6 +33,81 @@ class OreRankingRequest {
 }
 
 // ---------------------------------------------------------------------------
+// SellLocation
+// ---------------------------------------------------------------------------
+
+/// Where an item (raw ore or a refined mineral) can be sold.
+/// Backend: the `raw_sell` object and each material's `sell` object.
+class SellLocation {
+  const SellLocation({
+    required this.isStructure,
+    this.stationName,
+    this.systemName,
+  });
+
+  /// Backend: `is_structure` — true when the location is a player citadel
+  /// (the SDE can't name it; the UI shows "Player-Struktur").
+  final bool isStructure;
+
+  /// Backend: `station_name` — nullable; absent for citadels.
+  final String? stationName;
+
+  /// Backend: `system_name` — nullable; absent for citadels.
+  final String? systemName;
+
+  factory SellLocation.fromJson(Map<String, dynamic> json) {
+    return SellLocation(
+      isStructure: json['is_structure'] as bool? ?? false,
+      stationName: json['station_name'] as String?,
+      systemName: json['system_name'] as String?,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RefineMaterial
+// ---------------------------------------------------------------------------
+
+/// One mineral produced by reprocessing the ore, with where to sell it.
+/// Backend: an element of an ore row's `materials` array.
+class RefineMaterial {
+  const RefineMaterial({
+    required this.materialTypeId,
+    required this.materialName,
+    required this.effectiveQty,
+    required this.buyPrice,
+    required this.sell,
+  });
+
+  /// Backend: `material_type_id`
+  final int materialTypeId;
+
+  /// Backend: `material_name`
+  final String materialName;
+
+  /// Backend: `effective_qty` — units produced after the station's net yield.
+  final int effectiveQty;
+
+  /// Backend: `buy_price` — highest buy order for the mineral.
+  final double buyPrice;
+
+  /// Backend: `sell` — where the mineral fetches that best buy price.
+  final SellLocation sell;
+
+  factory RefineMaterial.fromJson(Map<String, dynamic> json) {
+    return RefineMaterial(
+      materialTypeId: (json['material_type_id'] as num?)?.toInt() ?? 0,
+      materialName: json['material_name'] as String? ?? '',
+      effectiveQty: (json['effective_qty'] as num?)?.toInt() ?? 0,
+      buyPrice: (json['buy_price'] as num?)?.toDouble() ?? 0,
+      sell: json['sell'] is Map<String, dynamic>
+          ? SellLocation.fromJson(json['sell'] as Map<String, dynamic>)
+          : const SellLocation(isStructure: false),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // OreRankRow
 // ---------------------------------------------------------------------------
 
@@ -51,6 +126,10 @@ class OreRankRow {
     required this.deltaIskPerHour,
     required this.bestStationTax,
     this.bestStationId,
+    this.bestStationName,
+    this.bestStationSystem,
+    this.rawSell,
+    this.materials = const [],
   });
 
   /// Backend: `ore_type_id`
@@ -86,7 +165,21 @@ class OreRankRow {
   /// Backend: `best_station_tax`
   final double bestStationTax;
 
+  /// Backend: `best_station_name` — nullable; the reprocess station's name.
+  final String? bestStationName;
+
+  /// Backend: `best_station_system` — nullable; the reprocess station's system.
+  final String? bestStationSystem;
+
+  /// Backend: `raw_sell` — nullable; where to sell the raw ore (best buy).
+  final SellLocation? rawSell;
+
+  /// Backend: `materials` — per-mineral breakdown for the refine path. Empty
+  /// for the raw path (or when the backend omits it).
+  final List<RefineMaterial> materials;
+
   factory OreRankRow.fromJson(Map<String, dynamic> json) {
+    final rawMaterials = json['materials'] as List<dynamic>? ?? const [];
     return OreRankRow(
       oreTypeId: (json['ore_type_id'] as num?)?.toInt() ?? 0,
       oreName: json['ore_name'] as String? ?? '',
@@ -100,6 +193,15 @@ class OreRankRow {
       deltaIskPerHour: (json['delta_isk_per_hour'] as num?)?.toDouble() ?? 0,
       bestStationId: (json['best_station_id'] as num?)?.toInt(),
       bestStationTax: (json['best_station_tax'] as num?)?.toDouble() ?? 0,
+      bestStationName: json['best_station_name'] as String?,
+      bestStationSystem: json['best_station_system'] as String?,
+      rawSell: json['raw_sell'] is Map<String, dynamic>
+          ? SellLocation.fromJson(json['raw_sell'] as Map<String, dynamic>)
+          : null,
+      materials: rawMaterials
+          .whereType<Map<String, dynamic>>()
+          .map(RefineMaterial.fromJson)
+          .toList(),
     );
   }
 }

--- a/app/lib/features/mining/mining_screen.dart
+++ b/app/lib/features/mining/mining_screen.dart
@@ -324,8 +324,11 @@ class _EmptyResult extends StatelessWidget {
 // Ore ranking table
 // ---------------------------------------------------------------------------
 
-/// Scrollable data table rendering the ranked ore rows.
-/// Extracted as a public widget so widget tests can import it directly.
+/// Scrollable list of ranked ore rows. Each ore is an [ExpansionTile]: the
+/// header shows the summary (name, ISK/h, verdict, tax, Δ); expanding reveals
+/// where to reprocess (best NPC station — system) and where to sell — a
+/// per-mineral breakdown for the refine path, or the raw ore location for the
+/// raw path. Extracted as a public widget so widget tests can import it.
 class OreRankingTable extends StatelessWidget {
   const OreRankingTable({super.key, required this.result});
 
@@ -348,22 +351,140 @@ class OreRankingTable extends StatelessWidget {
             style: Theme.of(context).textTheme.bodySmall,
           ),
           const SizedBox(height: 16),
-          SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: DataTable(
-              key: const Key('mining-ore-table'),
-              columns: const [
-                DataColumn(label: Text('Erz')),
-                DataColumn(label: Text('m³/h'), numeric: true),
-                DataColumn(label: Text('ISK/h roh'), numeric: true),
-                DataColumn(label: Text('ISK/h raffiniert'), numeric: true),
-                DataColumn(label: Text('Verdict')),
-                DataColumn(label: Text('Steuer %'), numeric: true),
-                DataColumn(label: Text('Δ ISK/h'), numeric: true),
-              ],
-              rows: [
-                for (final row in result.rows) _buildRow(context, row),
-              ],
+          Column(
+            key: const Key('mining-ore-table'),
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final row in result.rows) _OreRankTile(row: row),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One expandable ore card: collapsed header + reprocess/sell detail panel.
+class _OreRankTile extends StatelessWidget {
+  const _OreRankTile({required this.row});
+
+  final OreRankRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final isRefine = row.best == 'refine';
+    final verdictColor = isRefine
+        ? const Color(0xFF66BB6A) // green — refining wins
+        : Theme.of(context).colorScheme.primary;
+    final verdictLabel = isRefine ? 'Raffinieren' : 'Roh verkaufen';
+
+    return Card(
+      key: ValueKey('mining-ore-row-${row.oreTypeId}'),
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ExpansionTile(
+        key: ValueKey('mining-ore-expand-${row.oreTypeId}'),
+        tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        title: Row(
+          children: [
+            Expanded(
+              child: Text(
+                row.oreName,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+            ),
+            _verdictChip(context, verdictColor, verdictLabel),
+          ],
+        ),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Text(
+            'm³/h ${fmtVolume(row.miningM3PerHour)} · '
+            'roh ${fmtIsk(row.rawIskPerHour)} · '
+            'refine ${fmtIsk(row.refineIskPerHour)} · '
+            'Steuer ${(row.bestStationTax * 100).toStringAsFixed(1)}% · '
+            'Δ ${fmtIsk(row.deltaIskPerHour)}',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ),
+        children: [isRefine ? _refineDetail(context) : _rawDetail(context)],
+      ),
+    );
+  }
+
+  Widget _verdictChip(BuildContext context, Color color, String label) {
+    return Container(
+      key: Key('mining-verdict-${row.oreTypeId}'),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withAlpha(40),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withAlpha(150)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontWeight: FontWeight.w600,
+          fontSize: 12,
+        ),
+      ),
+    );
+  }
+
+  Widget _refineDetail(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _detailLine(
+          context,
+          'Aufbereiten bei',
+          _formatStation(row.bestStationName, row.bestStationSystem),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Raffinate verkaufen:',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 4),
+        for (final m in row.materials) _materialRow(context, m),
+      ],
+    );
+  }
+
+  Widget _materialRow(BuildContext context, RefineMaterial m) {
+    return Padding(
+      key: ValueKey('mining-material-${row.oreTypeId}-${m.materialTypeId}'),
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            flex: 3,
+            child: Text(
+              m.materialName.isEmpty ? 'Typ ${m.materialTypeId}' : m.materialName,
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Text(
+              fmtUnits(m.effectiveQty.toDouble()),
+              textAlign: TextAlign.right,
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Text(fmtIsk(m.buyPrice), textAlign: TextAlign.right),
+          ),
+          Expanded(
+            flex: 4,
+            child: Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: Text(
+                _formatSell(m.sell),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
             ),
           ),
         ],
@@ -371,45 +492,29 @@ class OreRankingTable extends StatelessWidget {
     );
   }
 
-  DataRow _buildRow(BuildContext context, OreRankRow row) {
-    final isRefine = row.best == 'refine';
-    final verdictColor = isRefine
-        ? const Color(0xFF66BB6A) // green — refining wins
-        : Theme.of(context).colorScheme.primary;
-    final verdictLabel = isRefine ? 'Raffinieren' : 'Roh verkaufen';
+  Widget _rawDetail(BuildContext context) {
+    return _detailLine(context, 'Roh verkaufen bei', _formatSell(row.rawSell));
+  }
 
-    return DataRow(
-      key: ValueKey('mining-ore-row-${row.oreTypeId}'),
-      cells: [
-        DataCell(Text(row.oreName)),
-        DataCell(Text(fmtVolume(row.miningM3PerHour))),
-        DataCell(Text(fmtIsk(row.rawIskPerHour))),
-        DataCell(Text(fmtIsk(row.refineIskPerHour))),
-        DataCell(
-          Container(
-            key: Key('mining-verdict-${row.oreTypeId}'),
-            padding:
-                const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-            decoration: BoxDecoration(
-              color: verdictColor.withAlpha(40),
-              borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: verdictColor.withAlpha(150)),
-            ),
-            child: Text(
-              verdictLabel,
+  Widget _detailLine(BuildContext context, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Text.rich(
+        TextSpan(
+          children: [
+            TextSpan(
+              text: '$label: ',
               style: TextStyle(
-                color: verdictColor,
-                fontWeight: FontWeight.w600,
-                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurface.withAlpha(160),
               ),
             ),
-          ),
+            TextSpan(
+              text: value,
+              style: const TextStyle(fontWeight: FontWeight.w500),
+            ),
+          ],
         ),
-        DataCell(
-          Text('${(row.bestStationTax * 100).toStringAsFixed(1)}%'),
-        ),
-        DataCell(Text(fmtIsk(row.deltaIskPerHour))),
-      ],
+      ),
     );
   }
 }
@@ -465,4 +570,25 @@ String _secBandLabel(String band) {
     default:
       return 'High-Sec';
   }
+}
+
+/// "Station — System", dropping empty parts; '—' when both are absent.
+String _formatStation(String? name, String? system) {
+  final parts = [name, system]
+      .where((s) => s != null && s.isNotEmpty)
+      .cast<String>()
+      .toList();
+  return parts.isEmpty ? '—' : parts.join(' — ');
+}
+
+/// Human label for a sell location. Citadels (SDE can't name them) render as
+/// "Player-Struktur"; otherwise "Station — System".
+String _formatSell(SellLocation? loc) {
+  if (loc == null) return '—';
+  if (loc.isStructure) return 'Player-Struktur';
+  final parts = [loc.stationName, loc.systemName]
+      .where((s) => s != null && s.isNotEmpty)
+      .cast<String>()
+      .toList();
+  return parts.isEmpty ? 'unbekannt' : parts.join(' — ');
 }

--- a/app/test/mining_models_test.dart
+++ b/app/test/mining_models_test.dart
@@ -101,6 +101,74 @@ void main() {
       });
       expect(row.bestStationId, isNull);
     });
+
+    test('parses location fields: reprocess station, raw_sell, materials', () {
+      final row = OreRankRow.fromJson(const {
+        'ore_type_id': 1230,
+        'ore_name': 'Veldspar',
+        'best': 'refine',
+        'best_station_name': 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
+        'best_station_system': 'Jita',
+        'raw_sell': {
+          'station_name': 'Amarr VIII - Emperor Family Academy',
+          'system_name': 'Amarr',
+          'is_structure': false,
+        },
+        'materials': [
+          {
+            'material_type_id': 34,
+            'material_name': 'Tritanium',
+            'effective_qty': 12345,
+            'buy_price': 5.5,
+            'sell': {
+              'station_name': 'Dodixie IX - Moon 20 - Federation Navy',
+              'system_name': 'Dodixie',
+              'is_structure': false,
+            },
+          },
+        ],
+      });
+
+      expect(row.bestStationName,
+          'Jita IV - Moon 4 - Caldari Navy Assembly Plant');
+      expect(row.bestStationSystem, 'Jita');
+      expect(row.rawSell, isNotNull);
+      expect(row.rawSell!.isStructure, isFalse);
+      expect(row.rawSell!.stationName, 'Amarr VIII - Emperor Family Academy');
+      expect(row.rawSell!.systemName, 'Amarr');
+
+      expect(row.materials, hasLength(1));
+      final mat = row.materials.first;
+      expect(mat.materialTypeId, 34);
+      expect(mat.materialName, 'Tritanium');
+      expect(mat.effectiveQty, 12345);
+      expect(mat.buyPrice, 5.5);
+      expect(mat.sell.systemName, 'Dodixie');
+    });
+
+    test('location fields default when absent (no exceptions)', () {
+      final row = OreRankRow.fromJson(const {
+        'ore_type_id': 1228,
+        'ore_name': 'Scordite',
+        'best': 'raw',
+      });
+      expect(row.bestStationName, isNull);
+      expect(row.bestStationSystem, isNull);
+      expect(row.rawSell, isNull);
+      expect(row.materials, isEmpty);
+    });
+
+    test('citadel sell location parses is_structure=true', () {
+      final row = OreRankRow.fromJson(const {
+        'ore_type_id': 1228,
+        'ore_name': 'Scordite',
+        'best': 'raw',
+        'raw_sell': {'is_structure': true},
+      });
+      expect(row.rawSell, isNotNull);
+      expect(row.rawSell!.isStructure, isTrue);
+      expect(row.rawSell!.stationName, isNull);
+    });
   });
 
   group('OreRankingResponse.fromJson', () {

--- a/app/test/mining_screen_layout_test.dart
+++ b/app/test/mining_screen_layout_test.dart
@@ -57,6 +57,72 @@ OreRankingResponse _fakeResponse() => const OreRankingResponse(
       ],
     );
 
+OreRankingResponse _detailResponse() => const OreRankingResponse(
+      regionId: 10000002,
+      secBand: 'high',
+      noMiningSetup: false,
+      rows: [
+        OreRankRow(
+          oreTypeId: 1230,
+          oreName: 'Veldspar',
+          miningM3PerHour: 3600,
+          rawIskPerHour: 4200000,
+          refineIskPerHour: 5100000,
+          rawNetPerM3: 1166.67,
+          refineNetPerM3: 1416.67,
+          best: 'refine',
+          deltaIskPerHour: 900000,
+          bestStationId: 60003760,
+          bestStationTax: 0.05,
+          bestStationName: 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
+          bestStationSystem: 'Jita',
+          materials: [
+            RefineMaterial(
+              materialTypeId: 34,
+              materialName: 'Tritanium',
+              effectiveQty: 12345,
+              buyPrice: 5.5,
+              sell: SellLocation(
+                isStructure: false,
+                stationName: 'Amarr VIII - Emperor Family Academy',
+                systemName: 'Amarr',
+              ),
+            ),
+          ],
+        ),
+        OreRankRow(
+          oreTypeId: 1228,
+          oreName: 'Scordite',
+          miningM3PerHour: 3000,
+          rawIskPerHour: 3100000,
+          refineIskPerHour: 3400000,
+          rawNetPerM3: 1033.33,
+          refineNetPerM3: 1133.33,
+          best: 'raw',
+          deltaIskPerHour: 300000,
+          bestStationTax: 0.04,
+          rawSell: SellLocation(
+            isStructure: false,
+            stationName: 'Dodixie IX - Moon 20 - Federation Navy Assembly Plant',
+            systemName: 'Dodixie',
+          ),
+        ),
+        OreRankRow(
+          oreTypeId: 1224,
+          oreName: 'Pyroxeres',
+          miningM3PerHour: 2000,
+          rawIskPerHour: 2100000,
+          refineIskPerHour: 1900000,
+          rawNetPerM3: 700,
+          refineNetPerM3: 633,
+          best: 'raw',
+          deltaIskPerHour: 200000,
+          bestStationTax: 0.03,
+          rawSell: SellLocation(isStructure: true),
+        ),
+      ],
+    );
+
 OreRankingResponse _noSetupResponse() => const OreRankingResponse(
       regionId: 10000002,
       secBand: 'high',
@@ -87,6 +153,11 @@ const _currentShip = CharacterShip(
 class _StubNotifier extends OreRankingNotifier {
   @override
   Future<OreRankingResponse?> build() async => _fakeResponse();
+}
+
+class _DetailNotifier extends OreRankingNotifier {
+  @override
+  Future<OreRankingResponse?> build() async => _detailResponse();
 }
 
 class _NoSetupNotifier extends OreRankingNotifier {
@@ -200,5 +271,55 @@ void main() {
     expect(find.byKey(const Key('current-ship-card')), findsOneWidget);
     // Ship name from the stub.
     expect(find.text('Schiff'), findsOneWidget);
+  });
+
+  testWidgets('Location detail is hidden until a row is expanded',
+      (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _DetailNotifier.new);
+
+    // Reprocess station + minerals live in the collapsed (lazy) detail panel.
+    expect(find.textContaining('Aufbereiten bei'), findsNothing);
+    expect(find.text('Tritanium'), findsNothing);
+  });
+
+  testWidgets('Expanding a refine row shows reprocess station + mineral sell',
+      (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _DetailNotifier.new);
+
+    await tester.tap(find.byKey(const ValueKey('mining-ore-expand-1230')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Caldari Navy Assembly Plant — Jita'),
+      findsOneWidget,
+    );
+    expect(find.text('Tritanium'), findsOneWidget);
+    expect(
+      find.textContaining('Emperor Family Academy — Amarr'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('Expanding a raw row shows the raw ore sell location',
+      (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _DetailNotifier.new);
+
+    await tester.tap(find.byKey(const ValueKey('mining-ore-expand-1228')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('Federation Navy Assembly Plant — Dodixie'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('Citadel sell location renders as Player-Struktur',
+      (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _DetailNotifier.new);
+
+    await tester.tap(find.byKey(const ValueKey('mining-ore-expand-1224')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Player-Struktur'), findsOneWidget);
   });
 }

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -177,7 +177,7 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 	if !ok {
 		return nil, fmt.Errorf("skills service does not implement MiningSkillsProvider")
 	}
-	miningService := services.NewMiningService(c.DB.SDE, c.SDERepo, c.MarketRepo, miningSkillsProvider, fittingService, characterHelper, c.SDERepo, c.AppLogger)
+	miningService := services.NewMiningService(c.DB.SDE, c.SDERepo, c.MarketRepo, miningSkillsProvider, fittingService, characterHelper, c.SDERepo, c.SDERepo, c.AppLogger)
 	c.MiningHandler = handlers.NewMiningHandler(miningService)
 
 	// Start the competition collector in the background (lazy-tracked pairs).

--- a/backend/internal/models/mining.go
+++ b/backend/internal/models/mining.go
@@ -8,6 +8,25 @@ type OreRankingRequest struct {
 	SecBand  string `json:"sec_band"`
 }
 
+// SellLocation describes where a market order sits. NPC stations resolve to a name +
+// system; citadels (not in the SDE) carry only IsStructure (UI shows "Player-Structure",
+// the region is already known since the ranking is region-scoped).
+type SellLocation struct {
+	StationName string `json:"station_name,omitempty"`
+	SystemName  string `json:"system_name,omitempty"`
+	IsStructure bool   `json:"is_structure"`
+}
+
+// RefineMaterial is one reprocessing output mineral with where to sell it.
+// EffectiveQty is the amount you actually get per portionSize batch (qty × net yield).
+type RefineMaterial struct {
+	MaterialTypeID int64        `json:"material_type_id"`
+	MaterialName   string       `json:"material_name"`
+	EffectiveQty   int64        `json:"effective_qty"`
+	BuyPrice       float64      `json:"buy_price"`
+	Sell           SellLocation `json:"sell"`
+}
+
 // OreRankRow is one ore's raw-vs-refine ranking row. Per-m³ and isk/h figures are
 // internal (used for sorting); only the user-facing fields are serialized.
 type OreRankRow struct {
@@ -22,6 +41,11 @@ type OreRankRow struct {
 	DeltaISKPerHour  float64 `json:"delta_isk_per_hour"`
 	BestStationID    int64   `json:"best_station_id,omitempty"`
 	BestStationTax   float64 `json:"best_station_tax"`
+	// Where to act:
+	BestStationName   string           `json:"best_station_name,omitempty"`   // reprocess station (NPC type name)
+	BestStationSystem string           `json:"best_station_system,omitempty"` // reprocess station system
+	RawSell           *SellLocation    `json:"raw_sell,omitempty"`            // where to sell the raw ore
+	Materials         []RefineMaterial `json:"materials,omitempty"`           // per-mineral sell breakdown
 }
 
 // OreRankingResponse is the ore-ranking result for a region + security band.

--- a/backend/internal/services/mining_location.go
+++ b/backend/internal/services/mining_location.go
@@ -1,0 +1,58 @@
+package services
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
+)
+
+// locSDE is the SDE subset the sell-location resolver needs.
+type locSDE interface {
+	GetStationName(ctx context.Context, stationID int64) (string, error)
+	GetSystemName(ctx context.Context, systemID int64) (string, error)
+	GetSystemIDForLocation(ctx context.Context, locationID int64) (int64, error)
+}
+
+// citadelIDFloor is the lower bound of Upwell-structure (citadel) item ids; below it are
+// NPC station ids. Citadels are not in the SDE, so they resolve to IsStructure only.
+const citadelIDFloor = int64(1_000_000_000_000)
+
+// locResolver maps market-order location ids to SellLocation, memoizing within a request
+// (many ores' best buys sit at the same regional hub).
+type locResolver struct {
+	sde   locSDE
+	cache map[int64]models.SellLocation
+}
+
+func newLocResolver(sde locSDE) *locResolver {
+	return &locResolver{sde: sde, cache: map[int64]models.SellLocation{}}
+}
+
+// resolve maps a locationID to a SellLocation. NPC stations → station-type name + system;
+// citadels / unresolvable → IsStructure (fail-loud: never a fabricated NPC name).
+func (r *locResolver) resolve(ctx context.Context, locationID int64) models.SellLocation {
+	if loc, ok := r.cache[locationID]; ok {
+		return loc
+	}
+	var loc models.SellLocation
+	switch {
+	case locationID >= citadelIDFloor:
+		loc = models.SellLocation{IsStructure: true}
+	default:
+		name, err := r.sde.GetStationName(ctx, locationID)
+		if err != nil || strings.HasPrefix(name, "Station-") {
+			// GetStationName returns "Station-<id>" for non-NPC ids — treat as a structure.
+			loc = models.SellLocation{IsStructure: true}
+		} else {
+			loc.StationName = name
+			if sysID, e := r.sde.GetSystemIDForLocation(ctx, locationID); e == nil {
+				if sysName, e2 := r.sde.GetSystemName(ctx, sysID); e2 == nil {
+					loc.SystemName = sysName
+				}
+			}
+		}
+	}
+	r.cache[locationID] = loc
+	return loc
+}

--- a/backend/internal/services/mining_location_test.go
+++ b/backend/internal/services/mining_location_test.go
@@ -1,0 +1,56 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func openLocSDE(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	schema := `
+		CREATE TABLE npcStations (_key INTEGER PRIMARY KEY, solarSystemID INTEGER, typeID INTEGER);
+		CREATE TABLE types (_key INTEGER PRIMARY KEY, name TEXT);
+		CREATE TABLE mapSolarSystems (_key INTEGER PRIMARY KEY, name TEXT);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	data := `
+		INSERT INTO types (_key, name) VALUES (1531, '{"en":"Caldari Navy Assembly Plant"}');
+		INSERT INTO mapSolarSystems (_key, name) VALUES (30000142, '{"en":"Jita"}');
+		INSERT INTO npcStations (_key, solarSystemID, typeID) VALUES (60003760, 30000142, 1531);
+	`
+	if _, err := db.Exec(data); err != nil {
+		t.Fatalf("data: %v", err)
+	}
+	return db
+}
+
+func TestResolveSellLocation(t *testing.T) {
+	db := openLocSDE(t)
+	defer func() { _ = db.Close() }()
+	repo := database.NewSDERepository(db)
+	r := newLocResolver(repo)
+	ctx := context.Background()
+
+	npc := r.resolve(ctx, 60003760)
+	if npc.IsStructure {
+		t.Fatalf("NPC station should not be a structure: %+v", npc)
+	}
+	if npc.StationName != "Caldari Navy Assembly Plant" || npc.SystemName != "Jita" {
+		t.Fatalf("npc resolve: %+v", npc)
+	}
+
+	cit := r.resolve(ctx, 1_035_000_000_001) // citadel id ≥ 1e12
+	if !cit.IsStructure || cit.StationName != "" || cit.SystemName != "" {
+		t.Fatalf("citadel should resolve to structure-only: %+v", cit)
+	}
+}

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -3,7 +3,9 @@ package services
 import (
 	"context"
 	"database/sql"
+	"math"
 	"sort"
+	"strings"
 
 	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
 	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
@@ -46,6 +48,16 @@ type MiningRegionProvider interface {
 	GetRegionIDForSystem(ctx context.Context, systemID int64) (int, error)
 }
 
+// MiningNameProvider resolves NPC station/system/type names for the sell + reprocess
+// locations. Implemented by *database.SDERepository; kept narrow for fakeability. Includes
+// the locSDE methods (used by locResolver) plus GetTypeInfo for mineral names.
+type MiningNameProvider interface {
+	GetStationName(ctx context.Context, stationID int64) (string, error)
+	GetSystemName(ctx context.Context, systemID int64) (string, error)
+	GetSystemIDForLocation(ctx context.Context, locationID int64) (int64, error)
+	GetTypeInfo(ctx context.Context, typeID int) (*database.TypeInfo, error)
+}
+
 // MiningService ranks asteroid ores for a region + security band by raw-vs-refine
 // net ISK (per m³ and, with a mining fit, per hour). It reuses the reprocessing/mining
 // evedb building blocks + the ore-compare service helpers.
@@ -57,6 +69,7 @@ type MiningService struct {
 	fitting    MiningModulesProvider
 	location   MiningLocationProvider
 	region     MiningRegionProvider
+	names      MiningNameProvider
 	logger     *logger.Logger
 }
 
@@ -69,6 +82,7 @@ func NewMiningService(
 	fitting MiningModulesProvider,
 	location MiningLocationProvider,
 	region MiningRegionProvider,
+	names MiningNameProvider,
 	logger *logger.Logger,
 ) *MiningService {
 	return &MiningService{
@@ -79,6 +93,7 @@ func NewMiningService(
 		fitting:    fitting,
 		location:   location,
 		region:     region,
+		names:      names,
 		logger:     logger,
 	}
 }
@@ -178,6 +193,21 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	}
 	stationTax := ReprocessTax(baseTake, bestStanding)
 
+	// Resolve the chosen reprocess station's name + system, and a request-scoped
+	// sell-location resolver (memoizes hub stations across ores).
+	loc := newLocResolver(s.names)
+	var bestStationName, bestStationSystem string
+	if bestStationID != 0 {
+		if n, e := s.names.GetStationName(ctx, bestStationID); e == nil && !strings.HasPrefix(n, "Station-") {
+			bestStationName = n
+		}
+		if sysID, e := s.names.GetSystemIDForLocation(ctx, bestStationID); e == nil {
+			if sn, e2 := s.names.GetSystemName(ctx, sysID); e2 == nil {
+				bestStationSystem = sn
+			}
+		}
+	}
+
 	// 5. Per ore.
 	for i := range allOres {
 		if !bandGroups[allOres[i].GroupID] {
@@ -194,36 +224,46 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 			continue
 		}
 
-		oreBuy := s.highestBuyPrice(ctx, regionID, int(o.TypeID))
-
-		// Materials: each material's highest buy price. Missing material price → 0
-		// (that material contributes nothing to the refine value).
-		mats := make([]MaterialValue, 0, len(o.Materials))
-		anyMatPrice := false
-		for _, m := range o.Materials {
-			bp := s.highestBuyPrice(ctx, regionID, int(m.MaterialTypeID))
-			if bp > 0 {
-				anyMatPrice = true
-			}
-			mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: bp})
-		}
-
-		// Skip the ore entirely if NEITHER raw nor refine has any buy-order value.
-		if oreBuy <= 0 && !anyMatPrice {
-			continue
-		}
-
-		oreProc := skills.OreProcessing[o.GroupID]
+		// Net reprocessing yield for this ore (also drives each mineral's effective qty).
 		net := reprocessing.NetYield(baseRate, reprocessing.ReprocessingSkills{
 			Reprocessing:           skills.Reprocessing,
 			ReprocessingEfficiency: skills.ReprocessingEfficiency,
-			OreProcessing:          oreProc,
+			OreProcessing:          skills.OreProcessing[o.GroupID],
 		})
+
+		orePrice, oreLoc, oreOK := s.highestBuyOrder(ctx, regionID, int(o.TypeID))
+
+		// Materials: each material's highest buy order → CompareOre input + per-mineral breakdown.
+		mats := make([]MaterialValue, 0, len(o.Materials))
+		breakdown := make([]models.RefineMaterial, 0, len(o.Materials))
+		anyMatPrice := false
+		for _, m := range o.Materials {
+			mp, mLoc, mOK := s.highestBuyOrder(ctx, regionID, int(m.MaterialTypeID))
+			if mOK && mp > 0 {
+				anyMatPrice = true
+			}
+			mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: mp})
+			rm := models.RefineMaterial{
+				MaterialTypeID: m.MaterialTypeID,
+				MaterialName:   s.typeName(ctx, int(m.MaterialTypeID)),
+				EffectiveQty:   int64(math.Floor(float64(m.Quantity) * net)),
+				BuyPrice:       mp,
+			}
+			if mOK {
+				rm.Sell = loc.resolve(ctx, mLoc)
+			}
+			breakdown = append(breakdown, rm)
+		}
+
+		// Skip the ore entirely if NEITHER raw nor refine has any buy-order value.
+		if !oreOK && !anyMatPrice {
+			continue
+		}
 
 		cmp := CompareOre(OreCompareInput{
 			PortionSize:  o.PortionSize,
 			OreVolumeM3:  o.VolumeM3,
-			OreBuyPrice:  oreBuy,
+			OreBuyPrice:  orePrice,
 			Materials:    mats,
 			NetYield:     net,
 			StationTake:  stationTax,
@@ -231,17 +271,24 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 		})
 
 		row := models.OreRankRow{
-			OreTypeID:        o.TypeID,
-			OreName:          o.Name,
-			MiningM3PerHour:  m3h,
-			RawNetPerM3:      cmp.RawNetPerM3,
-			RefineNetPerM3:   cmp.RefineNetPerM3,
-			Best:             cmp.Best,
-			RawISKPerHour:    m3h * cmp.RawNetPerM3,
-			RefineISKPerHour: m3h * cmp.RefineNetPerM3,
-			DeltaISKPerHour:  m3h * cmp.DeltaPerM3,
-			BestStationID:    bestStationID,
-			BestStationTax:   stationTax,
+			OreTypeID:         o.TypeID,
+			OreName:           o.Name,
+			MiningM3PerHour:   m3h,
+			RawNetPerM3:       cmp.RawNetPerM3,
+			RefineNetPerM3:    cmp.RefineNetPerM3,
+			Best:              cmp.Best,
+			RawISKPerHour:     m3h * cmp.RawNetPerM3,
+			RefineISKPerHour:  m3h * cmp.RefineNetPerM3,
+			DeltaISKPerHour:   m3h * cmp.DeltaPerM3,
+			BestStationID:     bestStationID,
+			BestStationTax:    stationTax,
+			BestStationName:   bestStationName,
+			BestStationSystem: bestStationSystem,
+			Materials:         breakdown,
+		}
+		if oreOK {
+			rs := loc.resolve(ctx, oreLoc)
+			row.RawSell = &rs
 		}
 		resp.Rows = append(resp.Rows, row)
 	}
@@ -260,21 +307,30 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 }
 
 // highestBuyPrice returns the highest buy-order price for (region, type), or 0 if none.
-func (s *MiningService) highestBuyPrice(ctx context.Context, regionID, typeID int) float64 {
+// highestBuyOrder returns the highest buy-order price and its location for (region, type).
+// ok=false when there is no buy order.
+func (s *MiningService) highestBuyOrder(ctx context.Context, regionID, typeID int) (price float64, locationID int64, ok bool) {
 	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warn("ore ranking: market orders fetch failed", "typeID", typeID, "error", err)
 		}
-		return 0
+		return 0, 0, false
 	}
-	best := 0.0
 	for _, o := range orders {
-		if o.IsBuyOrder && o.Price > best {
-			best = o.Price
+		if o.IsBuyOrder && (!ok || o.Price > price) {
+			price, locationID, ok = o.Price, o.LocationID, true
 		}
 	}
-	return best
+	return price, locationID, ok
+}
+
+// typeName resolves a type's name (e.g. for a refined mineral), "" on failure.
+func (s *MiningService) typeName(ctx context.Context, typeID int) string {
+	if ti, err := s.names.GetTypeInfo(ctx, typeID); err == nil && ti != nil {
+		return ti.Name
+	}
+	return ""
 }
 
 func maxFloat(a, b float64) float64 {

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"math"
 	"testing"
 
@@ -26,11 +27,38 @@ func (f *fakeMiningMarket) GetMarketOrders(_ context.Context, _ int, typeID int)
 		return []database.MarketOrder{}, nil
 	}
 	return []database.MarketOrder{
-		{TypeID: typeID, IsBuyOrder: true, Price: price, VolumeRemain: 1_000_000},
+		{TypeID: typeID, IsBuyOrder: true, Price: price, VolumeRemain: 1_000_000, LocationID: 60000123},
 		// a lower buy order + a sell order, to prove we pick the highest buy.
-		{TypeID: typeID, IsBuyOrder: true, Price: price * 0.5, VolumeRemain: 100},
+		{TypeID: typeID, IsBuyOrder: true, Price: price * 0.5, VolumeRemain: 100, LocationID: 60000999},
 		{TypeID: typeID, IsBuyOrder: false, Price: price * 2, VolumeRemain: 100},
 	}, nil
+}
+
+// fakeMiningNames resolves canned station/system/type names. Station 60000001 is the
+// reprocess station; 60000123 is the sell-order station (both NPC); others → structure.
+type fakeMiningNames struct{}
+
+func (fakeMiningNames) GetStationName(_ context.Context, id int64) (string, error) {
+	switch id {
+	case 60000001:
+		return "Test Reprocess Station", nil
+	case 60000123:
+		return "Jita IV-4", nil
+	}
+	return fmt.Sprintf("Station-%d", id), nil // unknown → resolver treats as structure
+}
+
+func (fakeMiningNames) GetSystemName(_ context.Context, _ int64) (string, error) { return "Jita", nil }
+
+func (fakeMiningNames) GetSystemIDForLocation(_ context.Context, _ int64) (int64, error) {
+	return 30000142, nil
+}
+
+func (fakeMiningNames) GetTypeInfo(_ context.Context, typeID int) (*database.TypeInfo, error) {
+	if typeID == tritaniumTypeID {
+		return &database.TypeInfo{Name: "Tritanium"}, nil
+	}
+	return &database.TypeInfo{Name: ""}, nil
 }
 
 type fakeStations struct{ stations []database.ReprocessStation }
@@ -91,7 +119,7 @@ func TestMiningService_OreRanking_Veldspar(t *testing.T) {
 		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
 	}}
 
-	svc := NewMiningService(sdeDB, stations, market, skills, fitting, nil, nil, logger.NewNoop())
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, nil, nil, fakeMiningNames{}, logger.NewNoop())
 
 	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{
 		RegionID: 10000002,
@@ -155,6 +183,27 @@ func TestMiningService_OreRanking_Veldspar(t *testing.T) {
 	if row.BestStationID != 60000001 {
 		t.Errorf("BestStationID: got %d, want 60000001", row.BestStationID)
 	}
+
+	// Locations: reprocess station name+system, raw sell location, per-mineral breakdown.
+	if row.BestStationName != "Test Reprocess Station" || row.BestStationSystem != "Jita" {
+		t.Errorf("reprocess station: name=%q system=%q", row.BestStationName, row.BestStationSystem)
+	}
+	if row.RawSell == nil || row.RawSell.IsStructure || row.RawSell.StationName != "Jita IV-4" || row.RawSell.SystemName != "Jita" {
+		t.Errorf("RawSell: %+v", row.RawSell)
+	}
+	if len(row.Materials) != 1 {
+		t.Fatalf("Materials: want 1 (Tritanium), got %d", len(row.Materials))
+	}
+	mat := row.Materials[0]
+	if mat.MaterialTypeID != tritaniumTypeID || mat.MaterialName != "Tritanium" {
+		t.Errorf("material: id=%d name=%q", mat.MaterialTypeID, mat.MaterialName)
+	}
+	if mat.EffectiveQty != 200 { // floor(400 × 0.50)
+		t.Errorf("EffectiveQty: got %d, want 200", mat.EffectiveQty)
+	}
+	if mat.BuyPrice != tritBuy || mat.Sell.StationName != "Jita IV-4" {
+		t.Errorf("material sell: price=%v sell=%+v", mat.BuyPrice, mat.Sell)
+	}
 }
 
 // TestMiningService_OreRanking_NoMiningSetup verifies that with no fitted mining modules
@@ -176,7 +225,7 @@ func TestMiningService_OreRanking_NoMiningSetup(t *testing.T) {
 		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
 	}}
 
-	svc := NewMiningService(sdeDB, stations, market, skills, fitting, nil, nil, logger.NewNoop())
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, nil, nil, fakeMiningNames{}, logger.NewNoop())
 
 	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{
 		RegionID: 10000002,

--- a/docs/superpowers/plans/2026-05-31-mining-sell-reprocess-locations.md
+++ b/docs/superpowers/plans/2026-05-31-mining-sell-reprocess-locations.md
@@ -1,0 +1,220 @@
+# Mining sell & reprocess locations — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add to each Mining ore-ranking row WHERE to act: the best NPC reprocess station (name + system), where to sell the raw ore, and a per-mineral breakdown (mineral · effective qty · buy price · sell location) for the refine path — citadel locations shown as "Player-Structure".
+
+**Architecture:** Backend captures the best buy order's location (not just price), resolves NPC station/system names (citadels → structure flag), and adds the fields to `OreRankRow` + the per-mineral breakdown in `MiningService.OreRanking`. Web + Flutter rows become expandable to show the locations.
+
+**Tech Stack:** Go 1.24 / Fiber, SQLite SDE, Next.js/React/TS (web), Flutter/Dart (`app/`).
+
+Spec: `docs/superpowers/specs/2026-05-31-mining-sell-reprocess-locations-design.md`.
+
+**Verify env:** backend SDE tests use `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db` + `GOWORK=off`; golangci-lint 0 issues. Commits: prefix `PATH="$HOME/.local/bin:$PATH"`; Conventional Commits; NEVER --no-verify. Branch `feat/mining-sell-reprocess-locations` (already created).
+
+**Confirmed interfaces:**
+- `database.MarketOrder` has `IsBuyOrder bool`, `Price float64`, `LocationID int64`.
+- `*SDERepository`: `GetStationName(ctx, int64) (string, error)` (NPC station-type name; returns `"Station-<id>"` for non-NPC/citadel), `GetSystemName(ctx, int64) (string, error)`, `GetSystemIDForLocation(ctx, int64) (int64, error)`, `GetTypeInfo(ctx, typeID int) (*TypeInfo, error)`.
+- `MiningService` uses narrow dep interfaces (`MarketBuyProvider`, `ReprocessStationProvider`, `MiningLocationProvider`, …) — extend `MiningLocationProvider` with the name/system/type methods (all exist on `*SDERepository`).
+
+---
+
+## Task 1: highestBuyOrder — capture price + location
+
+**Files:** `internal/services/mining_service.go`, `internal/services/mining_service_test.go`.
+
+- [ ] **Step 1 — replace `highestBuyPrice`** with one that also returns the order's location:
+```go
+// highestBuyOrder returns the highest buy-order price and its location for (region, type).
+// ok=false when there is no buy order.
+func (s *MiningService) highestBuyOrder(ctx context.Context, regionID, typeID int) (price float64, locationID int64, ok bool) {
+	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("ore ranking: market orders fetch failed", "typeID", typeID, "error", err)
+		}
+		return 0, 0, false
+	}
+	for _, o := range orders {
+		if o.IsBuyOrder && (!ok || o.Price > price) {
+			price, locationID, ok = o.Price, o.LocationID, true
+		}
+	}
+	return price, locationID, ok
+}
+```
+Update the two call sites in `OreRanking` (ore price, material price) to use the new signature (keep the existing `oreBuy`/`bp` price usage; you now also have the locationID for Task 4). Until Task 4 uses them, you may temporarily ignore the locationID with `_` — but prefer to land Task 4 right after so nothing is unused.
+
+- [ ] **Step 2 — run** `SDE_DB_PATH=… GOWORK=off go test ./internal/services/ -run Mining` — existing mining tests still pass (the change is internal; the fake market repo already returns orders with a LocationID — set one in the test fixture if not).
+- [ ] **Step 3 — commit:** `... -m "refactor(mining): capture buy-order location alongside price"`
+
+## Task 2: resolveSellLocation + SellLocation type
+
+**Files:** `internal/services/mining_location.go` (new) + `internal/services/mining_location_test.go`.
+
+- [ ] **Step 1 — failing test** (in-memory SDE: an NPC station + its system; a citadel id):
+```go
+func TestResolveSellLocation(t *testing.T) {
+	db := openLocSDE(t) // npcStations(60003760→typeID 1531, sys 30000142), types(1531 'Caldari Navy Assembly Plant'), mapSolarSystems(30000142 'Jita')
+	repo := database.NewSDERepository(db)
+	r := newLocResolver(repo)
+
+	npc := r.resolve(context.Background(), 60003760)
+	if npc.IsStructure || npc.StationName == "" || npc.SystemName != "Jita" {
+		t.Fatalf("npc: %+v", npc)
+	}
+	cit := r.resolve(context.Background(), 1_035_000_000_001) // citadel id ≥ 1e12
+	if !cit.IsStructure || cit.StationName != "" {
+		t.Fatalf("citadel: %+v", cit)
+	}
+}
+```
+> Write `openLocSDE` mirroring `sde_reprocess_test.go`'s in-memory-schema style (create `npcStations`, `types`, `mapSolarSystems`; insert the rows). `GetStationName` joins `npcStations.typeID → types.name` (json `$.en`); `GetSystemName` reads `mapSolarSystems` (check the exact column it uses — read `GetSystemName` first).
+
+- [ ] **Step 2 — run, expect fail.**
+- [ ] **Step 3 — implement** `mining_location.go`:
+```go
+package services
+
+import (
+	"context"
+	"strings"
+)
+
+// SellLocation describes where an order sits. Citadels (not in the SDE) carry only IsStructure.
+type SellLocation struct {
+	StationName string `json:"station_name,omitempty"`
+	SystemName  string `json:"system_name,omitempty"`
+	IsStructure bool   `json:"is_structure"`
+}
+
+// locSDE is the SDE subset the resolver needs.
+type locSDE interface {
+	GetStationName(ctx context.Context, stationID int64) (string, error)
+	GetSystemName(ctx context.Context, systemID int64) (string, error)
+	GetSystemIDForLocation(ctx context.Context, locationID int64) (int64, error)
+}
+
+type locResolver struct {
+	sde   locSDE
+	cache map[int64]SellLocation
+}
+
+func newLocResolver(sde locSDE) *locResolver { return &locResolver{sde: sde, cache: map[int64]SellLocation{}} }
+
+const citadelIDFloor = int64(1_000_000_000_000)
+
+// resolve maps a market-order locationID to a SellLocation. NPC stations → name + system;
+// citadels / unresolvable → IsStructure (fail-loud: never a fabricated NPC name).
+func (r *locResolver) resolve(ctx context.Context, locationID int64) SellLocation {
+	if loc, ok := r.cache[locationID]; ok {
+		return loc
+	}
+	var loc SellLocation
+	if locationID >= citadelIDFloor {
+		loc = SellLocation{IsStructure: true}
+	} else if name, err := r.sde.GetStationName(ctx, locationID); err != nil || strings.HasPrefix(name, "Station-") {
+		loc = SellLocation{IsStructure: true}
+	} else {
+		loc.StationName = name
+		if sysID, e := r.sde.GetSystemIDForLocation(ctx, locationID); e == nil {
+			if sysName, e2 := r.sde.GetSystemName(ctx, sysID); e2 == nil {
+				loc.SystemName = sysName
+			}
+		}
+	}
+	r.cache[locationID] = loc
+	return loc
+}
+```
+
+- [ ] **Step 4 — run, expect PASS.**
+- [ ] **Step 5 — commit:** `... -m "feat(mining): resolve sell location (NPC station/system; citadel→structure)"`
+
+## Task 3: model additions
+
+**Files:** `internal/models/mining.go`.
+
+- [ ] **Step 1 — add** to `models`:
+```go
+type RefineMaterial struct {
+	MaterialTypeID int64               `json:"material_type_id"`
+	MaterialName   string              `json:"material_name"`
+	EffectiveQty   int64               `json:"effective_qty"`
+	BuyPrice       float64             `json:"buy_price"`
+	Sell           services.SellLocation `json:"sell"`
+}
+```
+> `SellLocation` lives in `package services`; to avoid an import cycle (models must not import services), **define `SellLocation` in `package models`** instead (move the type from Task 2 into `models/mining.go`, and have `services` reference `models.SellLocation`). Adjust Task 2's resolver to return `models.SellLocation`. Add to `OreRankRow`:
+```go
+	BestStationName   string                 `json:"best_station_name,omitempty"`
+	BestStationSystem string                 `json:"best_station_system,omitempty"`
+	RawSell           *models.SellLocation   `json:"raw_sell,omitempty"`
+	Materials         []models.RefineMaterial `json:"materials,omitempty"`
+```
+(Place `SellLocation`/`RefineMaterial` in `models/mining.go`; `OreRankRow` references them directly since it's already in `models`.)
+
+- [ ] **Step 2 — build** `GOWORK=off go build ./...` (no test yet — wired in Task 4).
+- [ ] **Step 3 — commit:** `... -m "feat(mining): response fields for sell + reprocess locations"`
+
+## Task 4: wire locations into OreRanking
+
+**Files:** `internal/services/mining_service.go`, `mining_service_test.go`. Extend `MiningLocationProvider` (the service's SDE dep) with `GetStationName`, `GetSystemName`, `GetSystemIDForLocation`, `GetTypeInfo` if not already present, and update the fakes in `mining_service_test.go`.
+
+- [ ] **Step 1 — in `OreRanking`**, build a `locResolver` once per call from the service's SDE dep. Per ore:
+  - ore best-buy: `orePrice, oreLoc, oreOK := s.highestBuyOrder(...)`; if `oreOK`, `row.RawSell = ptr(loc.resolve(ctx, oreLoc))`.
+  - per material: `mp, mLoc, mOK := s.highestBuyOrder(...)`; build `models.RefineMaterial{ MaterialTypeID, MaterialName: typeName(ctx, matID), EffectiveQty: int64(math.Floor(float64(m.Quantity)*netYield)), BuyPrice: mp, Sell: loc.resolve(ctx, mLoc) }` (sell zero-value when `!mOK`); append to `row.Materials`.
+  - reprocess station: `row.BestStationName = stationName(ctx, best.StationID)`; `row.BestStationSystem`: `GetSystemIDForLocation(best.StationID) → GetSystemName`.
+  `typeName` uses `GetTypeInfo(ctx, int(matID)).Name` (guard nil/err → ""). Keep the existing `CompareOre` math unchanged.
+
+- [ ] **Step 2 — extend the service test:** assert a Veldspar row has `RawSell` (with the fake station's name/system or IsStructure), and a `Materials` entry for Tritanium (type 34) with `EffectiveQty == floor(400×netYield)`, its `BuyPrice`, and `Sell`; and that a refine-verdict ore sets `BestStationName`/`BestStationSystem`. Extend the fake SDE/location provider to return canned names.
+
+- [ ] **Step 3 — verify + commit:** `cd backend && gofmt -l internal && GOWORK=off go vet ./... && GOWORK=off golangci-lint run ./... && SDE_DB_PATH=… GOWORK=off go test ./...` → all green; `... -m "feat(mining): populate sell + reprocess locations in ore ranking"`.
+
+---
+
+## Task 5: web — types, api, expandable row
+
+**Files:** `frontend/src/types/trading.ts`, `frontend/src/components/trading/OreRankingTable.tsx`, test.
+
+- [ ] **Step 1 — types:** add `SellLocation { station_name?: string; system_name?: string; is_structure: boolean }`, `RefineMaterial { material_type_id: number; material_name: string; effective_qty: number; buy_price: number; sell: SellLocation }`; extend `OreRankRow` with `best_station_name?`, `best_station_system?`, `raw_sell?: SellLocation`, `materials?: RefineMaterial[]`. (`fetchOreRanking` is unchanged — same endpoint.)
+
+- [ ] **Step 2 — `OreRankingTable`:** make each row **expandable** (a click/chevron toggles a detail panel under the row — mirror an existing expandable component if one exists; else a simple `useState` open-set keyed by `ore_type_id`). Detail panel:
+  - if `best === "refine"`: show the reprocess station — `formatLocation(best_station_name, best_station_system)` (e.g. "Caldari Navy Assembly Plant — Jita") and a small **materials table**: `material_name · effective_qty · buy_price · formatSell(sell)`.
+  - if `best === "raw"`: show "Verkaufen: " + `formatSell(raw_sell)`.
+  - `formatSell(loc)`: `loc.is_structure ? "Player-Structure" : [loc.station_name, loc.system_name].filter(Boolean).join(" — ")`.
+  Add a "Verkaufs-/Aufbereitungs-Ort" affordance (chevron) on each row.
+
+- [ ] **Step 3 — test** (`tests/components/OreRankingTable.test.tsx`, extend): a refine row, when expanded, shows the reprocess station name + a material row with its sell location; a raw row shows the raw sell location; a row with `is_structure` sell shows "Player-Structure". Mirror existing test style.
+
+- [ ] **Step 4 — verify + commit:** `cd frontend && npx vitest run && rm -rf .next && npm run build && npx eslint <files>`; `... -m "feat(frontend): expandable mining rows with sell + reprocess locations"`.
+
+---
+
+## Task 6: Flutter — models + expandable row
+
+**Files:** `app/lib/api/mining_models.dart`, `app/lib/features/mining/mining_screen.dart` (or the ore_ranking_table widget), tests.
+
+- [ ] **Step 1 — models:** add `SellLocation.fromJson{stationName?, systemName?, isStructure}`, `RefineMaterial.fromJson{materialTypeId, materialName, effectiveQty, buyPrice, sell}`; extend `OreRankRow.fromJson` with `bestStationName?`, `bestStationSystem?`, `rawSell?`, `materials?`.
+
+- [ ] **Step 2 — table:** make each ore row **expandable** (`ExpansionTile` or the existing detail idiom). Expanded content mirrors web: refine → reprocess station (name — system) + per-material list (name · effective qty · buy price · sell location); raw → raw sell location; `isStructure` → "Player-Structure". Add a `_formatSell` helper.
+
+- [ ] **Step 3 — tests:** model fromJson for the new fields; a widget test expanding a refine row shows the station + a material's sell location; a structure sell shows "Player-Structure".
+
+- [ ] **Step 4 — verify + commit:** `cd app && flutter analyze && flutter test`; `... -m "feat(flutter): expandable mining rows with sell + reprocess locations"`.
+
+---
+
+## Task 7: full verification + PR
+
+- [ ] Backend: `gofmt -l internal pkg && GOWORK=off go vet ./... && GOWORK=off golangci-lint run ./... && SDE_DB_PATH=… GOWORK=off go test ./...` → green, golangci 0.
+- [ ] Web: `npx vitest run && npm run build`. Flutter: `flutter analyze && flutter test`.
+- [ ] Push `feat/mining-sell-reprocess-locations`; open PR (base main). After CI green + merge → release `v0.21.0` (gated). No Flutter APK rebuild needed for backend-only? — this touches Flutter too, so **rebuild + reinstall the APK** after release (`flutter build apk --release --dart-define=…` + `adb install -r`).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** reprocess station name+system (T4), raw sell location (T4), per-mineral breakdown with effective qty + buy price + sell location (T3/T4), citadel→structure (T2), buy-order-location capture without valuation change (T1), web expandable (T5), Flutter expandable (T6), fail-loud unresolvable→structure (T2). All covered.
+- **Import-cycle note:** `SellLocation`/`RefineMaterial` live in `package models`; `services` returns `models.SellLocation` — avoids models→services cycle. (Resolved inline in T3.)
+- **Verify during execution:** the exact `GetSystemName` source column; whether `MiningLocationProvider` already has these methods (extend + update fakes if not); an existing expandable-row pattern to mirror (web + Flutter).

--- a/docs/superpowers/specs/2026-05-31-mining-sell-reprocess-locations-design.md
+++ b/docs/superpowers/specs/2026-05-31-mining-sell-reprocess-locations-design.md
@@ -1,0 +1,116 @@
+# Mining ranking — sell & reprocess locations — Design
+
+**Date:** 2026-05-31
+**Status:** Approved (design)
+
+## Problem
+
+The Mining ore-ranking tells you *whether* to sell raw or reprocess, but not *where*: which
+NPC station to reprocess at, and where to sell the raw ore or the refined minerals. The
+backend already picks the best reprocessing station internally but only surfaces its tax
+(no name), and it values sales at the best buy order but discards that order's location.
+
+## Goal
+
+Per ore row, surface the actionable locations:
+- **Reprocess** (when refine is suggested): the chosen best NPC station — **name + system**.
+- **Sell, raw** (when raw is suggested): the location of the best buy order for the ore.
+- **Sell, refine**: a **per-mineral breakdown** — each output mineral with its effective
+  quantity, buy price, and the location of its best buy order.
+
+## Decisions (from brainstorming)
+
+- Refine sell location: **per-mineral breakdown** (each mineral its own best-buy location),
+  expandable per row.
+- Buy orders: **best regardless of location** (incl. citadels) — **no valuation change**. NPC
+  stations resolve to a name + system; citadels (LocationID not in SDE) show as
+  "Player-Structure" (the region is already known — the ranking is region-scoped).
+- Reprocessing stays **NPC stations only** (as today).
+
+## Architecture
+
+### Sell-location resolution (new)
+
+`highestBuyPrice(region, type)` → `highestBuyOrder(region, type) (price float64, locationID int64, ok bool)`.
+
+New helper `resolveSellLocation(ctx, locationID) SellLocation`:
+- `SellLocation{ StationName string; SystemName string; IsStructure bool }`.
+- NPC station (resolvable via `SDERepository`): `StationName` = `GetStationName` (station-type
+  name, e.g. "Caldari Navy Assembly Plant"); `SystemName` = the station's `solarSystemID` →
+  `GetSystemName`; `IsStructure = false`.
+- Citadel / unresolvable (LocationID ≥ 1e12, or station lookup fails): `IsStructure = true`,
+  `StationName = ""`, `SystemName = ""` (UI shows "Player-Structure"; region known from context).
+- Failures to resolve are surfaced as the structure/unknown state — never a fabricated NPC name
+  (fail-loud).
+
+### Reprocess station resolution
+
+The service already has `best.StationID`. Resolve `best_station_name` (= `GetStationName`)
+and `best_station_system` (= station `solarSystemID` → `GetSystemName`).
+
+### Response model (`OreRankRow` additions)
+
+```go
+type SellLocation struct {
+	StationName string `json:"station_name,omitempty"`
+	SystemName  string `json:"system_name,omitempty"`
+	IsStructure bool   `json:"is_structure"`
+}
+type RefineMaterial struct {
+	MaterialTypeID int64        `json:"material_type_id"`
+	MaterialName   string       `json:"material_name"`
+	EffectiveQty   int64        `json:"effective_qty"` // qty × netYield per portionSize batch, floored
+	BuyPrice       float64      `json:"buy_price"`
+	Sell           SellLocation `json:"sell"`
+}
+// OreRankRow gains:
+//   BestStationName   string           `json:"best_station_name,omitempty"`
+//   BestStationSystem string           `json:"best_station_system,omitempty"`
+//   RawSell           *SellLocation    `json:"raw_sell,omitempty"`     // ore's best-buy location
+//   Materials         []RefineMaterial `json:"materials,omitempty"`    // per-mineral breakdown
+```
+
+`MaterialName` resolved via `SDERepository.GetTypeInfo`. `EffectiveQty = floor(material.Quantity × netYield)`.
+
+### Service flow (MiningService.OreRanking)
+
+For each in-scope ore, in addition to today's comparison:
+- ore best-buy → `RawSell = resolveSellLocation(oreLocationID)`.
+- per material: best-buy (price + locationID) → `Materials += {…, EffectiveQty, BuyPrice, Sell: resolveSellLocation(matLocationID)}`.
+- reprocess: `BestStationName/System` from `best.StationID`.
+Caching: `resolveSellLocation` results memoized per request (many ores share the same hub
+station) to avoid repeated SDE lookups.
+
+### Frontend (web + Flutter)
+
+Each ore row becomes **expandable**. Collapsed: today's columns (+ the reprocess station
+name shown compactly when best=refine). Expanded:
+- best=refine → the reprocess station (name + system) and the **per-mineral table**
+  (Mineral · effektive Menge · Buy-Preis · Verkaufsort).
+- best=raw → the raw ore's sell location.
+- Citadel locations render as "Player-Structure".
+Mirror the existing expandable/detail patterns in the app (web + Flutter).
+
+## Error handling (fail-loud)
+
+- Unresolvable location → "Player-Structure" / "unbekannt"; never a fabricated station name.
+- Station/system/type-name resolution errors → logged + surfaced as the unknown state, not
+  silently dropped.
+
+## Testing
+
+- `resolveSellLocation`: NPC station → name + system, `IsStructure=false`; citadel id (≥ 1e12)
+  → `IsStructure=true`, empty name (against an in-memory SDE with npcStations + mapSolarSystems).
+- `highestBuyOrder`: returns the price AND location of the max buy order; `ok=false` when none.
+- Service: a Veldspar row carries `RawSell` (ore's buy location) and a `Materials` entry for
+  Tritanium with `EffectiveQty = floor(400 × netYield)`, its buy price, and sell location; a
+  refine-verdict ore carries the reprocess station name+system.
+- Frontend: expanding a refine row shows the per-mineral table + reprocess station; a raw row
+  shows the raw sell location; a citadel location shows "Player-Structure".
+
+## Scope / YAGNI
+
+- No system-accurate citadel resolution (SDE has no citadel data) — deliberately "Player-Structure".
+- Station name is the station-*type* name + system (the SDE has no unique per-station name column);
+  good enough to navigate to.
+- Reprocessing remains NPC-only; valuation unchanged (best buy regardless of location).

--- a/frontend/src/components/trading/OreRankingTable.tsx
+++ b/frontend/src/components/trading/OreRankingTable.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import type { OreRankRow } from "@/types/trading";
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import type { OreRankRow, SellLocation } from "@/types/trading";
 import { cn, formatISK } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
@@ -8,10 +10,22 @@ interface OreRankingTableProps {
   rows: OreRankRow[];
 }
 
+function formatSell(loc?: SellLocation): string {
+  if (!loc) return "—";
+  if (loc.is_structure) return "Player-Structure";
+  const parts = [loc.station_name, loc.system_name].filter(Boolean);
+  return parts.length ? parts.join(" — ") : "unbekannt";
+}
+
+function formatStation(name?: string, system?: string): string {
+  const parts = [name, system].filter(Boolean);
+  return parts.length ? parts.join(" — ") : "—";
+}
+
 /**
  * Ranks ores by ISK/hour (raw sell vs reprocess). Rows arrive pre-sorted by
- * best ISK/hour descending. An empty rows array means no ore data was found
- * for the given region/sec-band combination.
+ * best ISK/hour descending. Each row expands to show where to reprocess and
+ * where to sell (raw ore, or a per-mineral breakdown for the refine path).
  */
 export function OreRankingTable({ rows }: OreRankingTableProps) {
   if (rows.length === 0) {
@@ -42,27 +56,13 @@ export function OreRankingTable({ rows }: OreRankingTableProps) {
           <table className="w-full text-sm" aria-label="Erz-Ranking">
             <thead>
               <tr className="border-b text-left text-muted-foreground">
-                <th scope="col" className="px-4 py-3 font-medium">
-                  Erz
-                </th>
-                <th scope="col" className="px-4 py-3 text-right font-medium">
-                  m³/h
-                </th>
-                <th scope="col" className="px-4 py-3 text-right font-medium">
-                  ISK/h roh
-                </th>
-                <th scope="col" className="px-4 py-3 text-right font-medium">
-                  ISK/h refine
-                </th>
-                <th scope="col" className="px-4 py-3 font-medium">
-                  Verdict
-                </th>
-                <th scope="col" className="px-4 py-3 text-right font-medium">
-                  Steuer
-                </th>
-                <th scope="col" className="px-4 py-3 text-right font-medium">
-                  Δ ISK/h
-                </th>
+                <th scope="col" className="px-4 py-3 font-medium">Erz</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">m³/h</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">ISK/h roh</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">ISK/h refine</th>
+                <th scope="col" className="px-4 py-3 font-medium">Verdict</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">Steuer</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">Δ ISK/h</th>
               </tr>
             </thead>
             <tbody>
@@ -78,6 +78,7 @@ export function OreRankingTable({ rows }: OreRankingTableProps) {
 }
 
 function OreRankRow({ row }: { row: OreRankRow }) {
+  const [open, setOpen] = useState(false);
   const isRefine = row.best === "refine";
   const verdictText = isRefine ? "Reprozessieren" : "Roh verkaufen";
   const verdictClass = isRefine
@@ -90,22 +91,73 @@ function OreRankRow({ row }: { row: OreRankRow }) {
       : String(row.mining_m3_per_hour);
 
   return (
-    <tr
-      data-testid="ore-ranking-row"
-      data-ore-type-id={row.ore_type_id}
-      className="border-b transition-colors hover:bg-muted/40"
-    >
-      <td className="px-4 py-3 font-medium">{row.ore_name}</td>
-      <td className="px-4 py-3 text-right">{m3PerHour}</td>
-      <td className="px-4 py-3 text-right">{formatISK(row.raw_isk_per_hour)}</td>
-      <td className="px-4 py-3 text-right">{formatISK(row.refine_isk_per_hour)}</td>
-      <td className={cn("px-4 py-3", verdictClass)}>{verdictText}</td>
-      <td className="px-4 py-3 text-right">
-        {(row.best_station_tax * 100).toFixed(1)}%
-      </td>
-      <td className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
-        {formatISK(row.delta_isk_per_hour)}
-      </td>
-    </tr>
+    <>
+      <tr
+        data-testid="ore-ranking-row"
+        data-ore-type-id={row.ore_type_id}
+        className="cursor-pointer border-b transition-colors hover:bg-muted/40"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <td className="px-4 py-3 font-medium">
+          <span className="inline-flex items-center gap-1">
+            {open ? (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            )}
+            {row.ore_name}
+          </span>
+        </td>
+        <td className="px-4 py-3 text-right">{m3PerHour}</td>
+        <td className="px-4 py-3 text-right">{formatISK(row.raw_isk_per_hour)}</td>
+        <td className="px-4 py-3 text-right">{formatISK(row.refine_isk_per_hour)}</td>
+        <td className={cn("px-4 py-3", verdictClass)}>{verdictText}</td>
+        <td className="px-4 py-3 text-right">{(row.best_station_tax * 100).toFixed(1)}%</td>
+        <td className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
+          {formatISK(row.delta_isk_per_hour)}
+        </td>
+      </tr>
+      {open && (
+        <tr data-testid="ore-ranking-detail" className="border-b bg-muted/20">
+          <td colSpan={7} className="px-4 py-3">
+            {isRefine ? (
+              <div className="space-y-2">
+                <div className="text-sm">
+                  <span className="text-muted-foreground">Aufbereiten bei: </span>
+                  {formatStation(row.best_station_name, row.best_station_system)}
+                </div>
+                <div className="text-sm text-muted-foreground">Raffinate verkaufen:</div>
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="text-left text-muted-foreground">
+                      <th className="py-1 pr-4 font-medium">Mineral</th>
+                      <th className="py-1 pr-4 text-right font-medium">Menge</th>
+                      <th className="py-1 pr-4 text-right font-medium">Buy</th>
+                      <th className="py-1 font-medium">Verkaufsort</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(row.materials ?? []).map((m) => (
+                      <tr key={m.material_type_id}>
+                        <td className="py-1 pr-4">{m.material_name || `Typ ${m.material_type_id}`}</td>
+                        <td className="py-1 pr-4 text-right">{m.effective_qty.toLocaleString("de-DE")}</td>
+                        <td className="py-1 pr-4 text-right">{formatISK(m.buy_price)}</td>
+                        <td className="py-1">{formatSell(m.sell)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="text-sm">
+                <span className="text-muted-foreground">Roh verkaufen bei: </span>
+                {formatSell(row.raw_sell)}
+              </div>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
   );
 }

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -351,6 +351,20 @@ export interface OreRankingRequest {
   sec_band: string; // "high" | "low" | "null"
 }
 
+export interface SellLocation {
+  station_name?: string;
+  system_name?: string;
+  is_structure: boolean;
+}
+
+export interface RefineMaterial {
+  material_type_id: number;
+  material_name: string;
+  effective_qty: number;
+  buy_price: number;
+  sell: SellLocation;
+}
+
 export interface OreRankRow {
   ore_type_id: number;
   ore_name: string;
@@ -363,6 +377,10 @@ export interface OreRankRow {
   delta_isk_per_hour: number;
   best_station_id?: number;
   best_station_tax: number;
+  best_station_name?: string;
+  best_station_system?: string;
+  raw_sell?: SellLocation;
+  materials?: RefineMaterial[];
 }
 
 export interface OreRankingResponse {

--- a/frontend/tests/components/OreRankingTable.test.tsx
+++ b/frontend/tests/components/OreRankingTable.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, fireEvent } from "@testing-library/react";
 import { OreRankingTable } from "@/components/trading/OreRankingTable";
 import { OreRankRow } from "@/types/trading";
 
@@ -84,5 +84,89 @@ describe("OreRankingTable", () => {
 
     expect(screen.getByTestId("ore-ranking-empty")).toBeInTheDocument();
     expect(screen.queryByTestId("ore-ranking-row")).not.toBeInTheDocument();
+  });
+
+  it("hides the detail panel until a row is clicked", () => {
+    render(<OreRankingTable rows={rows} />);
+
+    expect(screen.queryByTestId("ore-ranking-detail")).not.toBeInTheDocument();
+  });
+
+  it("expands a refine row to show the reprocess station and per-mineral sell breakdown", () => {
+    const refineRows: OreRankRow[] = [
+      makeRow({
+        ore_type_id: 1230,
+        ore_name: "Veldspar",
+        best: "refine",
+        best_station_name: "Jita IV - Moon 4 - Caldari Navy Assembly Plant",
+        best_station_system: "Jita",
+        materials: [
+          {
+            material_type_id: 34,
+            material_name: "Tritanium",
+            effective_qty: 12345,
+            buy_price: 5.5,
+            sell: {
+              station_name: "Amarr VIII - Emperor Family Academy",
+              system_name: "Amarr",
+              is_structure: false,
+            },
+          },
+        ],
+      }),
+    ];
+    render(<OreRankingTable rows={refineRows} />);
+
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+
+    const detail = screen.getByTestId("ore-ranking-detail");
+    expect(
+      within(detail).getByText(/Caldari Navy Assembly Plant — Jita/),
+    ).toBeInTheDocument();
+    expect(within(detail).getByText("Tritanium")).toBeInTheDocument();
+    expect(within(detail).getByText("12.345")).toBeInTheDocument(); // de-DE grouping
+    expect(
+      within(detail).getByText(/Emperor Family Academy — Amarr/),
+    ).toBeInTheDocument();
+  });
+
+  it("expands a raw row to show the raw ore sell location", () => {
+    const rawRows: OreRankRow[] = [
+      makeRow({
+        ore_type_id: 1228,
+        ore_name: "Scordite",
+        best: "raw",
+        raw_sell: {
+          station_name: "Dodixie IX - Moon 20 - Federation Navy Assembly Plant",
+          system_name: "Dodixie",
+          is_structure: false,
+        },
+      }),
+    ];
+    render(<OreRankingTable rows={rawRows} />);
+
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+
+    const detail = screen.getByTestId("ore-ranking-detail");
+    expect(
+      within(detail).getByText(/Federation Navy Assembly Plant — Dodixie/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Player-Structure' for a sell location inside a citadel", () => {
+    const structureRows: OreRankRow[] = [
+      makeRow({
+        ore_type_id: 1228,
+        ore_name: "Scordite",
+        best: "raw",
+        raw_sell: { is_structure: true },
+      }),
+    ];
+    render(<OreRankingTable rows={structureRows} />);
+
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+
+    const detail = screen.getByTestId("ore-ranking-detail");
+    expect(within(detail).getByText("Player-Structure")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Was

Die Mining-Erz-Rangliste zeigt jetzt **wo** man aufbereiten und **wo** man verkaufen soll — auf Nachfrage pro Erz aufklappbar (Web + Flutter-Tablet).

- **Refine-Pfad:** beste NPC-Aufbereitungs-Station (Name — System) + pro-Mineral-Aufschlüsselung (Mineral · effektive Menge nach Net-Yield · Buy-Preis · Verkaufsort).
- **Roh-Pfad:** Verkaufsort des Roherzes (bestes Buy-Order, egal wo).
- Citadels lassen sich aus der SDE nicht benennen → Anzeige als „Player-Structure" / „Player-Struktur".

## Wie

- **Backend** (`mining_location.go`, `mining_service.go`, `models/mining.go`): neuer `locResolver` (Citadel ≥ 1e12 → Struktur, sonst NPC-Stationsname + System, gecacht). `highestBuyOrder` liefert jetzt zusätzlich die `location_id` des konkreten Sell-Orders. Pro-Mineral-Breakdown mit `EffectiveQty = floor(qty × netYield)`.
- **Web** (`OreRankingTable.tsx`): Zeilen aufklappbar; Detail-Panel mit Reprozessier-Station + Mineral-Tabelle bzw. Roh-Verkaufsort.
- **Flutter** (`mining_screen.dart`): `DataTable` → `ExpansionTile`-Liste; gleiche Detail-Inhalte. DTOs `SellLocation`/`RefineMaterial` null/float-robust.

## Tests

- Backend: `mining_location_test.go` (Resolver) + erweiterte `mining_service_test.go` (Stationsname/System, RawSell, Materials-Breakdown). `go test`/`vet`/`golangci-lint` = 0 issues.
- Web: erweiterte `OreRankingTable.test.tsx` (Expand-Verhalten, Refine-/Roh-/Citadel-Detail) — 90 Tests grün, `next build` ok.
- Flutter: erweiterte `mining_models_test.dart` (neue Felder, Citadel) + `mining_screen_layout_test.dart` (Expand-Tests) — 24 Tests grün, `flutter analyze` clean.

Spec: `docs/superpowers/specs/2026-05-31-mining-sell-reprocess-locations-design.md`
Plan: `docs/superpowers/plans/2026-05-31-mining-sell-reprocess-locations.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)