### PR TITLE
feat(mining): rank by effective ISK/h (haul-downtime cycle)

### DIFF
--- a/app/lib/api/mining_models.dart
+++ b/app/lib/api/mining_models.dart
@@ -134,6 +134,12 @@ class OreRankRow {
     this.crystalMultiplier = 1.0,
     this.isEstimate = false,
     this.estimateReason,
+    this.effectiveIskPerHour = 0.0,
+    this.loadVolumeM3 = 0.0,
+    this.fillMinutes = 0.0,
+    this.cycleMinutes = 0.0,
+    this.routeJumps = 0,
+    this.sellSystemName,
   });
 
   /// Backend: `ore_type_id`
@@ -194,6 +200,24 @@ class OreRankRow {
   /// Backend: `estimate_reason` — short reason, present only when [isEstimate].
   final String? estimateReason;
 
+  /// Backend: `effective_isk_per_hour` — ISK/h including fill + travel cycle.
+  final double effectiveIskPerHour;
+
+  /// Backend: `load_volume_m3` — m³ loaded per haul cycle.
+  final double loadVolumeM3;
+
+  /// Backend: `fill_minutes` — minutes to fill the cargo hold.
+  final double fillMinutes;
+
+  /// Backend: `cycle_minutes` — total cycle time in minutes (fill + travel).
+  final double cycleMinutes;
+
+  /// Backend: `route_jumps` — jumps to sell station and back.
+  final int routeJumps;
+
+  /// Backend: `sell_system_name` — nullable; name of the sell system.
+  final String? sellSystemName;
+
   factory OreRankRow.fromJson(Map<String, dynamic> json) {
     final rawMaterials = json['materials'] as List<dynamic>? ?? const [];
     return OreRankRow(
@@ -223,6 +247,12 @@ class OreRankRow {
       crystalMultiplier: (json['crystal_multiplier'] as num?)?.toDouble() ?? 1.0,
       isEstimate: json['is_estimate'] as bool? ?? false,
       estimateReason: json['estimate_reason'] as String?,
+      effectiveIskPerHour: (json['effective_isk_per_hour'] as num?)?.toDouble() ?? 0.0,
+      loadVolumeM3: (json['load_volume_m3'] as num?)?.toDouble() ?? 0.0,
+      fillMinutes: (json['fill_minutes'] as num?)?.toDouble() ?? 0.0,
+      cycleMinutes: (json['cycle_minutes'] as num?)?.toDouble() ?? 0.0,
+      routeJumps: (json['route_jumps'] as num?)?.toInt() ?? 0,
+      sellSystemName: json['sell_system_name'] as String?,
     );
   }
 }

--- a/app/lib/features/mining/mining_screen.dart
+++ b/app/lib/features/mining/mining_screen.dart
@@ -202,7 +202,8 @@ class _ResultPane extends ConsumerWidget {
               child: Text(
                 'Hinweis: ISK/h berücksichtigt Schiffs-/Skill-Boni und (best-case) '
                 'Erz-Crystals. Zeilen mit ≈ sind Schätzwerte (Schiffs-Bonus oder '
-                'Crystal nicht auflösbar). Roh-vs-Refine-Verdict unberührt.',
+                'Crystal nicht auflösbar). Roh-vs-Refine-Verdict unberührt.'
+                ' ISK/h ist effektiv inkl. Füllen + Flug (ein Zyklus ab deinem System).',
                 style: TextStyle(fontSize: 11, color: Colors.grey),
               ),
             ),
@@ -415,6 +416,7 @@ class _OreRankTile extends StatelessWidget {
         subtitle: Padding(
           padding: const EdgeInsets.only(top: 4),
           child: Text(
+            '${row.effectiveIskPerHour > 0 ? 'eff ${fmtIsk(row.effectiveIskPerHour)} · ' : ''}'
             'm³/h ${fmtVolume(row.miningM3PerHour)} · '
             'roh ${fmtIsk(row.rawIskPerHour)} · '
             'refine ${fmtIsk(row.refineIskPerHour)} · '
@@ -452,6 +454,15 @@ class _OreRankTile extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        if (row.cycleMinutes > 0)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Text(
+              'Zyklus ${row.cycleMinutes.toStringAsFixed(1)} min · ${row.routeJumps} Jumps'
+              '${row.sellSystemName != null ? ' · Verkauf in ${row.sellSystemName}' : ''}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
         _detailLine(
           context,
           'Aufbereiten bei',
@@ -508,7 +519,21 @@ class _OreRankTile extends StatelessWidget {
   }
 
   Widget _rawDetail(BuildContext context) {
-    return _detailLine(context, 'Roh verkaufen bei', _formatSell(row.rawSell));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (row.cycleMinutes > 0)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Text(
+              'Zyklus ${row.cycleMinutes.toStringAsFixed(1)} min · ${row.routeJumps} Jumps'
+              '${row.sellSystemName != null ? ' · Verkauf in ${row.sellSystemName}' : ''}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+        _detailLine(context, 'Roh verkaufen bei', _formatSell(row.rawSell)),
+      ],
+    );
   }
 
   Widget _detailLine(BuildContext context, String label, String value) {

--- a/app/test/mining_models_test.dart
+++ b/app/test/mining_models_test.dart
@@ -189,6 +189,22 @@ void main() {
       expect(row.rawSell!.isStructure, isTrue);
       expect(row.rawSell!.stationName, isNull);
     });
+
+    test('parses effective-ISK/h cycle fields; defaults to zero', () {
+      final r = OreRankRow.fromJson(const {
+        'ore_type_id': 1230, 'ore_name': 'Veldspar', 'best': 'refine',
+        'effective_isk_per_hour': 950000, 'cycle_minutes': 12.5,
+        'route_jumps': 3, 'sell_system_name': 'Amarr', 'load_volume_m3': 11500,
+      });
+      expect(r.effectiveIskPerHour, closeTo(950000, 0.1));
+      expect(r.cycleMinutes, closeTo(12.5, 0.01));
+      expect(r.routeJumps, 3);
+      expect(r.sellSystemName, 'Amarr');
+
+      final d = OreRankRow.fromJson(const {'ore_type_id': 1, 'ore_name': 'X', 'best': 'raw'});
+      expect(d.effectiveIskPerHour, 0.0);
+      expect(d.routeJumps, 0);
+    });
   });
 
   group('OreRankingResponse.fromJson', () {

--- a/app/test/mining_screen_layout_test.dart
+++ b/app/test/mining_screen_layout_test.dart
@@ -76,6 +76,9 @@ OreRankingResponse _detailResponse() => const OreRankingResponse(
           bestStationTax: 0.05,
           bestStationName: 'Jita IV - Moon 4 - Caldari Navy Assembly Plant',
           bestStationSystem: 'Jita',
+          effectiveIskPerHour: 950000,
+          cycleMinutes: 12.5,
+          routeJumps: 3,
           materials: [
             RefineMaterial(
               materialTypeId: 34,
@@ -333,5 +336,18 @@ void main() {
     expect(find.byKey(const ValueKey('mining-estimate-1224')), findsOneWidget);
     // Veldspar (1230) is exact → no marker.
     expect(find.byKey(const ValueKey('mining-estimate-1230')), findsNothing);
+  });
+
+  testWidgets('Expanded row shows the cycle line', (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _DetailNotifier.new);
+    await tester.tap(find.byKey(const ValueKey('mining-ore-expand-1230')));
+    await tester.pumpAndSettle();
+    // Scope to the expanded tile to avoid matching the footer hint that also
+    // contains the word "Zyklus".
+    final tileScope = find.ancestor(
+      of: find.textContaining('Zyklus 12.5 min'),
+      matching: find.byKey(const ValueKey('mining-ore-row-1230')),
+    );
+    expect(tileScope, findsOneWidget);
   });
 }

--- a/backend/internal/models/mining.go
+++ b/backend/internal/models/mining.go
@@ -51,6 +51,13 @@ type OreRankRow struct {
 	CrystalMultiplier   float64 `json:"crystal_multiplier,omitempty"`    // per ore; 1.0 = no crystals used
 	IsEstimate          bool    `json:"is_estimate,omitempty"`           // hull bonus / crystal not fully resolved
 	EstimateReason      string  `json:"estimate_reason,omitempty"`       // short reason, only when IsEstimate
+	// Haul-downtime cycle (effective ISK/h, greedy one cycle from current system):
+	EffectiveISKPerHour float64 `json:"effective_isk_per_hour,omitempty"` // sort key; 0 when not resolvable
+	LoadVolumeM3        float64 `json:"load_volume_m3,omitempty"`         // ore-hold m³ filled per load
+	FillMinutes         float64 `json:"fill_minutes,omitempty"`           // time to fill the hold
+	CycleMinutes        float64 `json:"cycle_minutes,omitempty"`          // fill + legs + stops
+	RouteJumps          int     `json:"route_jumps,omitempty"`            // jumps over the cycle's legs
+	SellSystemName      string  `json:"sell_system_name,omitempty"`       // chosen sell hub (refine) / ore-sell system (raw)
 }
 
 // OreRankingResponse is the ore-ranking result for a region + security band.

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -195,6 +195,40 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 		return nil, err
 	}
 
+	const oreStopSecs = 75.0 // fixed dock/action overhead per stop (shown in UI)
+
+	// Cycle inputs: origin system, ore-hold capacity, ship warp/align.
+	cycleResolved := true
+	var originSys int64
+	if loc, e := s.location.GetCharacterLocation(ctx, characterID, accessToken); e == nil {
+		originSys = loc.SolarSystemID
+	} else {
+		cycleResolved = false
+	}
+	var oreHoldM3 float64
+	if hullResolved && hullTypeID != 0 {
+		if c, found, e := mining.OreHoldCapacity(s.sdeDB, int64(hullTypeID)); e == nil && found {
+			oreHoldM3 = c
+		} else {
+			cycleResolved = false
+		}
+	} else {
+		cycleResolved = false
+	}
+	navParams := &navigation.NavigationParams{AvoidLowSec: req.SecBand == "high"}
+	if hullResolved && hullTypeID != 0 {
+		if fit, e := s.fitting.GetShipFitting(ctx, characterID, hullTypeID, accessToken); e == nil && fit != nil {
+			ws, at := fit.Bonuses.WarpSpeedAUS, fit.Bonuses.AlignTime
+			navParams.WarpSpeed, navParams.AlignTime = &ws, &at
+		} else {
+			cycleResolved = false
+		}
+	} else {
+		cycleResolved = false
+	}
+	travelMemo := map[travelKey]*navigation.RouteResult{}
+	sysOf := map[int64]int64{} // order location → system, memoised across ores
+
 	// 4. Best reprocessing station (lowest tax given the player's owner-corp standing).
 	stations, err := s.stations.GetRegionReprocessStations(ctx, regionID)
 	if err != nil {
@@ -226,11 +260,13 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	// sell-location resolver (memoizes hub stations across ores).
 	loc := newLocResolver(s.names)
 	var bestStationName, bestStationSystem string
+	var reprocessSys int64
 	if bestStationID != 0 {
 		if n, e := s.names.GetStationName(ctx, bestStationID); e == nil && !strings.HasPrefix(n, "Station-") {
 			bestStationName = n
 		}
 		if sysID, e := s.names.GetSystemIDForLocation(ctx, bestStationID); e == nil {
+			reprocessSys = sysID
 			if sn, e2 := s.names.GetSystemName(ctx, sysID); e2 == nil {
 				bestStationSystem = sn
 			}
@@ -347,14 +383,113 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 			rs := loc.resolve(ctx, oreLoc)
 			row.RawSell = &rs
 		}
+
+		// ---- Haul-downtime cycle (greedy): raw 1 leg, refine best-hub 2 legs ----
+		rowResolved := cycleResolved && hullResolved
+		var rawEff, rawCycleMin, rawFillMin float64
+		var rawJumps int
+		var rawSellSys int64
+		if rowResolved && oreOK {
+			if sid, e := s.names.GetSystemIDForLocation(ctx, oreLoc); e == nil {
+				rawSellSys = sid
+				if secs, jumps, ok := s.travelSecs(originSys, rawSellSys, navParams, travelMemo); ok {
+					rawEff, rawCycleMin, rawFillMin = mining.EffectiveISKPerHour(oreHoldM3, oreM3h, cmp.RawNetPerM3, secs, oreStopSecs)
+					rawJumps = jumps
+				} else {
+					rowResolved = false
+				}
+			} else {
+				rowResolved = false
+			}
+		}
+
+		var refEff, refCycleMin, refFillMin float64
+		var refJumps int
+		var refSellSysName string
+		// A reprocess station exists but its system didn't resolve → can't route the
+		// refine haul; fail-loud rather than silently publishing a raw-only verdict.
+		if rowResolved && bestStationID != 0 && reprocessSys == 0 {
+			rowResolved = false
+		}
+		if rowResolved && reprocessSys != 0 {
+			o2rSecs, o2rJumps, ok := s.travelSecs(originSys, reprocessSys, navParams, travelMemo)
+			if !ok {
+				rowResolved = false
+			} else {
+				bySys := make(map[int64]map[int64]systemBuy, len(o.Materials)) // mineralType → system → buy
+				candidates := map[int64]bool{}
+				for _, m := range o.Materials {
+					g, e := s.bestBuyBySystem(ctx, regionID, int(m.MaterialTypeID), sysOf)
+					if e != nil {
+						rowResolved = false
+						break
+					}
+					bySys[m.MaterialTypeID] = g
+					for sysID := range g {
+						candidates[sysID] = true
+					}
+				}
+				bestEff := -1.0
+				for sysID := range candidates {
+					mats := make([]MaterialValue, 0, len(o.Materials))
+					for _, m := range o.Materials {
+						price := bySys[m.MaterialTypeID][sysID].price // 0 if absent
+						mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: price})
+					}
+					hubCmp := CompareOre(OreCompareInput{
+						PortionSize: o.PortionSize, OreVolumeM3: o.VolumeM3, OreBuyPrice: orePrice,
+						Materials: mats, NetYield: net, StationTake: stationTax, SalesTaxRate: salesTaxRate,
+					})
+					hubSecs, hubJumps, hok := s.travelSecs(reprocessSys, sysID, navParams, travelMemo)
+					if !hok {
+						continue
+					}
+					eff, cyc, fil := mining.EffectiveISKPerHour(oreHoldM3, oreM3h, hubCmp.RefineNetPerM3, o2rSecs+hubSecs, 2*oreStopSecs)
+					if eff > bestEff {
+						bestEff, refEff, refCycleMin, refFillMin = eff, eff, cyc, fil
+						refJumps = o2rJumps + hubJumps
+						if sn, e := s.names.GetSystemName(ctx, sysID); e == nil {
+							refSellSysName = sn
+						}
+					}
+				}
+			}
+		}
+
+		if rowResolved && (rawEff > 0 || refEff > 0) {
+			if refEff > rawEff {
+				row.Best = "refine"
+				row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = refEff, refCycleMin, refFillMin
+				row.RouteJumps, row.SellSystemName = refJumps, refSellSysName
+			} else {
+				row.Best = "raw"
+				row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = rawEff, rawCycleMin, rawFillMin
+				row.RouteJumps = rawJumps
+				if row.RawSell != nil {
+					row.SellSystemName = row.RawSell.SystemName
+				}
+			}
+			row.LoadVolumeM3 = oreHoldM3
+		} else if oreM3h > 0 {
+			row.IsEstimate = true
+			if row.EstimateReason == "" {
+				row.EstimateReason = "Haul-Downtime nicht berechenbar"
+			}
+		}
+
 		resp.Rows = append(resp.Rows, row)
 	}
 
 	// 6. Sort: by isk/h when mining, else by per-m³.
+	sortKey := func(r models.OreRankRow) float64 {
+		if r.EffectiveISKPerHour > 0 {
+			return r.EffectiveISKPerHour
+		}
+		return maxFloat(r.RawISKPerHour, r.RefineISKPerHour)
+	}
 	sort.SliceStable(resp.Rows, func(i, j int) bool {
 		if m3h > 0 {
-			return maxFloat(resp.Rows[i].RawISKPerHour, resp.Rows[i].RefineISKPerHour) >
-				maxFloat(resp.Rows[j].RawISKPerHour, resp.Rows[j].RefineISKPerHour)
+			return sortKey(resp.Rows[i]) > sortKey(resp.Rows[j])
 		}
 		return maxFloat(resp.Rows[i].RawNetPerM3, resp.Rows[i].RefineNetPerM3) >
 			maxFloat(resp.Rows[j].RawNetPerM3, resp.Rows[j].RefineNetPerM3)
@@ -398,10 +533,10 @@ func maxFloat(a, b float64) float64 {
 }
 
 // travelKey memoises CalculateTravelTime results within one OreRanking request.
-type travelKey struct{ from, to int64 } //nolint:unused // used by next task's haul-cycle wiring
+type travelKey struct{ from, to int64 }
 
 // systemBuy is the best buy price for a type in one system, with the order's station.
-type systemBuy struct { //nolint:unused // used by next task's haul-cycle wiring
+type systemBuy struct {
 	price      float64
 	locationID int64
 }
@@ -409,8 +544,6 @@ type systemBuy struct { //nolint:unused // used by next task's haul-cycle wiring
 // bestBuyBySystem groups a type's region buy-orders by solar system and keeps the
 // highest price per system (with its station location). Locations that can't be
 // resolved to a system (e.g. citadels) are skipped — they can't anchor a haul leg.
-//
-//nolint:unused // wired into the ranking loop by the next task
 func (s *MiningService) bestBuyBySystem(ctx context.Context, regionID, typeID int, sysOf map[int64]int64) (map[int64]systemBuy, error) {
 	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
 	if err != nil {
@@ -443,8 +576,6 @@ func (s *MiningService) bestBuyBySystem(ctx context.Context, regionID, typeID in
 
 // travelSecs returns one-way travel seconds + jumps between two systems, memoised.
 // resolved=false when the route can't be computed (the caller marks an estimate).
-//
-//nolint:unused // wired into the ranking loop by the next task
 func (s *MiningService) travelSecs(from, to int64, params *navigation.NavigationParams, memo map[travelKey]*navigation.RouteResult) (secs float64, jumps int, resolved bool) {
 	if from == to {
 		return 0, 0, true

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
 	"github.com/Sternrassler/eve-o-provit/backend/internal/models"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/mining"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/navigation"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/reprocessing"
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
 )
@@ -21,10 +22,11 @@ type MiningSkillsProvider interface {
 	GetCharacterStandings(ctx context.Context, characterID int, accessToken string) (map[int64]float64, error)
 }
 
-// MiningModulesProvider exposes the active ship's fitted mining module type ids.
-// Subset of FittingServicer, kept narrow for fakeability.
+// MiningModulesProvider exposes the active ship's fitted mining module type ids
+// and the ship's fitting bonuses (warp/align) for the haul-downtime cycle.
 type MiningModulesProvider interface {
 	ActiveShipFittedModuleTypeIDs(ctx context.Context, characterID int, accessToken string) ([]int64, error)
+	GetShipFitting(ctx context.Context, characterID, shipTypeID int, accessToken string) (*FittingData, error)
 }
 
 // ReprocessStationProvider lists a region's NPC reprocessing stations. Abstracted so the
@@ -393,4 +395,72 @@ func maxFloat(a, b float64) float64 {
 		return a
 	}
 	return b
+}
+
+// travelKey memoises CalculateTravelTime results within one OreRanking request.
+type travelKey struct{ from, to int64 } //nolint:unused // used by next task's haul-cycle wiring
+
+// systemBuy is the best buy price for a type in one system, with the order's station.
+type systemBuy struct { //nolint:unused // used by next task's haul-cycle wiring
+	price      float64
+	locationID int64
+}
+
+// bestBuyBySystem groups a type's region buy-orders by solar system and keeps the
+// highest price per system (with its station location). Locations that can't be
+// resolved to a system (e.g. citadels) are skipped — they can't anchor a haul leg.
+//
+//nolint:unused // wired into the ranking loop by the next task
+func (s *MiningService) bestBuyBySystem(ctx context.Context, regionID, typeID int, sysOf map[int64]int64) (map[int64]systemBuy, error) {
+	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
+	if err != nil {
+		return nil, err
+	}
+	out := map[int64]systemBuy{}
+	for _, o := range orders {
+		if !o.IsBuyOrder || o.Price <= 0 {
+			continue
+		}
+		sysID, ok := sysOf[o.LocationID]
+		if !ok {
+			id, e := s.names.GetSystemIDForLocation(ctx, o.LocationID)
+			if e != nil {
+				sysOf[o.LocationID] = 0 // memoise "unresolvable"
+				continue
+			}
+			sysOf[o.LocationID] = id
+			sysID = id
+		}
+		if sysID == 0 {
+			continue
+		}
+		if cur, exists := out[sysID]; !exists || o.Price > cur.price {
+			out[sysID] = systemBuy{price: o.Price, locationID: o.LocationID}
+		}
+	}
+	return out, nil
+}
+
+// travelSecs returns one-way travel seconds + jumps between two systems, memoised.
+// resolved=false when the route can't be computed (the caller marks an estimate).
+//
+//nolint:unused // wired into the ranking loop by the next task
+func (s *MiningService) travelSecs(from, to int64, params *navigation.NavigationParams, memo map[travelKey]*navigation.RouteResult) (secs float64, jumps int, resolved bool) {
+	if from == to {
+		return 0, 0, true
+	}
+	key := travelKey{from, to}
+	if r, ok := memo[key]; ok {
+		if r == nil {
+			return 0, 0, false
+		}
+		return r.TotalSeconds, r.Jumps, true
+	}
+	r, err := navigation.CalculateTravelTime(s.sdeDB, from, to, params, false)
+	if err != nil {
+		memo[key] = nil
+		return 0, 0, false
+	}
+	memo[key] = r
+	return r.TotalSeconds, r.Jumps, true
 }

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -74,7 +74,7 @@ func (f *fakeMiningModules) ActiveShipFittedModuleTypeIDs(_ context.Context, _ i
 }
 
 func (f *fakeMiningModules) GetShipFitting(_ context.Context, _, _ int, _ string) (*FittingData, error) {
-	return nil, nil
+	return &FittingData{Bonuses: FittingBonuses{WarpSpeedAUS: 3.0, AlignTime: 6.0}}, nil
 }
 
 // fakeMiningSkillsProvider implements MiningSkillsProvider with fixed skills + standings.
@@ -99,7 +99,7 @@ type fakeMiningLocation struct {
 }
 
 func (f fakeMiningLocation) GetCharacterLocation(_ context.Context, _ int, _ string) (*CharacterLocation, error) {
-	return &CharacterLocation{}, nil
+	return &CharacterLocation{SolarSystemID: 30000142}, nil // Jita
 }
 
 func (f fakeMiningLocation) GetActiveShipTypeID(_ context.Context, _ int, _ string) (int, error) {
@@ -239,6 +239,22 @@ func TestMiningService_OreRanking_Veldspar(t *testing.T) {
 	}
 	if mat.BuyPrice != tritBuy || mat.Sell.StationName != "Jita IV-4" {
 		t.Errorf("material sell: price=%v sell=%+v", mat.BuyPrice, mat.Sell)
+	}
+	// Effective ISK/h (haul-downtime cycle). Active ship = Hulk (ore hold 11500).
+	// Origin/sell/reprocess all resolve to system 30000142 in this fake → travel 0,
+	// so the only downtime is the per-stop overhead.
+	if row.LoadVolumeM3 != 11500 {
+		t.Errorf("LoadVolumeM3: got %v, want 11500 (Hulk ore hold)", row.LoadVolumeM3)
+	}
+	if row.EffectiveISKPerHour <= 0 {
+		t.Error("EffectiveISKPerHour should be set (cycle resolvable)")
+	}
+	gross := row.MiningM3PerHour * row.RawNetPerM3
+	if row.Best == "raw" && row.EffectiveISKPerHour >= gross {
+		t.Errorf("effective (%v) must be below gross (%v) due to stop overhead", row.EffectiveISKPerHour, gross)
+	}
+	if row.IsEstimate {
+		t.Errorf("row should be resolvable (not estimate): %+v", *row)
 	}
 }
 

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -73,6 +73,10 @@ func (f *fakeMiningModules) ActiveShipFittedModuleTypeIDs(_ context.Context, _ i
 	return f.ids, nil
 }
 
+func (f *fakeMiningModules) GetShipFitting(_ context.Context, _, _ int, _ string) (*FittingData, error) {
+	return nil, nil
+}
+
 // fakeMiningSkillsProvider implements MiningSkillsProvider with fixed skills + standings.
 type fakeMiningSkillsProvider struct {
 	skills    *MiningReprocessingSkills

--- a/backend/pkg/evedb/mining/cycle.go
+++ b/backend/pkg/evedb/mining/cycle.go
@@ -1,0 +1,55 @@
+package mining
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+const attrMiningHoldCapacity = 1556
+
+// OreHoldCapacity returns the m³ a ship fills while mining: the dedicated ore
+// hold (attr 1556) if present, otherwise the regular cargo (types.capacity).
+// found=false when neither is > 0 (the caller marks the row as an estimate).
+func OreHoldCapacity(db *sql.DB, shipTypeID int64) (capM3 float64, found bool, err error) {
+	attrs, err := typeAttrs(db, shipTypeID)
+	if err != nil {
+		return 0, false, err
+	}
+	if v, ok := attrs[attrMiningHoldCapacity]; ok && v > 0 {
+		return v, true, nil
+	}
+	var capacity sql.NullFloat64
+	err = db.QueryRow(`SELECT capacity FROM types WHERE _key = ?`, shipTypeID).Scan(&capacity)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("ship capacity %d: %w", shipTypeID, err)
+	}
+	if capacity.Valid && capacity.Float64 > 0 {
+		return capacity.Float64, true, nil
+	}
+	return 0, false, nil
+}
+
+// EffectiveISKPerHour folds the mining cycle into an hourly rate:
+//
+//	t_fill  = oreHoldM3 / m3h            (hours to fill the hold)
+//	cycle   = t_fill + (travelSecs + stopSecs)/3600
+//	eff     = (oreHoldM3 * netPerM3) / cycle
+//
+// travelSecs is the sum of the one-way leg seconds for the path (no return trip);
+// stopSecs is the total dock/action overhead. Returns 0,0,0 when the ship cannot
+// fill the hold (m3h<=0 or oreHoldM3<=0).
+func EffectiveISKPerHour(oreHoldM3, m3h, netPerM3, travelSecs, stopSecs float64) (effISKPerHour, cycleMinutes, fillMinutes float64) {
+	if m3h <= 0 || oreHoldM3 <= 0 {
+		return 0, 0, 0
+	}
+	fillHours := oreHoldM3 / m3h
+	cycleHours := fillHours + (travelSecs+stopSecs)/3600.0
+	if cycleHours <= 0 {
+		return 0, 0, 0
+	}
+	iskLoad := oreHoldM3 * netPerM3
+	return iskLoad / cycleHours, cycleHours * 60.0, fillHours * 60.0
+}

--- a/backend/pkg/evedb/mining/cycle_test.go
+++ b/backend/pkg/evedb/mining/cycle_test.go
@@ -1,0 +1,59 @@
+package mining
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
+)
+
+func approxEqCycle(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func TestOreHoldCapacity(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	// Hulk (22544): ore hold 11500 (attr 1556), not the 350 cargo.
+	cap, found, err := OreHoldCapacity(db, 22544)
+	if err != nil || !found {
+		t.Fatalf("Hulk ore hold: found=%v err=%v", found, err)
+	}
+	if cap != 11500 {
+		t.Errorf("Hulk ore hold: got %v, want 11500", cap)
+	}
+
+	// Ibis (601): no ore hold → falls back to types.capacity 125.
+	cap, found, err = OreHoldCapacity(db, 601)
+	if err != nil || !found {
+		t.Fatalf("Ibis capacity: found=%v err=%v", found, err)
+	}
+	if cap != 125 {
+		t.Errorf("Ibis capacity: got %v, want 125", cap)
+	}
+}
+
+func TestEffectiveISKPerHour(t *testing.T) {
+	eff, cycleMin, fillMin := EffectiveISKPerHour(12000, 12000, 100, 600, 75)
+	if !approxEqCycle(eff, 1_200_000.0/1.1875) {
+		t.Errorf("eff: got %v, want %v", eff, 1_200_000.0/1.1875)
+	}
+	if !approxEqCycle(cycleMin, 1.1875*60) {
+		t.Errorf("cycleMin: got %v, want %v", cycleMin, 1.1875*60)
+	}
+	if !approxEqCycle(fillMin, 60) {
+		t.Errorf("fillMin: got %v, want 60", fillMin)
+	}
+
+	eff0, cycle0, _ := EffectiveISKPerHour(12000, 12000, 100, 0, 75)
+	wantCycle0 := (1.0 + 75.0/3600.0)
+	if !approxEqCycle(cycle0, wantCycle0*60) {
+		t.Errorf("same-system cycleMin: got %v, want %v", cycle0, wantCycle0*60)
+	}
+	if !approxEqCycle(eff0, 1_200_000.0/wantCycle0) {
+		t.Errorf("same-system eff: got %v, want %v", eff0, 1_200_000.0/wantCycle0)
+	}
+
+	if eff, _, _ := EffectiveISKPerHour(12000, 0, 100, 600, 75); eff != 0 {
+		t.Errorf("zero rate eff: got %v, want 0", eff)
+	}
+}

--- a/docs/superpowers/plans/2026-06-01-mining-haul-downtime.md
+++ b/docs/superpowers/plans/2026-06-01-mining-haul-downtime.md
@@ -1,0 +1,876 @@
+# Mining ISK/h incl. Haul-Downtime (Greedy) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rank mining ores by **effective ISK/hour** that folds in the fill→fly-to-sell/reprocess→sell cycle (greedy, one cycle from the current system), picking per ore the single in-region sell hub that maximises net ISK/h.
+
+**Architecture:** Pure cycle math + ore-hold lookup live in `pkg/evedb/mining/cycle.go`. The mining service resolves origin system + the current ship's warp/align, memoises travel times via `navigation.CalculateTravelTime`, groups mineral buy-orders by system, computes the raw cycle (1 leg) and the best refine hub (2 legs), sets new fields and re-sorts by effective ISK/h. Rows whose origin/ship/route can't be resolved keep the gross ISK/h and get the existing `is_estimate` marker (no silent 0-downtime).
+
+**Tech Stack:** Go 1.24, SQLite SDE, Next.js/TS, Flutter/Dart.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-mining-haul-downtime-design.md`. Follow-up (full max-ratio-cycle): **issue #158**.
+
+**Verified facts (do not re-derive):**
+- Ore-hold capacity = SDE attribute **1556** (`typeAttrs`); ships without it fall back to `types.capacity` (Hulk 22544: oreHold 11500, capacity 350; Retriever 17478: oreHold 27500; Ibis 601: no 1556, capacity 125).
+- `navigation.CalculateTravelTime(db, fromSys, toSys int64, *navigation.NavigationParams, useExactFormula bool) (*navigation.RouteResult, error)` → `RouteResult{TotalSeconds, Jumps, ...}`. `NavigationParams{WarpSpeed *float64, AlignTime *float64, AvoidLowSec bool}`.
+- `FittingService.GetShipFitting(ctx, characterID, shipTypeID int, accessToken) (*FittingData, error)`, `fit.Bonuses.WarpSpeedAUS`, `fit.Bonuses.AlignTime`.
+- `CharacterLocation.SolarSystemID int64` (from `location.GetCharacterLocation`).
+- Mining service already resolves the reprocess station system id (`mining_service.go` ~line 231, `s.names.GetSystemIDForLocation(ctx, bestStationID)`), the active ship type id (`s.location.GetActiveShipTypeID`), per-ore `oreM3h` (hull+crystal), `cmp` (CompareOre), and the per-ore best ore buy `oreLoc`.
+- `MarketOrder{IsBuyOrder bool, Price float64, LocationID int64}`.
+
+**Test DB:** `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off` from `backend/`.
+
+---
+
+## File Structure
+
+- `backend/pkg/evedb/mining/cycle.go` (Create) — `OreHoldCapacity` + pure `EffectiveISKPerHour`.
+- `backend/pkg/evedb/mining/cycle_test.go` (Create).
+- `backend/internal/models/mining.go` (Modify) — 6 new `OreRankRow` fields.
+- `backend/internal/services/mining_service.go` (Modify) — provider extension, nav params, travel memo, per-system buy grouping, per-ore raw+refine cycle, fields, sort.
+- `backend/internal/services/mining_service_test.go` (Modify) — fakes + assertions.
+- `frontend/src/types/trading.ts`, `frontend/src/components/trading/OreRankingTable.tsx`, `frontend/tests/components/OreRankingTable.test.tsx` (Modify).
+- `app/lib/api/mining_models.dart`, `app/lib/features/mining/mining_screen.dart`, `app/test/mining_models_test.dart`, `app/test/mining_screen_layout_test.dart` (Modify).
+
+---
+
+## Task 1: Ore-hold capacity + pure cycle math (`cycle.go`)
+
+**Files:**
+- Create: `backend/pkg/evedb/mining/cycle.go`
+- Test: `backend/pkg/evedb/mining/cycle_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// backend/pkg/evedb/mining/cycle_test.go
+package mining
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/testutil"
+)
+
+func approxEqCycle(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+func TestOreHoldCapacity(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	// Hulk (22544): ore hold 11500 (attr 1556), not the 350 cargo.
+	cap, found, err := OreHoldCapacity(db, 22544)
+	if err != nil || !found {
+		t.Fatalf("Hulk ore hold: found=%v err=%v", found, err)
+	}
+	if cap != 11500 {
+		t.Errorf("Hulk ore hold: got %v, want 11500", cap)
+	}
+
+	// Ibis (601): no ore hold → falls back to types.capacity 125.
+	cap, found, err = OreHoldCapacity(db, 601)
+	if err != nil || !found {
+		t.Fatalf("Ibis capacity: found=%v err=%v", found, err)
+	}
+	if cap != 125 {
+		t.Errorf("Ibis capacity: got %v, want 125", cap)
+	}
+}
+
+func TestEffectiveISKPerHour(t *testing.T) {
+	// oreHold 12000 m³, rate 12000 m³/h → fill = 1 h. netPerM3 = 100 → load = 1.2M ISK.
+	// travel 600 s + stop 75 s = 675 s = 0.1875 h. cycle = 1.1875 h.
+	// eff = 1_200_000 / 1.1875 = 1_010_526.315...
+	eff, cycleMin, fillMin := EffectiveISKPerHour(12000, 12000, 100, 600, 75)
+	if !approxEqCycle(eff, 1_200_000.0/1.1875) {
+		t.Errorf("eff: got %v, want %v", eff, 1_200_000.0/1.1875)
+	}
+	if !approxEqCycle(cycleMin, 1.1875*60) {
+		t.Errorf("cycleMin: got %v, want %v", cycleMin, 1.1875*60)
+	}
+	if !approxEqCycle(fillMin, 60) {
+		t.Errorf("fillMin: got %v, want 60", fillMin)
+	}
+
+	// Same-system (travel 0): cycle = fill + stop only.
+	eff0, cycle0, _ := EffectiveISKPerHour(12000, 12000, 100, 0, 75)
+	wantCycle0 := (1.0 + 75.0/3600.0)
+	if !approxEqCycle(cycle0, wantCycle0*60) {
+		t.Errorf("same-system cycleMin: got %v, want %v", cycle0, wantCycle0*60)
+	}
+	if !approxEqCycle(eff0, 1_200_000.0/wantCycle0) {
+		t.Errorf("same-system eff: got %v, want %v", eff0, 1_200_000.0/wantCycle0)
+	}
+
+	// Zero rate → zero (can't fill).
+	if eff, _, _ := EffectiveISKPerHour(12000, 0, 100, 600, 75); eff != 0 {
+		t.Errorf("zero rate eff: got %v, want 0", eff)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./pkg/evedb/mining/ -run 'TestOreHold|TestEffective' -v`
+Expected: FAIL — `undefined: OreHoldCapacity`, `undefined: EffectiveISKPerHour`.
+
+- [ ] **Step 3: Write the implementation**
+
+```go
+// backend/pkg/evedb/mining/cycle.go
+package mining
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+const attrMiningHoldCapacity = 1556
+
+// OreHoldCapacity returns the m³ a ship fills while mining: the dedicated ore
+// hold (attr 1556) if present, otherwise the regular cargo (types.capacity).
+// found=false when neither is > 0 (the caller marks the row as an estimate).
+func OreHoldCapacity(db *sql.DB, shipTypeID int64) (capM3 float64, found bool, err error) {
+	attrs, err := typeAttrs(db, shipTypeID)
+	if err != nil {
+		return 0, false, err
+	}
+	if v, ok := attrs[attrMiningHoldCapacity]; ok && v > 0 {
+		return v, true, nil
+	}
+	var capacity sql.NullFloat64
+	err = db.QueryRow(`SELECT capacity FROM types WHERE _key = ?`, shipTypeID).Scan(&capacity)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("ship capacity %d: %w", shipTypeID, err)
+	}
+	if capacity.Valid && capacity.Float64 > 0 {
+		return capacity.Float64, true, nil
+	}
+	return 0, false, nil
+}
+
+// EffectiveISKPerHour folds the mining cycle into an hourly rate:
+//
+//	t_fill  = oreHoldM3 / m3h            (hours to fill the hold)
+//	cycle   = t_fill + (travelSecs + stopSecs)/3600
+//	eff     = (oreHoldM3 * netPerM3) / cycle
+//
+// travelSecs is the sum of the one-way leg seconds for the path (no return trip);
+// stopSecs is the total dock/action overhead. Returns 0,0,0 when the ship cannot
+// fill the hold (m3h<=0 or oreHoldM3<=0).
+func EffectiveISKPerHour(oreHoldM3, m3h, netPerM3, travelSecs, stopSecs float64) (effISKPerHour, cycleMinutes, fillMinutes float64) {
+	if m3h <= 0 || oreHoldM3 <= 0 {
+		return 0, 0, 0
+	}
+	fillHours := oreHoldM3 / m3h
+	cycleHours := fillHours + (travelSecs+stopSecs)/3600.0
+	if cycleHours <= 0 {
+		return 0, 0, 0
+	}
+	iskLoad := oreHoldM3 * netPerM3
+	return iskLoad / cycleHours, cycleHours * 60.0, fillHours * 60.0
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./pkg/evedb/mining/ -run 'TestOreHold|TestEffective' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/pkg/evedb/mining/cycle.go backend/pkg/evedb/mining/cycle_test.go
+git commit -m "feat(mining): ore-hold capacity + effective-ISK/h cycle math"
+```
+
+---
+
+## Task 2: Response model fields (`models/mining.go`)
+
+**Files:**
+- Modify: `backend/internal/models/mining.go`
+
+- [ ] **Step 1: Add fields to `OreRankRow`** (after the `EstimateReason` field from feature #1)
+
+```go
+	// Haul-downtime cycle (effective ISK/h, greedy one cycle from current system):
+	EffectiveISKPerHour float64 `json:"effective_isk_per_hour,omitempty"` // sort key; 0 when not resolvable
+	LoadVolumeM3        float64 `json:"load_volume_m3,omitempty"`         // ore-hold m³ filled per load
+	FillMinutes         float64 `json:"fill_minutes,omitempty"`           // time to fill the hold
+	CycleMinutes        float64 `json:"cycle_minutes,omitempty"`          // fill + legs + stops
+	RouteJumps          int     `json:"route_jumps,omitempty"`            // jumps over the cycle's legs
+	SellSystemName      string  `json:"sell_system_name,omitempty"`       // chosen sell hub (refine) / ore-sell system (raw)
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cd backend && GOWORK=off go build ./internal/models/...`
+Expected: builds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/models/mining.go
+git commit -m "feat(mining): OreRankRow effective-ISK/h cycle fields"
+```
+
+---
+
+## Task 3: Service helpers — nav params, travel memo, per-system buy grouping
+
+**Files:**
+- Modify: `backend/internal/services/mining_service.go`
+
+- [ ] **Step 1: Extend `MiningModulesProvider` with the ship fitting accessor**
+
+```go
+// MiningModulesProvider exposes the active ship's fitted mining module type ids
+// and the ship's fitting bonuses (warp/align) for the haul-downtime cycle.
+type MiningModulesProvider interface {
+	ActiveShipFittedModuleTypeIDs(ctx context.Context, characterID int, accessToken string) ([]int64, error)
+	GetShipFitting(ctx context.Context, characterID, shipTypeID int, accessToken string) (*FittingData, error)
+}
+```
+
+`*FittingService` already implements `GetShipFitting`, so the container wiring is unchanged.
+
+- [ ] **Step 2: Add a travel-time memo + a per-system best-buy helper at the bottom of the file**
+
+```go
+// travelKey memoises CalculateTravelTime results within one OreRanking request.
+type travelKey struct{ from, to int64 }
+
+// systemBuy is the best buy price for a type in one system, with the order's station.
+type systemBuy struct {
+	price      float64
+	locationID int64
+}
+
+// bestBuyBySystem groups a type's region buy-orders by solar system and keeps the
+// highest price per system (with its station location). Locations that can't be
+// resolved to a system (e.g. citadels) are skipped — they can't anchor a haul leg.
+func (s *MiningService) bestBuyBySystem(ctx context.Context, regionID, typeID int, sysOf map[int64]int64) (map[int64]systemBuy, error) {
+	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
+	if err != nil {
+		return nil, err
+	}
+	out := map[int64]systemBuy{}
+	for _, o := range orders {
+		if !o.IsBuyOrder || o.Price <= 0 {
+			continue
+		}
+		sysID, ok := sysOf[o.LocationID]
+		if !ok {
+			id, e := s.names.GetSystemIDForLocation(ctx, o.LocationID)
+			if e != nil {
+				sysOf[o.LocationID] = 0 // memoise "unresolvable"
+				continue
+			}
+			sysOf[o.LocationID] = id
+			sysID = id
+		}
+		if sysID == 0 {
+			continue
+		}
+		if cur, exists := out[sysID]; !exists || o.Price > cur.price {
+			out[sysID] = systemBuy{price: o.Price, locationID: o.LocationID}
+		}
+	}
+	return out, nil
+}
+
+// travelSecs returns one-way travel seconds + jumps between two systems, memoised.
+// resolved=false when the route can't be computed (the caller marks an estimate).
+func (s *MiningService) travelSecs(from, to int64, params *navigation.NavigationParams, memo map[travelKey]*navigation.RouteResult) (secs float64, jumps int, resolved bool) {
+	if from == to {
+		return 0, 0, true
+	}
+	key := travelKey{from, to}
+	if r, ok := memo[key]; ok {
+		if r == nil {
+			return 0, 0, false
+		}
+		return r.TotalSeconds, r.Jumps, true
+	}
+	r, err := navigation.CalculateTravelTime(s.sdeDB, from, to, params, false)
+	if err != nil {
+		memo[key] = nil
+		return 0, 0, false
+	}
+	memo[key] = r
+	return r.TotalSeconds, r.Jumps, true
+}
+```
+
+- [ ] **Step 3: Add the `navigation` import** if not present
+
+Ensure the import block has `"github.com/Sternrassler/eve-o-provit/backend/pkg/evedb/navigation"`.
+
+- [ ] **Step 4: Build**
+
+Run: `cd backend && GOWORK=off go build ./internal/services/... ./cmd/...`
+Expected: builds (FittingService satisfies the extended interface).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/services/mining_service.go
+git commit -m "feat(mining): travel-time memo + per-system best-buy helper"
+```
+
+---
+
+## Task 4: Wire the cycle into per-ore ranking + re-sort
+
+**Files:**
+- Modify: `backend/internal/services/mining_service.go`
+
+- [ ] **Step 1: Resolve origin system, ship nav params, ore hold, reprocess system once**
+
+After the feature-#1 block that computes `hullMul`/`hullResolved`/`crystalCapable` and before "4. Best reprocessing station", add:
+
+```go
+	const oreStopSecs = 75.0 // fixed dock/action overhead per stop (shown in UI)
+
+	// Cycle inputs: origin system, ore-hold capacity, ship warp/align.
+	cycleResolved := true
+	var originSys int64
+	if loc, e := s.location.GetCharacterLocation(ctx, characterID, accessToken); e == nil {
+		originSys = loc.SolarSystemID
+	} else {
+		cycleResolved = false
+	}
+	var oreHoldM3 float64
+	if hullResolved && hullTypeID != 0 {
+		if c, found, e := mining.OreHoldCapacity(s.sdeDB, int64(hullTypeID)); e == nil && found {
+			oreHoldM3 = c
+		} else {
+			cycleResolved = false
+		}
+	} else {
+		cycleResolved = false
+	}
+	navParams := &navigation.NavigationParams{AvoidLowSec: req.SecBand == "high"}
+	if hullResolved && hullTypeID != 0 {
+		if fit, e := s.fitting.GetShipFitting(ctx, characterID, hullTypeID, accessToken); e == nil && fit != nil {
+			ws, at := fit.Bonuses.WarpSpeedAUS, fit.Bonuses.AlignTime
+			navParams.WarpSpeed, navParams.AlignTime = &ws, &at
+		} else {
+			cycleResolved = false
+		}
+	} else {
+		cycleResolved = false
+	}
+	travelMemo := map[travelKey]*navigation.RouteResult{}
+	sysOf := map[int64]int64{} // order location → system, memoised across ores
+```
+
+`hullTypeID` is the variable already declared by feature #1 (`hullTypeID, shipErr := s.location.GetActiveShipTypeID(...)`).
+
+- [ ] **Step 2: Capture the reprocess station system id**
+
+In the existing block that resolves the reprocess station system name (the `if sysID, e := s.names.GetSystemIDForLocation(ctx, bestStationID); e == nil { ... }`), hoist the id into an outer variable. Change:
+
+```go
+	var bestStationName, bestStationSystem string
+	var reprocessSys int64
+	if bestStationID != 0 {
+		if n, e := s.names.GetStationName(ctx, bestStationID); e == nil && !strings.HasPrefix(n, "Station-") {
+			bestStationName = n
+		}
+		if sysID, e := s.names.GetSystemIDForLocation(ctx, bestStationID); e == nil {
+			reprocessSys = sysID
+			if sn, e2 := s.names.GetSystemName(ctx, sysID); e2 == nil {
+				bestStationSystem = sn
+			}
+		}
+	}
+```
+
+- [ ] **Step 3: Per ore — compute raw + refine cycles, pick the better path**
+
+In the per-ore loop, after the existing `row := models.OreRankRow{...}` is built (feature #1 already sets gross ISK/h, materials, RawSell, etc.), insert the cycle computation **before** `resp.Rows = append(resp.Rows, row)` and after `row.RawSell` is set:
+
+```go
+		// ---- Haul-downtime cycle (greedy): raw 1 leg, refine best-hub 2 legs ----
+		rowResolved := cycleResolved && hullResolved
+		var rawEff, rawCycleMin, rawFillMin float64
+		var rawJumps int
+		var rawSellSys int64
+		if rowResolved && oreOK {
+			if sid, e := s.names.GetSystemIDForLocation(ctx, oreLoc); e == nil {
+				rawSellSys = sid
+				if secs, jumps, ok := s.travelSecs(originSys, rawSellSys, navParams, travelMemo); ok {
+					rawEff, rawCycleMin, rawFillMin = mining.EffectiveISKPerHour(oreHoldM3, oreM3h, cmp.RawNetPerM3, secs, oreStopSecs)
+					rawJumps = jumps
+				} else {
+					rowResolved = false
+				}
+			} else {
+				rowResolved = false
+			}
+		}
+
+		var refEff, refCycleMin, refFillMin float64
+		var refJumps int
+		var refSellSysName string
+		if rowResolved && reprocessSys != 0 {
+			// Travel origin → reprocess (shared by all hubs of this ore).
+			o2rSecs, o2rJumps, ok := s.travelSecs(originSys, reprocessSys, navParams, travelMemo)
+			if !ok {
+				rowResolved = false
+			} else {
+				// Candidate hubs = systems holding a buy order for any of this ore's minerals.
+				bySys := make(map[int64]map[int64]systemBuy, len(o.Materials)) // mineralType → system → buy
+				candidates := map[int64]bool{}
+				for _, m := range o.Materials {
+					g, e := s.bestBuyBySystem(ctx, regionID, int(m.MaterialTypeID), sysOf)
+					if e != nil {
+						rowResolved = false
+						break
+					}
+					bySys[m.MaterialTypeID] = g
+					for sysID := range g {
+						candidates[sysID] = true
+					}
+				}
+				bestEff := -1.0
+				for sysID := range candidates {
+					// Refine value at this hub: CompareOre with per-mineral prices in sysID.
+					mats := make([]MaterialValue, 0, len(o.Materials))
+					for _, m := range o.Materials {
+						price := bySys[m.MaterialTypeID][sysID].price // 0 if absent
+						mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: price})
+					}
+					hubCmp := CompareOre(OreCompareInput{
+						PortionSize: o.PortionSize, OreVolumeM3: o.VolumeM3, OreBuyPrice: orePrice,
+						Materials: mats, NetYield: net, StationTake: stationTax, SalesTaxRate: salesTaxRate,
+					})
+					hubSecs, hubJumps, hok := s.travelSecs(reprocessSys, sysID, navParams, travelMemo)
+					if !hok {
+						continue
+					}
+					eff, cyc, fil := mining.EffectiveISKPerHour(oreHoldM3, oreM3h, hubCmp.RefineNetPerM3, o2rSecs+hubSecs, 2*oreStopSecs)
+					if eff > bestEff {
+						bestEff, refEff, refCycleMin, refFillMin = eff, eff, cyc, fil
+						refJumps = o2rJumps + hubJumps
+						if sn, e := s.names.GetSystemName(ctx, sysID); e == nil {
+							refSellSysName = sn
+						}
+					}
+				}
+			}
+		}
+
+		// Pick the path with the higher effective ISK/h; that is the verdict now.
+		if rowResolved && (rawEff > 0 || refEff > 0) {
+			if refEff > rawEff {
+				row.Best = "refine"
+				row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = refEff, refCycleMin, refFillMin
+				row.RouteJumps, row.SellSystemName = refJumps, refSellSysName
+			} else {
+				row.Best = "raw"
+				row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = rawEff, rawCycleMin, rawFillMin
+				row.RouteJumps = rawJumps
+				if row.RawSell != nil {
+					row.SellSystemName = row.RawSell.SystemName
+				}
+			}
+			row.LoadVolumeM3 = oreHoldM3
+		} else if oreM3h > 0 {
+			// Could not resolve the cycle → keep gross, mark estimate (no silent 0-downtime).
+			row.IsEstimate = true
+			if row.EstimateReason == "" {
+				row.EstimateReason = "Haul-Downtime nicht berechenbar"
+			}
+		}
+```
+
+Note: `oreLoc`, `oreOK`, `orePrice`, `cmp`, `net`, `oreM3h`, `stationTax`, `salesTaxRate`, `regionID` are all already in scope from feature #1's loop body. `MaterialValue`/`OreCompareInput`/`CompareOre` are the existing ore-compare helpers.
+
+- [ ] **Step 4: Re-sort by effective ISK/h (gross fallback for estimate rows)**
+
+Replace the existing sort closure body. Find:
+
+```go
+	sort.SliceStable(resp.Rows, func(i, j int) bool {
+		if m3h > 0 {
+			return maxFloat(resp.Rows[i].RawISKPerHour, resp.Rows[i].RefineISKPerHour) >
+				maxFloat(resp.Rows[j].RawISKPerHour, resp.Rows[j].RefineISKPerHour)
+```
+
+and change the ranking metric to prefer effective ISK/h, falling back to gross when a row's effective value is 0 (estimate / no mining):
+
+```go
+	sortKey := func(r models.OreRankRow) float64 {
+		if r.EffectiveISKPerHour > 0 {
+			return r.EffectiveISKPerHour
+		}
+		return maxFloat(r.RawISKPerHour, r.RefineISKPerHour)
+	}
+	sort.SliceStable(resp.Rows, func(i, j int) bool {
+		if m3h > 0 {
+			return sortKey(resp.Rows[i]) > sortKey(resp.Rows[j])
+```
+
+Keep the rest of the closure (the `else` branch sorting by per-m³ when `m3h == 0`) unchanged.
+
+- [ ] **Step 5: Build + vet + lint**
+
+Run: `cd backend && GOWORK=off go build ./... && GOWORK=off go vet ./internal/services/... && GOWORK=off golangci-lint run ./internal/services/...`
+Expected: builds; `0 issues`. (If golangci flags an ineffectual assignment on `bestEff`, initialise it as shown — it is read in the comparison.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/internal/services/mining_service.go
+git commit -m "feat(mining): rank by effective ISK/h with haul-downtime cycle"
+```
+
+---
+
+## Task 5: Service tests (`mining_service_test.go`)
+
+**Files:**
+- Modify: `backend/internal/services/mining_service_test.go`
+
+- [ ] **Step 1: Teach the fakes the new methods**
+
+`fakeMiningModules` needs `GetShipFitting`; `fakeMiningLocation` already has `GetCharacterLocation` (returns `&CharacterLocation{}` — give it a system id). Update:
+
+```go
+func (f *fakeMiningModules) GetShipFitting(_ context.Context, _, _ int, _ string) (*FittingData, error) {
+	return &FittingData{Bonuses: FittingBonuses{WarpSpeedAUS: 3.0, AlignTime: 6.0}}, nil
+}
+```
+
+And make `fakeMiningLocation.GetCharacterLocation` return a concrete system so origin resolves:
+
+```go
+func (f fakeMiningLocation) GetCharacterLocation(_ context.Context, _ int, _ string) (*CharacterLocation, error) {
+	return &CharacterLocation{SolarSystemID: 30000142}, nil // Jita
+}
+```
+
+- [ ] **Step 2: Update the Veldspar test for effective ISK/h**
+
+The Veldspar test fakes market buy orders with `LocationID: 60000123`. For routing to resolve, `fakeMiningNames.GetSystemIDForLocation` already returns `30000142`; the active ship is the Hulk (`22544`, real ore hold 11500). Origin (30000142) == sell/reprocess system (30000142) → travel 0 → cycle = fill + stops. Add assertions after the existing feature-#1 assertions:
+
+```go
+	if row.LoadVolumeM3 != 11500 {
+		t.Errorf("LoadVolumeM3: got %v, want 11500 (Hulk ore hold)", row.LoadVolumeM3)
+	}
+	if row.EffectiveISKPerHour <= 0 {
+		t.Error("EffectiveISKPerHour should be set (cycle resolvable)")
+	}
+	// Same-system (origin==sell==30000142): travel 0, so effective < gross only by stop overhead.
+	gross := row.MiningM3PerHour * row.RawNetPerM3
+	if row.Best == "raw" && row.EffectiveISKPerHour >= gross {
+		t.Errorf("effective (%v) must be below gross (%v) due to stop overhead", row.EffectiveISKPerHour, gross)
+	}
+	if row.IsEstimate {
+		t.Errorf("row should be resolvable (not estimate): %+v", *row)
+	}
+```
+
+Note: the Veldspar `Best` may now be chosen by effective ISK/h. Keep the earlier `row.Best != ""` check; remove any assertion that pins `Best` to `CompareOre.Best` if present (the verdict is now cycle-based).
+
+- [ ] **Step 3: Update the existing estimate test fake**
+
+`TestMiningService_OreRanking_EstimateWhenShipUnknown` uses `fakeMiningLocation{shipErr: ...}` (ship lookup fails). With the cycle code, `hullResolved=false` → `cycleResolved=false` → rows are estimate (already asserted). Confirm the test still passes; the `GetShipFitting` fake is harmless here.
+
+- [ ] **Step 4: Run the mining service tests**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/services/ -run TestMiningService -v`
+Expected: PASS (Veldspar with effective ISK/h, NoMiningSetup, EstimateWhenShipUnknown).
+
+- [ ] **Step 5: Full backend gate**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/... ./pkg/... && gofmt -l internal pkg && GOWORK=off golangci-lint run ./internal/... ./pkg/... ./cmd/...`
+Expected: ok; no gofmt output; `0 issues`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/internal/services/mining_service_test.go
+git commit -m "test(mining): effective-ISK/h cycle coverage"
+```
+
+---
+
+## Task 6: Web — types + sort-by-effective + detail fields
+
+**Files:**
+- Modify: `frontend/src/types/trading.ts`, `frontend/src/components/trading/OreRankingTable.tsx`, `frontend/tests/components/OreRankingTable.test.tsx`
+
+- [ ] **Step 1: Add fields to `OreRankRow`** (after `estimate_reason?`)
+
+```ts
+  effective_isk_per_hour?: number;
+  load_volume_m3?: number;
+  fill_minutes?: number;
+  cycle_minutes?: number;
+  route_jumps?: number;
+  sell_system_name?: string;
+```
+
+- [ ] **Step 2: Write the failing test** (rows arrive pre-sorted by backend; the table shows effective ISK/h + cycle detail)
+
+Add to `OreRankingTable.test.tsx`:
+
+```ts
+  it("shows effective ISK/h and cycle detail when present", () => {
+    const r = makeRow({
+      ore_type_id: 1230, ore_name: "Veldspar", best: "refine",
+      effective_isk_per_hour: 950000, raw_isk_per_hour: 500000,
+      refine_isk_per_hour: 1100000, cycle_minutes: 12.5, route_jumps: 3,
+      sell_system_name: "Amarr",
+    });
+    render(<OreRankingTable rows={[r]} />);
+    expect(screen.getByTestId("ore-effective-isk")).toHaveTextContent(/ISK/);
+
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+    const detail = screen.getByTestId("ore-ranking-detail");
+    expect(within(detail).getByText(/Zyklus/)).toBeInTheDocument();
+    expect(within(detail).getByText(/Amarr/)).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 3: Run it (fails)**
+
+Run: `cd frontend && npx vitest run tests/components/OreRankingTable.test.tsx`
+Expected: FAIL — no `ore-effective-isk`.
+
+- [ ] **Step 4: Render effective ISK/h + cycle detail in `OreRankingTable.tsx`**
+
+In the summary `<tr>`, add an effective-ISK/h cell (reuse `formatISK`). Replace the "Δ ISK/h" cell value or add a column — to keep the column count stable, repurpose the existing right-most cell to show effective ISK/h when present, else the existing delta. Concretely, change the delta cell to:
+
+```tsx
+        <td data-testid="ore-effective-isk" className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
+          {formatISK(row.effective_isk_per_hour ?? row.delta_isk_per_hour)}
+        </td>
+```
+
+Update the header label for that column from `Δ ISK/h` to `ISK/h eff.`.
+
+In the detail panel (`isRefine` and raw branches), add a cycle line near the top of each branch:
+
+```tsx
+            {row.cycle_minutes != null && (
+              <div className="mb-2 text-xs text-muted-foreground">
+                Zyklus {row.cycle_minutes.toFixed(1)} min · {row.route_jumps ?? 0} Jumps
+                {row.sell_system_name ? ` · Verkauf in ${row.sell_system_name}` : ""}
+              </div>
+            )}
+```
+
+Update the legend `<p>` in `frontend/src/app/mining/page.tsx` to mention effective ISK/h, e.g. append: "ISK/h ist effektiv inkl. Füllen + Flug zum Verkauf/Reprocess (ein Zyklus ab deinem System)."
+
+- [ ] **Step 5: Run tests + build + lint**
+
+Run: `cd frontend && npx vitest run tests/components/OreRankingTable.test.tsx && npm run build && npx eslint src/components/trading/OreRankingTable.tsx src/types/trading.ts src/app/mining/page.tsx`
+Expected: tests pass; build ok; eslint clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/types/trading.ts frontend/src/components/trading/OreRankingTable.tsx frontend/tests/components/OreRankingTable.test.tsx frontend/src/app/mining/page.tsx
+git commit -m "feat(web): show effective ISK/h + cycle detail in ore ranking"
+```
+
+---
+
+## Task 7: Flutter — model fields + cycle detail
+
+**Files:**
+- Modify: `app/lib/api/mining_models.dart`, `app/lib/features/mining/mining_screen.dart`, `app/test/mining_models_test.dart`, `app/test/mining_screen_layout_test.dart`
+
+- [ ] **Step 1: Add fields to `OreRankRow` (Dart) + parse**
+
+Constructor params + fields:
+
+```dart
+    this.effectiveIskPerHour = 0.0,
+    this.loadVolumeM3 = 0.0,
+    this.fillMinutes = 0.0,
+    this.cycleMinutes = 0.0,
+    this.routeJumps = 0,
+    this.sellSystemName,
+```
+```dart
+  final double effectiveIskPerHour;
+  final double loadVolumeM3;
+  final double fillMinutes;
+  final double cycleMinutes;
+  final int routeJumps;
+  final String? sellSystemName;
+```
+
+In `fromJson`:
+
+```dart
+      effectiveIskPerHour: (json['effective_isk_per_hour'] as num?)?.toDouble() ?? 0.0,
+      loadVolumeM3: (json['load_volume_m3'] as num?)?.toDouble() ?? 0.0,
+      fillMinutes: (json['fill_minutes'] as num?)?.toDouble() ?? 0.0,
+      cycleMinutes: (json['cycle_minutes'] as num?)?.toDouble() ?? 0.0,
+      routeJumps: (json['route_jumps'] as num?)?.toInt() ?? 0,
+      sellSystemName: json['sell_system_name'] as String?,
+```
+
+- [ ] **Step 2: Write the failing model test**
+
+Add to `mining_models_test.dart` (inside the `OreRankRow.fromJson` group):
+
+```dart
+    test('parses effective-ISK/h cycle fields; defaults to zero', () {
+      final r = OreRankRow.fromJson(const {
+        'ore_type_id': 1230, 'ore_name': 'Veldspar', 'best': 'refine',
+        'effective_isk_per_hour': 950000, 'cycle_minutes': 12.5,
+        'route_jumps': 3, 'sell_system_name': 'Amarr', 'load_volume_m3': 11500,
+      });
+      expect(r.effectiveIskPerHour, closeTo(950000, 0.1));
+      expect(r.cycleMinutes, closeTo(12.5, 0.01));
+      expect(r.routeJumps, 3);
+      expect(r.sellSystemName, 'Amarr');
+
+      final d = OreRankRow.fromJson(const {'ore_type_id': 1, 'ore_name': 'X', 'best': 'raw'});
+      expect(d.effectiveIskPerHour, 0.0);
+      expect(d.routeJumps, 0);
+    });
+```
+
+- [ ] **Step 3: Run model tests (fail→pass)**
+
+Run: `cd app && flutter test test/mining_models_test.dart`
+Expected: FAIL before Step 1, PASS after.
+
+- [ ] **Step 4: Show effective ISK/h + cycle in `mining_screen.dart`**
+
+In `_OreRankTile`, change the subtitle to lead with effective ISK/h when present, and add a cycle line in the expanded detail. In the subtitle `Text`, prepend:
+
+```dart
+            '${row.effectiveIskPerHour > 0 ? 'eff ${fmtIsk(row.effectiveIskPerHour)} · ' : ''}'
+            'm³/h ${fmtVolume(row.miningM3PerHour)} · '
+```
+
+At the top of `_refineDetail` and `_rawDetail` column children, add (guarded):
+
+```dart
+        if (row.cycleMinutes > 0)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Text(
+              'Zyklus ${row.cycleMinutes.toStringAsFixed(1)} min · ${row.routeJumps} Jumps'
+              '${row.sellSystemName != null ? ' · Verkauf in ${row.sellSystemName}' : ''}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ),
+```
+
+Update the `_ResultPane` footer note to mention effective ISK/h (append: " ISK/h ist effektiv inkl. Füllen + Flug (ein Zyklus ab deinem System).").
+
+- [ ] **Step 5: Write the failing widget test**
+
+Add `effectiveIskPerHour`, `cycleMinutes`, `routeJumps`, `sellSystemName` to the Veldspar row in `_detailResponse()` and a test:
+
+```dart
+  testWidgets('Expanded row shows the cycle line', (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _DetailNotifier.new);
+    await tester.tap(find.byKey(const ValueKey('mining-ore-expand-1230')));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Zyklus'), findsOneWidget);
+  });
+```
+
+(Set the Veldspar row's `cycleMinutes: 12.5, routeJumps: 3, effectiveIskPerHour: 950000` in `_detailResponse()`.)
+
+- [ ] **Step 6: analyze + test**
+
+Run: `cd app && flutter analyze lib/api/mining_models.dart lib/features/mining/mining_screen.dart test/mining_models_test.dart test/mining_screen_layout_test.dart && flutter test test/mining_models_test.dart test/mining_screen_layout_test.dart`
+Expected: no issues; tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/lib/api/mining_models.dart app/lib/features/mining/mining_screen.dart app/test/mining_models_test.dart app/test/mining_screen_layout_test.dart
+git commit -m "feat(app): show effective ISK/h + cycle detail in ore ranking"
+```
+
+---
+
+## Task 8: Full verification, PR, release, deploy, APK
+
+**Files:** none (process).
+
+- [ ] **Step 1: Full backend gate**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/... ./pkg/... && gofmt -l internal cmd pkg && GOWORK=off go vet ./... && GOWORK=off golangci-lint run ./internal/... ./pkg/... ./cmd/...`
+Expected: ok; no gofmt output; `0 issues`.
+
+- [ ] **Step 2: Full frontend gate**
+
+Run: `cd frontend && npx vitest run && npm run build`
+Expected: all tests pass; build ok.
+
+- [ ] **Step 3: Full Flutter gate**
+
+Run: `cd app && flutter analyze && flutter test`
+Expected: no issues; all tests pass.
+
+- [ ] **Step 4: Push branch + open PR to `main`**
+
+```bash
+git push -u origin feat/mining-haul-downtime
+gh pr create --base main --title "feat(mining): rank by effective ISK/h (haul-downtime cycle)" --body "<summary: greedy 1-cycle effective ISK/h; raw 1 leg / refine best-hub 2 legs; supersedes feature #1 per-mineral-anywhere for refine; fail-loud estimate; follow-up max-ratio-cycle #158; spec+plan linked>"
+```
+
+- [ ] **Step 5: Wait for CI green, then squash-merge + delete branch**
+
+```bash
+gh pr checks <PR#> --watch --interval 20
+gh pr merge <PR#> --squash --delete-branch
+git checkout main && git pull --ff-only
+```
+
+- [ ] **Step 6: Release v0.23.0**
+
+Add a `## [Unreleased]` CHANGELOG entry (Added: effective ISK/h with haul-downtime cycle; notes the refine-sell single-hub change + #158 follow-up), commit, then:
+
+```bash
+make release-check
+make release VERSION=0.23.0
+git add CHANGELOG.md && git commit -m "chore(release): v0.23.0"
+git tag v0.23.0 && git push origin main && git push origin v0.23.0
+```
+
+- [ ] **Step 7: Watch deploy + prod smoke**
+
+```bash
+gh run watch <deploy-run-id> --interval 20 --exit-status
+curl -s https://eveonline.sternrassler.de/api/v1/version   # → v0.23.0
+curl -s -o /dev/null -w "%{http_code}\n" https://eveonline.sternrassler.de/mining  # → 200
+```
+
+- [ ] **Step 8: Rebuild + reinstall the Flutter APK on the tablet (Flutter changed)**
+
+```bash
+cd app && CID="$(grep '^EVE_MOBILE_CLIENT_ID=' ../deployments/.env | cut -d= -f2- | tr -d '"'\'' \t')" \
+  && flutter build apk --release --dart-define=API_BASE_URL=https://eveonline.sternrassler.de --dart-define=EVE_CLIENT_ID="$CID"
+adb -s R5GL3433JKE install -r build/app/outputs/flutter-apk/app-release.apk
+```
+
+Expected: `Success`. Do not print `$CID`.
+
+---
+
+## Notes for the implementer
+
+- **No silent fallbacks:** effective ISK/h is computed only when origin system, ship warp/align and the needed routes resolve. Otherwise the row keeps gross ISK/h and is flagged `is_estimate` — never a silent 0-downtime.
+- **One-way chain:** there is no return leg (you mine again where you sold). Raw = 1 leg (origin→ore-sell), refine = 2 legs (origin→reprocess, reprocess→best-hub).
+- **Verdict is now cycle-based:** `Best` = whichever path yields higher effective ISK/h; this can differ from feature #1's per-m³ verdict, and the refine value now reflects a single sell hub (supersedes feature #1's per-mineral-anywhere). Both are intended.
+- **Performance:** travel times and order-location→system are memoised per request; candidate hubs are bounded to systems that actually hold the ore's mineral buy-orders. Don't route per ore unmemoised.

--- a/docs/superpowers/specs/2026-06-01-mining-haul-downtime-design.md
+++ b/docs/superpowers/specs/2026-06-01-mining-haul-downtime-design.md
@@ -1,0 +1,167 @@
+# Mining ISK/h inkl. Haul-Downtime (Greedy 1-Schritt) — Design
+
+**Datum:** 2026-06-01
+**Status:** Approved (Design)
+**Kontext:** Feature #2 der Mining-Reihe. Die Mining-Rangliste sortiert heute nach
+roher Mining-Rate (`m3h · netPerM3`). Das ignoriert die Realität, dass man den
+Erzraum vollmacht, zum Verkaufen/Aufbereiten fliegt und dort weitermint. Dieses
+Feature modelliert den **Lade-Zyklus** und rankt nach **effektiver ISK/h**.
+
+**Optimierungs-Niveau:** Greedy-1-Schritt (bester nächster Zyklus ab dem
+aktuellen System). Das volle Optimum (Maximum Profit-to-Time Ratio Cycle /
+Tramp-Steamer) ist als Follow-up **Issue #158** angelegt — nicht in diesem Scope.
+
+---
+
+## 1. Workflow (vom Nutzer vorgegeben)
+
+Immer im **aktuellen System** das empfohlene Erz abbauen, dann:
+- **(Raw)** zur empfohlenen Verkaufsstation fliegen, Roherz verkaufen, dort
+  weitermint.
+- **(Refine)** zur empfohlenen Aufbereitungsstation fliegen, aufbereiten, dann
+  zur besten Verkaufsstation der Raffinate fliegen, verkaufen, dort weitermint.
+
+Es gibt **keinen Rückweg** zum Start-Belt — man mint dort weiter, wo man zuletzt
+verkauft hat. Pro Zyklus zählen also nur die **Einweg-Etappen**.
+
+---
+
+## 2. Zyklus-Modell
+
+```
+t_fill  = oreHold / m3h[erz]                         // Erzraum vollmachen (h)
+isk_load = oreHold · netPerM3[erz]                   // Wert einer vollen Ladung
+
+Raw:    cycle = t_fill + travel(origin → ore_sell_sys)                       + 1·t_stop
+Refine: cycle = t_fill + travel(origin → reprocess_sys) + travel(reprocess_sys → sell_hub_sys) + 2·t_stop
+
+eff_isk_h = isk_load / cycle
+```
+
+- `oreHold` = Erzraum-Kapazität des aktuellen Schiffs (SDE-Attribut **1556**,
+  „Mining Hold Capacity"). Schiff ohne Erzraum (aber mit Minern) → reguläre
+  `types.capacity` (korrekt, kein Fallback).
+- `m3h[erz]` ist die ore-spezifische Mining-Rate aus Feature #1 (Hull-Bonus +
+  Crystal). `netPerM3[erz]` aus der bestehenden CompareOre-Logik.
+- `t_stop` = fixer, **im UI sichtbarer** Overhead pro Stopp (Docken, Aktion,
+  Undock; Default 75 s). Deckt auch den Same-System-Fall (0 Jumps) ab.
+- **Ranking sortiert nach `eff_isk_h`.** Die rohe Brutto-ISK/h
+  (`m3h · netPerM3`) bleibt als Detailwert erhalten.
+
+---
+
+## 3. Routing
+
+- **Origin** = aktuelles Solar-System des Characters (`GetCharacterLocation`,
+  schon vorhanden; die Region-Auflösung nutzt es bereits).
+- **Reisezeit:** `navigation.CalculateTravelTime(db, fromSys, toSys, params, false)`
+  → `RouteResult.TotalSeconds` (einfach) + `Jumps`. `params` aus Warp/Align des
+  **aktuellen Schiffs** (Fitting-Bonuses `WarpSpeedAUS` / `AlignTime`, wie beim
+  Hauling über `GetShipFitting`). `AvoidLowSec = (sec_band == "high")`.
+- **Memoisierung:** Reisezeiten je Zielsystem cachen — zwei Tabellen pro Request:
+  ab `origin` und ab `reprocess_sys` (das ist für alle Erze konstant). So bleibt
+  die Anzahl `CalculateTravelTime`-Aufrufe an die Zahl distinkter Zielsysteme
+  gebunden, nicht an die Zahl der Erze.
+
+---
+
+## 4. Sell-Hub-Wahl (Refine) — „bestes Einzel-Hub netto"
+
+Pro Erz wird **das eine In-Region-Verkaufssystem** `S` gewählt, das `eff_isk_h`
+maximiert (= fraktionale Wahl über endlich viele Kandidaten; Dinkelbach nicht
+nötig, da klein):
+
+```
+value(S)     = Σ_mineral  qty_eff_mineral · bestBuyPrice(mineral, S) · (1 − salesTax)
+cycle(S)     = t_fill + travel(origin → reprocess_sys) + travel(reprocess_sys → S) + 2·t_stop
+choose S* = argmax_S  value(S) / cycle(S)
+```
+
+- `qty_eff_mineral` = Menge nach Net-Yield (wie in Feature #1, pro voller Ladung
+  hochgerechnet auf `oreHold`).
+- `bestBuyPrice(mineral, S)` = höchstes Buy-Order dieses Minerals **im System S**.
+  Dafür werden die (ohnehin je Mineral-Typ geholten) Region-Market-Orders **nach
+  System gruppiert** (Order-Location → System via `GetSystemIDForLocation`),
+  Buy-Orders, bestes je System.
+- **Kandidaten-Systeme** = alle Systeme, in denen mindestens ein Mineral dieses
+  Erzes ein Buy-Order hat. (Erz-spezifisch, da Mineralmix variiert.)
+
+**Interaktion mit Feature #1:** Für den Refine-Pfad ersetzt das die bisherige
+„bestes Buy egal wo, pro Mineral einzeln"-Wertbasis durch „alle Minerale am
+besten Einzel-Hub `S*`". Die Pro-Mineral-Aufschlüsselung (Feature #1, Detail-
+Panel) zeigt dann die Preise **an `S*`** statt je Mineral woanders. Folge:
+**Refine-Wert, Verdict und Ranking können sich gegenüber Feature #1 ändern** —
+das ist gewollt (Routing-Realität). **Raw-Pfad** bleibt: Erz an seinem
+Region-Best-Buy (ein Ort, eine Etappe).
+
+---
+
+## 5. Fehlerverhalten (fail-loud, keine stillen Fallbacks)
+
+`eff_isk_h` wird **nur** berechnet, wenn Origin-System, Schiff-Warp/Align und die
+benötigten Routen auflösbar sind. Andernfalls **kein** stilles „0 Downtime":
+- Die Zeile behält die Brutto-ISK/h als Anzeigewert.
+- Sie wird mit dem bestehenden `is_estimate`-Marker (Feature #1) + Grund
+  versehen (z. B. „Route nicht berechenbar", „aktuelles Schiff/Warp unbekannt").
+- Sortierung: Estimate-Zeilen nach `eff_isk_h`, wo vorhanden, sonst nach Brutto;
+  Marker macht den Unterschied sichtbar.
+
+Kein neuer ESI-Scope, kein Deploy-Gate.
+
+---
+
+## 6. Response-Schema (Ergänzung `OreRankRow`)
+
+| Feld | Typ | Bedeutung |
+|------|-----|-----------|
+| `effective_isk_per_hour` | float | ISK/h inkl. Zyklus (Füllen + Etappen + Stops). Sortier-Key. |
+| `load_volume_m3` | float | genutzte Erzraum-Kapazität pro Ladung. |
+| `fill_minutes` | float | Zeit, den Erzraum zu füllen. |
+| `cycle_minutes` | float | Gesamt-Zykluszeit (Füllen + Etappen + Stops). |
+| `route_jumps` | int | Summe der Jumps über die Etappen des Zyklus. |
+| `sell_system_name` | string (omitempty) | gewähltes Sell-Hub-System (Refine) bzw. Roherz-Sell-System (Raw). |
+
+Bestehende `is_estimate`/`estimate_reason` werden wiederverwendet. `oreHold`/
+`t_stop` werden als einmaliger Kontext (nicht je Zeile) im UI angezeigt.
+
+---
+
+## 7. Tests
+
+**Backend (`pkg/evedb/mining` + Service):**
+- Zyklus-Mathe: `eff_isk_h == isk_load / (t_fill + Σ legs + n·t_stop)` für Raw
+  (1 Etappe) und Refine (2 Etappen) gegen feste Inputs.
+- Same-System (0 Jumps): `travel ≈ 0` → cycle = `t_fill + n·t_stop`.
+- Sell-Hub-Auswahl: bei zwei Kandidatensystemen wird das mit max `value/cycle`
+  gewählt; per-System-Preise korrekt gruppiert.
+- Memoisierung: gleiche Zielsysteme lösen nur einen Routing-Aufruf aus
+  (Spy-Fake zählt Aufrufe).
+- Fail-loud: Routenfehler / unbekanntes Origin/Schiff → `is_estimate` gesetzt,
+  Brutto-ISK/h bleibt, `effective_isk_per_hour` = 0. Sortier-Key der Zeile =
+  `effective_isk_per_hour` falls > 0, sonst die Brutto-ISK/h (Fallback nur fürs
+  Sortieren, sichtbar durch den Marker).
+
+**Web (`OreRankingTable`) & Flutter (`mining_*`):**
+- Neue Felder parsen null/float-robust.
+- Tabelle sortiert nach `effective_isk_per_hour`.
+- Detail zeigt Ladung, Füllzeit, Zyklus, Jumps, Sell-Hub; `t_stop`-Hinweis.
+- Estimate-Marker bleibt funktional.
+
+---
+
+## 8. Betroffene Dateien (Überblick)
+
+- `backend/pkg/evedb/mining/cycle.go` (neu) — Zyklus-Mathe + Sell-Hub-Auswahl
+  (pure Funktionen, ohne ESI/DB-IO; bekommt Reisezeiten + per-System-Preise als
+  Inputs) + Tests.
+- `backend/internal/services/mining_service.go` — Origin/Schiff-Params holen,
+  Market-Orders je System gruppieren, Routing memoisiert, Zyklus je Erz, Felder
+  setzen, Sortierung umstellen.
+- `backend/internal/services/mining_service.go` braucht Schiff-Warp/Align →
+  schmales Interface auf `FittingService.GetShipFitting` (neuer Provider-Param
+  oder Erweiterung eines bestehenden).
+- `backend/internal/models/mining.go` — neue `OreRankRow`-Felder.
+- `frontend/src/types/trading.ts` + `OreRankingTable.tsx` + Test.
+- `app/lib/api/mining_models.dart` + `features/mining/mining_screen.dart` + Tests.
+
+Kein neuer ESI-Scope, keine `deployments`-Änderung. Follow-up: Issue #158.

--- a/frontend/src/app/mining/page.tsx
+++ b/frontend/src/app/mining/page.tsx
@@ -140,7 +140,7 @@ function MiningPageContent() {
               <p className="text-xs text-muted-foreground">
                 Hinweis: ISK/h berücksichtigt Schiffs-/Skill-Boni und (best-case) Erz-Crystals.
                 Zeilen mit ≈ sind Schätzwerte (Schiffs-Bonus oder Crystal nicht auflösbar). Die
-                Roh-vs-Refine-Entscheidung ist davon unberührt.
+                Roh-vs-Refine-Entscheidung ist davon unberührt. ISK/h ist effektiv inkl. Füllen + Flug zum Verkauf/Reprocess (ein Zyklus ab deinem System).
               </p>
             </div>
           )}

--- a/frontend/src/components/trading/OreRankingTable.tsx
+++ b/frontend/src/components/trading/OreRankingTable.tsx
@@ -62,7 +62,7 @@ export function OreRankingTable({ rows }: OreRankingTableProps) {
                 <th scope="col" className="px-4 py-3 text-right font-medium">ISK/h refine</th>
                 <th scope="col" className="px-4 py-3 font-medium">Verdict</th>
                 <th scope="col" className="px-4 py-3 text-right font-medium">Steuer</th>
-                <th scope="col" className="px-4 py-3 text-right font-medium">Δ ISK/h</th>
+                <th scope="col" className="px-4 py-3 text-right font-medium">ISK/h eff.</th>
               </tr>
             </thead>
             <tbody>
@@ -123,8 +123,8 @@ function OreRankRow({ row }: { row: OreRankRow }) {
         <td className="px-4 py-3 text-right">{formatISK(row.refine_isk_per_hour)}</td>
         <td className={cn("px-4 py-3", verdictClass)}>{verdictText}</td>
         <td className="px-4 py-3 text-right">{(row.best_station_tax * 100).toFixed(1)}%</td>
-        <td className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
-          {formatISK(row.delta_isk_per_hour)}
+        <td data-testid="ore-effective-isk" className="px-4 py-3 text-right font-medium text-green-600 dark:text-green-400">
+          {formatISK(row.effective_isk_per_hour ?? row.delta_isk_per_hour)}
         </td>
       </tr>
       {open && (
@@ -132,6 +132,12 @@ function OreRankRow({ row }: { row: OreRankRow }) {
           <td colSpan={7} className="px-4 py-3">
             {isRefine ? (
               <div className="space-y-2">
+                {row.cycle_minutes != null && (
+                  <div className="mb-2 text-xs text-muted-foreground">
+                    Zyklus {row.cycle_minutes.toFixed(1)} min · {row.route_jumps ?? 0} Jumps
+                    {row.sell_system_name ? ` · Verkauf in ${row.sell_system_name}` : ""}
+                  </div>
+                )}
                 <div className="text-sm">
                   <span className="text-muted-foreground">Aufbereiten bei: </span>
                   {formatStation(row.best_station_name, row.best_station_system)}
@@ -160,6 +166,12 @@ function OreRankRow({ row }: { row: OreRankRow }) {
               </div>
             ) : (
               <div className="text-sm">
+                {row.cycle_minutes != null && (
+                  <div className="mb-2 text-xs text-muted-foreground">
+                    Zyklus {row.cycle_minutes.toFixed(1)} min · {row.route_jumps ?? 0} Jumps
+                    {row.sell_system_name ? ` · Verkauf in ${row.sell_system_name}` : ""}
+                  </div>
+                )}
                 <span className="text-muted-foreground">Roh verkaufen bei: </span>
                 {formatSell(row.raw_sell)}
               </div>

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -385,6 +385,12 @@ export interface OreRankRow {
   crystal_multiplier?: number;
   is_estimate?: boolean;
   estimate_reason?: string;
+  effective_isk_per_hour?: number;
+  load_volume_m3?: number;
+  fill_minutes?: number;
+  cycle_minutes?: number;
+  route_jumps?: number;
+  sell_system_name?: string;
 }
 
 export interface OreRankingResponse {

--- a/frontend/tests/components/OreRankingTable.test.tsx
+++ b/frontend/tests/components/OreRankingTable.test.tsx
@@ -187,4 +187,20 @@ describe("OreRankingTable", () => {
     const detail = screen.getByTestId("ore-ranking-detail");
     expect(within(detail).getByText("Player-Structure")).toBeInTheDocument();
   });
+
+  it("shows effective ISK/h and cycle detail when present", () => {
+    const r = makeRow({
+      ore_type_id: 1230, ore_name: "Veldspar", best: "refine",
+      effective_isk_per_hour: 950000, raw_isk_per_hour: 500000,
+      refine_isk_per_hour: 1100000, cycle_minutes: 12.5, route_jumps: 3,
+      sell_system_name: "Amarr",
+    });
+    render(<OreRankingTable rows={[r]} />);
+    expect(screen.getByTestId("ore-effective-isk")).toHaveTextContent(/ISK/);
+
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+    const detail = screen.getByTestId("ore-ranking-detail");
+    expect(within(detail).getByText(/Zyklus/)).toBeInTheDocument();
+    expect(within(detail).getByText(/Amarr/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Was

Die Mining-Rangliste sortiert jetzt nach **effektiver ISK/h** — inkl. des realen Lade-Zyklus: Erzraum vollmachen → zum Verkauf/Reprocess fliegen → dort weiterminen (Einweg-Kette, **kein Rückweg**). Greedy-1-Schritt ab dem aktuellen System.

```
Raw    : cycle = t_fill + travel(origin → Erz-Verkauf)                          + 1·stop
Refine : cycle = t_fill + travel(origin → Reprocess) + travel(Reprocess → Sell-Hub) + 2·stop
eff_isk_h = (Erzraum · netPerM3) / cycle
```

- **Sell-Hub (Refine):** pro Erz das eine In-Region-System gewählt, das `eff_isk_h` maximiert (alle Minerale dort, per-System-Buy-Preise). Löst Feature #1's „pro Mineral egal wo" für den Refine-Pfad ab → **Verdict/Ranking können sich ändern** (gewollt, Routing-Realität).
- **Verdict** = der Pfad mit höherer effektiver ISK/h.
- **Erzraum** = SDE-Attr 1556 (sonst `types.capacity`). Reisezeit aus Warp/Align des aktuellen Schiffs (`CalculateTravelTime`), `avoidLowSec` bei High-Sec-Band; Routen + Order→System memoisiert.
- **Fixer Stopp-Overhead** 75 s/Stopp.

## Fail-loud

`eff_isk_h` nur wenn Origin-System, Schiff-Warp/Align und Routen auflösbar sind — sonst Brutto-ISK/h + `is_estimate`-Marker, **nie stilles „0 Downtime"**. (Inkl. Fix aus Review: existierende Reprocess-Station mit unauflösbarem System → estimate statt stiller Raw-Verdict.)

## Tests

- Backend: `cycle_test.go` (Erzraum 1556/capacity, Zyklus-Mathe, Same-System, Zero-Rate); Service (effektive ISK/h, estimate bei unbekanntem Schiff). `go test`/`vet`/`golangci-lint` = 0 issues.
- Web: 92 vitest grün (eff-Spalte + Zyklus-Detail), `next build` ok.
- Flutter: 229 Tests grün, `flutter analyze` clean.

## Scope / Follow-up

Greedy-1-Schritt. Das volle Optimum (**Maximum Profit-to-Time Ratio Cycle / Tramp-Steamer**) ist als **Issue #158** angelegt.

Spec: `docs/superpowers/specs/2026-06-01-mining-haul-downtime-design.md`
Plan: `docs/superpowers/plans/2026-06-01-mining-haul-downtime.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)