### PR TITLE
feat(web): in-game market + route links in mining ranking

### DIFF
--- a/backend/internal/models/mining.go
+++ b/backend/internal/models/mining.go
@@ -15,6 +15,7 @@ type SellLocation struct {
 	StationName string `json:"station_name,omitempty"`
 	SystemName  string `json:"system_name,omitempty"`
 	IsStructure bool   `json:"is_structure"`
+	LocationID  int64  `json:"location_id,omitempty"` // station/structure id — in-game waypoint target
 }
 
 // RefineMaterial is one reprocessing output mineral with where to sell it.

--- a/backend/internal/services/mining_location.go
+++ b/backend/internal/services/mining_location.go
@@ -53,6 +53,7 @@ func (r *locResolver) resolve(ctx context.Context, locationID int64) models.Sell
 			}
 		}
 	}
+	loc.LocationID = locationID
 	r.cache[locationID] = loc
 	return loc
 }

--- a/backend/internal/services/mining_location_test.go
+++ b/backend/internal/services/mining_location_test.go
@@ -48,9 +48,15 @@ func TestResolveSellLocation(t *testing.T) {
 	if npc.StationName != "Caldari Navy Assembly Plant" || npc.SystemName != "Jita" {
 		t.Fatalf("npc resolve: %+v", npc)
 	}
+	if npc.LocationID != 60003760 {
+		t.Errorf("NPC LocationID: got %d, want 60003760", npc.LocationID)
+	}
 
 	cit := r.resolve(ctx, 1_035_000_000_001) // citadel id ≥ 1e12
 	if !cit.IsStructure || cit.StationName != "" || cit.SystemName != "" {
 		t.Fatalf("citadel should resolve to structure-only: %+v", cit)
+	}
+	if cit.LocationID != 1_035_000_000_001 {
+		t.Errorf("citadel LocationID: got %d, want 1035000000001", cit.LocationID)
 	}
 }

--- a/docs/superpowers/plans/2026-06-01-mining-ingame-links.md
+++ b/docs/superpowers/plans/2026-06-01-mining-ingame-links.md
@@ -1,0 +1,454 @@
+# In-Game Market + Route Links in Mining Ranking (Web) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** From the web Mining ranking, click an ore/mineral name to open its EVE market window, and click a reprocess station / sell location to set an in-game autopilot waypoint.
+
+**Architecture:** Reuse the existing web client functions `openMarketDetails(typeId)` and `setWaypoint(destId, opts)` (already used by the ROI table; web SSO already holds both scopes). The only backend change is adding a `location_id` to `SellLocation` so sell locations have a waypoint target; the reprocess station already exposes `best_station_id`. No new endpoints, no new scopes, no Flutter, no deploy gate.
+
+**Tech Stack:** Go 1.24 (backend), Next.js/React/TS + vitest (web).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-mining-ingame-links-design.md`.
+
+**Verified facts:**
+- `openMarketDetails(typeId: number)` and `setWaypoint(destinationId: number, opts: { clearOtherWaypoints?: boolean })` exist in `frontend/src/lib/api-client.ts` and throw human messages on 401/403/404.
+- Web SSO requests `esi-ui.open_window.v1` + `esi-ui.write_waypoint.v1` (`frontend/src/lib/auth-context.tsx:33,36`).
+- `frontend/src/components/trading/OreRankingTable.tsx` is a client component; each row is an `OreRankRow` sub-component with `useState` expand. Ore name is rendered at the chevron span; refine detail shows the reprocess station via `formatStation(...)` and a per-mineral table with `formatSell(m.sell)`; raw detail shows `formatSell(row.raw_sell)`.
+- `models.SellLocation` (backend) currently has `StationName/SystemName/IsStructure` only. `locResolver.resolve(ctx, locationID)` (`backend/internal/services/mining_location.go`) already receives the `locationID` and caches a `SellLocation`.
+- The mock pattern for `@/lib/api-client` + `@/hooks/use-toast` is established in `frontend/tests/components/PortfolioResultTable.test.tsx`.
+
+**Test commands:**
+- Backend (from `backend/`): `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/services/ -run TestResolveSellLocation -v`
+- Web (from `frontend/`): `npx vitest run tests/components/OreRankingTable.test.tsx`
+
+---
+
+## File Structure
+
+- `backend/internal/models/mining.go` (Modify) — `SellLocation.LocationID`.
+- `backend/internal/services/mining_location.go` (Modify) — populate `LocationID` in `resolve`.
+- `backend/internal/services/mining_location_test.go` (Modify) — assert `LocationID`.
+- `frontend/src/types/trading.ts` (Modify) — `SellLocation.location_id?`.
+- `frontend/src/components/trading/OreRankingTable.tsx` (Modify) — toast handlers + market/route links.
+- `frontend/tests/components/OreRankingTable.test.tsx` (Modify) — mocks + click tests.
+
+---
+
+## Task 1: Backend — `location_id` on `SellLocation`
+
+**Files:**
+- Modify: `backend/internal/models/mining.go`
+- Modify: `backend/internal/services/mining_location.go`
+- Modify: `backend/internal/services/mining_location_test.go`
+
+- [ ] **Step 1: Extend the resolve test (failing)**
+
+In `backend/internal/services/mining_location_test.go`, `TestResolveSellLocation` currently checks the NPC and citadel cases. Add `LocationID` assertions. After the existing NPC block (the `npc := r.resolve(ctx, 60003760)` checks), add:
+```go
+	if npc.LocationID != 60003760 {
+		t.Errorf("NPC LocationID: got %d, want 60003760", npc.LocationID)
+	}
+```
+After the existing citadel block (`cit := r.resolve(ctx, 1_035_000_000_001)`), add:
+```go
+	if cit.LocationID != 1_035_000_000_001 {
+		t.Errorf("citadel LocationID: got %d, want 1035000000001", cit.LocationID)
+	}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/services/ -run TestResolveSellLocation -v`
+Expected: FAIL — `npc.LocationID` undefined (compile error: SellLocation has no field LocationID).
+
+- [ ] **Step 3: Add the field to `SellLocation`**
+
+In `backend/internal/models/mining.go`, the struct is:
+```go
+type SellLocation struct {
+	StationName string `json:"station_name,omitempty"`
+	SystemName  string `json:"system_name,omitempty"`
+	IsStructure bool   `json:"is_structure"`
+}
+```
+Add the field:
+```go
+type SellLocation struct {
+	StationName string `json:"station_name,omitempty"`
+	SystemName  string `json:"system_name,omitempty"`
+	IsStructure bool   `json:"is_structure"`
+	LocationID  int64  `json:"location_id,omitempty"` // station/structure id — in-game waypoint target
+}
+```
+
+- [ ] **Step 4: Populate it in `resolve`**
+
+In `backend/internal/services/mining_location.go`, the `resolve` method builds `loc` then caches it:
+```go
+	r.cache[locationID] = loc
+	return loc
+```
+Insert the assignment immediately before the cache write so both the NPC and structure branches get it:
+```go
+	loc.LocationID = locationID
+	r.cache[locationID] = loc
+	return loc
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/services/ -run TestResolveSellLocation -v`
+Expected: PASS.
+
+- [ ] **Step 6: Wider backend gate**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/... && gofmt -l internal && GOWORK=off golangci-lint run ./internal/...`
+Expected: ok; no gofmt output; `0 issues`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/internal/models/mining.go backend/internal/services/mining_location.go backend/internal/services/mining_location_test.go
+git commit -m "feat(mining): expose sell-location id for in-game waypoints"
+```
+
+---
+
+## Task 2: Web — market + route links
+
+**Files:**
+- Modify: `frontend/src/types/trading.ts`
+- Modify: `frontend/src/components/trading/OreRankingTable.tsx`
+- Modify: `frontend/tests/components/OreRankingTable.test.tsx`
+
+- [ ] **Step 1: Add `location_id` to the `SellLocation` TS type**
+
+In `frontend/src/types/trading.ts`, the interface is:
+```ts
+export interface SellLocation {
+  station_name?: string;
+  system_name?: string;
+  is_structure: boolean;
+}
+```
+Add the field:
+```ts
+export interface SellLocation {
+  station_name?: string;
+  system_name?: string;
+  is_structure: boolean;
+  location_id?: number;
+}
+```
+
+- [ ] **Step 2: Add the mocks + failing tests**
+
+In `frontend/tests/components/OreRankingTable.test.tsx`, change the first import line and add mocks + mocked handles. Replace:
+```ts
+import { describe, it, expect } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
+import { OreRankingTable } from "@/components/trading/OreRankingTable";
+import { OreRankRow } from "@/types/trading";
+```
+with:
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
+import { OreRankingTable } from "@/components/trading/OreRankingTable";
+import { OreRankRow } from "@/types/trading";
+import { openMarketDetails, setWaypoint } from "@/lib/api-client";
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+vi.mock("@/lib/api-client", () => ({
+  openMarketDetails: vi.fn().mockResolvedValue(undefined),
+  setWaypoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+const openMarketMock = vi.mocked(openMarketDetails);
+const setWaypointMock = vi.mocked(setWaypoint);
+
+beforeEach(() => {
+  openMarketMock.mockClear();
+  setWaypointMock.mockClear();
+});
+```
+Then add these tests inside the existing `describe("OreRankingTable", () => { ... })` block (e.g. after the last `it(...)`):
+```ts
+  it("opens the ore market on ore-name click without expanding the row", () => {
+    render(<OreRankingTable rows={[makeRow({ ore_type_id: 1230, ore_name: "Veldspar" })]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Veldspar" }));
+    expect(openMarketMock).toHaveBeenCalledWith(1230);
+    // stopPropagation: the row stayed collapsed.
+    expect(screen.queryByTestId("ore-ranking-detail")).not.toBeInTheDocument();
+  });
+
+  it("routes to the reprocess station and opens/routes minerals in the refine detail", () => {
+    const r = makeRow({
+      ore_type_id: 1230, ore_name: "Veldspar", best: "refine",
+      best_station_id: 60003760, best_station_name: "Jita IV-4", best_station_system: "Jita",
+      materials: [{
+        material_type_id: 34, material_name: "Tritanium", effective_qty: 100, buy_price: 5,
+        sell: { station_name: "Amarr VIII", system_name: "Amarr", is_structure: false, location_id: 60008494 },
+      }],
+    });
+    render(<OreRankingTable rows={[r]} />);
+    fireEvent.click(screen.getByTestId("ore-ranking-row")); // expand
+
+    fireEvent.click(screen.getByRole("button", { name: /Jita IV-4 — Jita/ }));
+    expect(setWaypointMock).toHaveBeenCalledWith(60003760, { clearOtherWaypoints: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Tritanium" }));
+    expect(openMarketMock).toHaveBeenCalledWith(34);
+
+    fireEvent.click(screen.getByRole("button", { name: /Amarr VIII — Amarr/ }));
+    expect(setWaypointMock).toHaveBeenCalledWith(60008494, { clearOtherWaypoints: true });
+  });
+
+  it("routes to the raw ore sell location in the raw detail", () => {
+    const r = makeRow({
+      ore_type_id: 1228, ore_name: "Scordite", best: "raw",
+      raw_sell: { station_name: "Dodixie IX", system_name: "Dodixie", is_structure: false, location_id: 60011866 },
+    });
+    render(<OreRankingTable rows={[r]} />);
+    fireEvent.click(screen.getByTestId("ore-ranking-row")); // expand
+    fireEvent.click(screen.getByRole("button", { name: /Dodixie IX — Dodixie/ }));
+    expect(setWaypointMock).toHaveBeenCalledWith(60011866, { clearOtherWaypoints: true });
+  });
+```
+
+- [ ] **Step 3: Run the tests to confirm the new ones fail**
+
+Run: `cd frontend && npx vitest run tests/components/OreRankingTable.test.tsx`
+Expected: the 3 new tests FAIL (no `button` with those names yet); pre-existing tests still pass.
+
+- [ ] **Step 4: Add imports + handlers in `OreRankingTable.tsx`**
+
+Add to the import block:
+```ts
+import { useToast } from "@/hooks/use-toast";
+import { openMarketDetails, setWaypoint } from "@/lib/api-client";
+```
+Inside the `OreRankRow` function, right after `const [open, setOpen] = useState(false);`, add:
+```tsx
+  const { toast } = useToast();
+  const linkCls = "text-left hover:underline underline-offset-2 hover:text-primary transition-colors";
+  const openMarket = async (typeId: number, name: string) => {
+    try {
+      await openMarketDetails(typeId);
+      toast({
+        title: "Markt-Detail an EVE gesendet",
+        description: `${name} — falls nichts passiert: Markt-Fenster im Spiel (Alt+R) öffnen und nochmal klicken.`,
+      });
+    } catch (err) {
+      toast({
+        title: "Fehler",
+        description: err instanceof Error ? err.message : "Unbekannter Fehler",
+        variant: "destructive",
+      });
+    }
+  };
+  const setRoute = async (destId: number, label: string) => {
+    try {
+      await setWaypoint(destId, { clearOtherWaypoints: true });
+      toast({ title: "Route gesetzt", description: `Waypoint in EVE gesetzt: ${label}` });
+    } catch (err) {
+      toast({
+        title: "Fehler",
+        description: err instanceof Error ? err.message : "Unbekannter Fehler",
+        variant: "destructive",
+      });
+    }
+  };
+```
+
+- [ ] **Step 5: Ore name → market button**
+
+In the ore summary `<td>`, replace the bare `{row.ore_name}` (inside the chevron span) with:
+```tsx
+            <button
+              type="button"
+              className={linkCls}
+              title="Marktdetails im EVE-Client öffnen"
+              onClick={(e) => {
+                e.stopPropagation();
+                openMarket(row.ore_type_id, row.ore_name);
+              }}
+            >
+              {row.ore_name}
+            </button>
+```
+
+- [ ] **Step 6: Reprocess station → route link**
+
+Replace the reprocess station div:
+```tsx
+                <div className="text-sm">
+                  <span className="text-muted-foreground">Aufbereiten bei: </span>
+                  {formatStation(row.best_station_name, row.best_station_system)}
+                </div>
+```
+with:
+```tsx
+                <div className="text-sm">
+                  <span className="text-muted-foreground">Aufbereiten bei: </span>
+                  {row.best_station_id ? (
+                    <button
+                      type="button"
+                      className={linkCls}
+                      title="Route in EVE setzen"
+                      onClick={() =>
+                        setRoute(
+                          row.best_station_id!,
+                          formatStation(row.best_station_name, row.best_station_system)
+                        )
+                      }
+                    >
+                      {formatStation(row.best_station_name, row.best_station_system)}
+                    </button>
+                  ) : (
+                    formatStation(row.best_station_name, row.best_station_system)
+                  )}
+                </div>
+```
+
+- [ ] **Step 7: Mineral name → market, sell location → route**
+
+Replace the per-mineral `<tr>`:
+```tsx
+                    {(row.materials ?? []).map((m) => (
+                      <tr key={m.material_type_id}>
+                        <td className="py-1 pr-4">{m.material_name || `Typ ${m.material_type_id}`}</td>
+                        <td className="py-1 pr-4 text-right">{m.effective_qty.toLocaleString("de-DE")}</td>
+                        <td className="py-1 pr-4 text-right">{formatISK(m.buy_price)}</td>
+                        <td className="py-1">{formatSell(m.sell)}</td>
+                      </tr>
+                    ))}
+```
+with:
+```tsx
+                    {(row.materials ?? []).map((m) => (
+                      <tr key={m.material_type_id}>
+                        <td className="py-1 pr-4">
+                          <button
+                            type="button"
+                            className={linkCls}
+                            title="Marktdetails im EVE-Client öffnen"
+                            onClick={() =>
+                              openMarket(m.material_type_id, m.material_name || `Typ ${m.material_type_id}`)
+                            }
+                          >
+                            {m.material_name || `Typ ${m.material_type_id}`}
+                          </button>
+                        </td>
+                        <td className="py-1 pr-4 text-right">{m.effective_qty.toLocaleString("de-DE")}</td>
+                        <td className="py-1 pr-4 text-right">{formatISK(m.buy_price)}</td>
+                        <td className="py-1">
+                          {m.sell.location_id ? (
+                            <button
+                              type="button"
+                              className={linkCls}
+                              title="Route in EVE setzen"
+                              onClick={() => setRoute(m.sell.location_id!, formatSell(m.sell))}
+                            >
+                              {formatSell(m.sell)}
+                            </button>
+                          ) : (
+                            formatSell(m.sell)
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+```
+
+- [ ] **Step 8: Raw sell location → route link**
+
+Replace:
+```tsx
+                <span className="text-muted-foreground">Roh verkaufen bei: </span>
+                {formatSell(row.raw_sell)}
+```
+with:
+```tsx
+                <span className="text-muted-foreground">Roh verkaufen bei: </span>
+                {row.raw_sell?.location_id ? (
+                  <button
+                    type="button"
+                    className={linkCls}
+                    title="Route in EVE setzen"
+                    onClick={() => setRoute(row.raw_sell!.location_id!, formatSell(row.raw_sell))}
+                  >
+                    {formatSell(row.raw_sell)}
+                  </button>
+                ) : (
+                  formatSell(row.raw_sell)
+                )}
+```
+
+- [ ] **Step 9: Run tests + build + lint**
+
+Run: `cd frontend && npx vitest run tests/components/OreRankingTable.test.tsx && npm run build && npx eslint src/components/trading/OreRankingTable.tsx src/types/trading.ts`
+Expected: all tests pass (3 new + pre-existing); build ok; eslint clean. (If a pre-existing test that uses `screen.getByText("Veldspar")` now matches text inside the new button — that still works, `getByText` matches by text content.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/types/trading.ts frontend/src/components/trading/OreRankingTable.tsx frontend/tests/components/OreRankingTable.test.tsx
+git commit -m "feat(web): in-game market + route links in mining ranking"
+```
+
+---
+
+## Task 3: Verify, PR, release, deploy
+
+**Files:** none (process). **No Flutter change → no APK rebuild.**
+
+- [ ] **Step 1: Full backend + frontend gates**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/... ./pkg/... && gofmt -l internal cmd pkg && GOWORK=off go vet ./... && GOWORK=off golangci-lint run ./internal/... ./pkg/... ./cmd/...`
+Then: `cd ../frontend && npx vitest run && npm run build`
+Expected: backend ok + `0 issues`; frontend all tests pass + build ok.
+
+- [ ] **Step 2: Push branch + open PR**
+
+```bash
+git push -u origin feat/mining-ingame-links
+gh pr create --base main --title "feat(web): in-game market + route links in mining ranking" --body "<summary: ore/mineral name opens EVE market; reprocess station + sell locations set autopilot waypoint; backend adds SellLocation.location_id; web-only, no new scope/Flutter; spec+plan linked>"
+```
+
+- [ ] **Step 3: Wait for CI green, then squash-merge + delete branch**
+
+```bash
+gh pr checks <PR#> --watch --interval 20
+gh pr merge <PR#> --squash --delete-branch
+git checkout main && git pull --ff-only
+```
+
+- [ ] **Step 4: Release v0.24.0**
+
+Add a `## [Unreleased]` CHANGELOG entry (Added: in-game market + route links in the mining ranking, web-only), commit, then:
+```bash
+make release-check
+make release VERSION=0.24.0
+git add CHANGELOG.md && git commit -m "chore(release): v0.24.0"
+git tag v0.24.0 && git push origin main && git push origin v0.24.0
+```
+
+- [ ] **Step 5: Watch deploy + prod smoke**
+
+```bash
+gh run watch <deploy-run-id> --interval 20 --exit-status
+curl -s https://eveonline.sternrassler.de/api/v1/version   # → v0.24.0
+curl -s -o /dev/null -w "%{http_code}\n" https://eveonline.sternrassler.de/mining  # → 200
+```
+
+No tablet APK step — this feature does not touch Flutter.
+
+---
+
+## Notes for the implementer
+
+- **No silent fallbacks:** a missing destination id (no reprocess station, citadel without a resolvable target) renders plain text instead of a link; a failing ESI call (EVE not running, no docking access) surfaces a destructive toast — never a silent no-op.
+- **stopPropagation:** the ore-name market button must call `e.stopPropagation()` so opening the market does not also toggle the row's expand. Mineral/location buttons live inside the already-open detail panel, so they don't need it.
+- **Backward compatibility:** sell locations / minerals without `location_id` (older API responses, or mineral sells in unresolvable citadels) render as plain text exactly as before.

--- a/docs/superpowers/specs/2026-06-01-mining-ingame-links-design.md
+++ b/docs/superpowers/specs/2026-06-01-mining-ingame-links-design.md
@@ -1,0 +1,146 @@
+# In-Game-Markt- + Routen-Links in der Mining-Rangliste (nur Web) — Design
+
+**Datum:** 2026-06-01
+**Status:** Approved (Design)
+**Kontext:** Feature #3 der Mining-Reihe. Aus der Mining-Rangliste heraus soll man
+direkt im EVE-Client (a) das **Marktfenster** eines Erzes/Minerals öffnen und
+(b) eine **Autopilot-Route** zum Aufbereitungs-/Verkaufsort setzen. **Nur Web** —
+ausdrücklich **kein** Flutter (vermeidet das Mobile-ESI-Scope-Deploy-Gate).
+
+---
+
+## 1. Reuse & Scope
+
+Beide Aktionen existieren bereits und werden im ROI-Table genutzt:
+- `openMarketDetails(typeId)` → `POST /api/v1/esi/ui/openwindow/marketdetails`
+  (Scope `esi-ui.open_window.v1`).
+- `setWaypoint(destinationId, opts)` → `POST /api/v1/esi/ui/autopilot/waypoint`
+  (Scope `esi-ui.write_waypoint.v1`).
+
+Beide Scopes fragt der **Web**-SSO bereits ab (`frontend/src/lib/auth-context.tsx`
+Zeilen 33 + 36) → **kein Re-Login, kein neuer Scope, kein Deploy-Gate**. Keine
+Flutter-Änderung.
+
+---
+
+## 2. Mentales Modell
+
+- **Name anklicken → Markt öffnen** (`openMarketDetails(type_id)`): Erz-Name und
+  jeder Mineral-Name in der Refine-Aufschlüsselung.
+- **Ort anklicken → Route setzen** (`setWaypoint(destination_id, {clearOtherWaypoints: true})`,
+  Route ersetzen): Reprocess-Station, Roherz-Verkaufsort und je Mineral der
+  Verkaufsort.
+
+---
+
+## 3. Backend-Change (web-dienend, kein Scope)
+
+Routen brauchen ein Ziel-ID. Heute trägt `models.SellLocation` nur Namen:
+
+```go
+type SellLocation struct {
+	StationName string `json:"station_name,omitempty"`
+	SystemName  string `json:"system_name,omitempty"`
+	IsStructure bool   `json:"is_structure"`
+}
+```
+
+**Ergänzung:** ein Feld `LocationID int64 `json:"location_id,omitempty"``. Es wird
+in `locResolver.resolve(ctx, locationID)` befüllt — die `locationID` liegt dort
+bereits vor und ist genau die Station-/Struktur-ID des Buy-Orders (gültiges
+`setWaypoint`-Ziel für NPC-Stationen **und** Citadels). Wird einmal vor dem
+Cachen gesetzt, für beide Zweige (Station und Struktur).
+
+Damit haben `raw_sell.location_id` und jede `material.sell.location_id` ein
+Routen-Ziel. Die **Reprocess-Route** nutzt das bereits vorhandene
+`OreRankRow.BestStationID` (`best_station_id`).
+
+Kein anderer Backend-Change; keine neuen Endpunkte; keine `deployments`-Änderung.
+
+---
+
+## 4. Web-UI (`frontend/src/components/trading/OreRankingTable.tsx`)
+
+Zwei geteilte Handler innerhalb der Tabelle, mit ROI-identischer Toast-Sprache
+(`useToast`):
+
+- `openMarket(typeId, name)`:
+  - Erfolg → Toast „Markt-Detail an EVE gesendet" / „{name} — falls nichts
+    passiert: Markt-Fenster im Spiel (Alt+R) öffnen und nochmal klicken."
+  - Fehler → Toast „Fehler" / `err.message` (variant `destructive`).
+- `setRoute(destId, label)`:
+  - Erfolg → Toast „Route gesetzt" / „Waypoint in EVE gesetzt: {label}".
+  - Fehler → Toast „Fehler" / `err.message` (variant `destructive`).
+
+`openMarketDetails`/`setWaypoint` werfen schon sprechende Meldungen
+(„EVE client not running", „Missing scope …").
+
+**Platzierung:**
+- **Erz-Summenzeile:** der Erzname wird ein klickbarer Button (Hover-Underline,
+  `title` „Marktdetails im EVE-Client öffnen") → `openMarket(ore_type_id, ore_name)`.
+  `onClick` ruft `e.stopPropagation()`, damit der Klick **nicht** die Zeile
+  auf-/zuklappt.
+- **Refine-Detail-Panel:**
+  - Zeile „Aufbereiten bei: {Station} — {System}": die Station ist ein
+    Routen-Link → `setRoute(best_station_id, "<Station> — <System>")`. Nur
+    gezeigt, wenn `best_station_id` (>0) vorhanden.
+  - Pro Mineral-Zeile: der **Mineral-Name** ist Markt-Link
+    (`openMarket(material_type_id, material_name)`); der **Verkaufsort-Text** ist
+    Routen-Link (`setRoute(material.sell.location_id, "<sell label>")`), nur wenn
+    `material.sell.location_id` (>0) vorhanden.
+- **Raw-Detail-Panel:**
+  - Zeile „Roh verkaufen bei: {Ort}": der Ort ist Routen-Link
+    (`setRoute(raw_sell.location_id, "<raw sell label>")`), nur wenn vorhanden.
+
+Fehlt eine ID (Reprocess-Station 0, Citadel ohne auflösbares Ziel) → der
+jeweilige Link wird nicht gerendert. Schlägt der ESI-Call fehl (EVE nicht offen,
+Citadel ohne Zugriff) → Fehler-Toast, kein stiller No-Op.
+
+**Auth:** Kein extra Login-Guard — ohne Login lädt die Mining-View keine Zeilen;
+ein 401/403 landet als sprechender Fehler-Toast.
+
+---
+
+## 5. Frontend-Typ-Ergänzung
+
+`frontend/src/types/trading.ts` → `SellLocation` bekommt `location_id?: number`.
+Keine weiteren Typänderungen (`ore_type_id`, `material_type_id`, `best_station_id`
+existieren bereits).
+
+---
+
+## 6. Tests
+
+**Backend:**
+- `mining_location_test.go`: `resolve` setzt `LocationID` auf die übergebene
+  `locationID` — für NPC-Station und Citadel.
+- Service-Wire-Test: eine `raw_sell`/`material.sell` trägt `location_id` im JSON.
+
+**Web (vitest, `OreRankingTable.test.tsx`):**
+- `@/lib/api-client` mocken (`openMarketDetails`, `setWaypoint`).
+- Klick auf Erz-Name → `openMarketDetails(ore_type_id)` **und** Zeile bleibt
+  eingeklappt (stopPropagation).
+- Nach Aufklappen: Klick auf Mineral-Name → `openMarketDetails(material_type_id)`;
+  Klick auf Reprocess-Station → `setWaypoint(best_station_id, {clearOtherWaypoints:true})`;
+  Klick auf einen Verkaufsort → `setWaypoint(location_id, {clearOtherWaypoints:true})`.
+- Fehlerfall (Mock wirft) → Fehler-Toast (`useToast` gemockt).
+
+---
+
+## 7. Nicht im Scope
+
+- Flutter (bewusst ausgelassen).
+- Neue ESI-Scopes / Backend-Endpunkte.
+- Routen zum Refine-„Sell-Hub"-System als eigenes Ziel (die per-Mineral-
+  Verkaufsorte decken das ab).
+
+---
+
+## 8. Betroffene Dateien
+
+- `backend/internal/models/mining.go` — `SellLocation.LocationID`.
+- `backend/internal/services/mining_location.go` — `resolve` befüllt `LocationID`.
+- `backend/internal/services/mining_location_test.go` — Assertion.
+- `frontend/src/types/trading.ts` — `SellLocation.location_id?`.
+- `frontend/src/components/trading/OreRankingTable.tsx` — Handler + Links.
+- `frontend/tests/components/OreRankingTable.test.tsx` — Tests.

--- a/frontend/src/components/trading/OreRankingTable.tsx
+++ b/frontend/src/components/trading/OreRankingTable.tsx
@@ -5,6 +5,8 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import type { OreRankRow, SellLocation } from "@/types/trading";
 import { cn, formatISK } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
+import { openMarketDetails, setWaypoint } from "@/lib/api-client";
 
 interface OreRankingTableProps {
   rows: OreRankRow[];
@@ -79,6 +81,35 @@ export function OreRankingTable({ rows }: OreRankingTableProps) {
 
 function OreRankRow({ row }: { row: OreRankRow }) {
   const [open, setOpen] = useState(false);
+  const { toast } = useToast();
+  const linkCls = "text-left hover:underline underline-offset-2 hover:text-primary transition-colors";
+  const openMarket = async (typeId: number, name: string) => {
+    try {
+      await openMarketDetails(typeId);
+      toast({
+        title: "Markt-Detail an EVE gesendet",
+        description: `${name} — falls nichts passiert: Markt-Fenster im Spiel (Alt+R) öffnen und nochmal klicken.`,
+      });
+    } catch (err) {
+      toast({
+        title: "Fehler",
+        description: err instanceof Error ? err.message : "Unbekannter Fehler",
+        variant: "destructive",
+      });
+    }
+  };
+  const setRoute = async (destId: number, label: string) => {
+    try {
+      await setWaypoint(destId, { clearOtherWaypoints: true });
+      toast({ title: "Route gesetzt", description: `Waypoint in EVE gesetzt: ${label}` });
+    } catch (err) {
+      toast({
+        title: "Fehler",
+        description: err instanceof Error ? err.message : "Unbekannter Fehler",
+        variant: "destructive",
+      });
+    }
+  };
   const isRefine = row.best === "refine";
   const verdictText = isRefine ? "Reprozessieren" : "Roh verkaufen";
   const verdictClass = isRefine
@@ -106,7 +137,17 @@ function OreRankRow({ row }: { row: OreRankRow }) {
             ) : (
               <ChevronRight className="h-4 w-4 text-muted-foreground" />
             )}
-            {row.ore_name}
+            <button
+              type="button"
+              className={linkCls}
+              title="Marktdetails im EVE-Client öffnen"
+              onClick={(e) => {
+                e.stopPropagation();
+                openMarket(row.ore_type_id, row.ore_name);
+              }}
+            >
+              {row.ore_name}
+            </button>
             {row.is_estimate && (
               <span
                 data-testid="ore-estimate-badge"
@@ -140,7 +181,23 @@ function OreRankRow({ row }: { row: OreRankRow }) {
                 )}
                 <div className="text-sm">
                   <span className="text-muted-foreground">Aufbereiten bei: </span>
-                  {formatStation(row.best_station_name, row.best_station_system)}
+                  {row.best_station_id ? (
+                    <button
+                      type="button"
+                      className={linkCls}
+                      title="Route in EVE setzen"
+                      onClick={() =>
+                        setRoute(
+                          row.best_station_id!,
+                          formatStation(row.best_station_name, row.best_station_system)
+                        )
+                      }
+                    >
+                      {formatStation(row.best_station_name, row.best_station_system)}
+                    </button>
+                  ) : (
+                    formatStation(row.best_station_name, row.best_station_system)
+                  )}
                 </div>
                 <div className="text-sm text-muted-foreground">Raffinate verkaufen:</div>
                 <table className="w-full text-xs">
@@ -155,10 +212,34 @@ function OreRankRow({ row }: { row: OreRankRow }) {
                   <tbody>
                     {(row.materials ?? []).map((m) => (
                       <tr key={m.material_type_id}>
-                        <td className="py-1 pr-4">{m.material_name || `Typ ${m.material_type_id}`}</td>
+                        <td className="py-1 pr-4">
+                          <button
+                            type="button"
+                            className={linkCls}
+                            title="Marktdetails im EVE-Client öffnen"
+                            onClick={() =>
+                              openMarket(m.material_type_id, m.material_name || `Typ ${m.material_type_id}`)
+                            }
+                          >
+                            {m.material_name || `Typ ${m.material_type_id}`}
+                          </button>
+                        </td>
                         <td className="py-1 pr-4 text-right">{m.effective_qty.toLocaleString("de-DE")}</td>
                         <td className="py-1 pr-4 text-right">{formatISK(m.buy_price)}</td>
-                        <td className="py-1">{formatSell(m.sell)}</td>
+                        <td className="py-1">
+                          {m.sell.location_id ? (
+                            <button
+                              type="button"
+                              className={linkCls}
+                              title="Route in EVE setzen"
+                              onClick={() => setRoute(m.sell.location_id!, formatSell(m.sell))}
+                            >
+                              {formatSell(m.sell)}
+                            </button>
+                          ) : (
+                            formatSell(m.sell)
+                          )}
+                        </td>
                       </tr>
                     ))}
                   </tbody>
@@ -173,7 +254,18 @@ function OreRankRow({ row }: { row: OreRankRow }) {
                   </div>
                 )}
                 <span className="text-muted-foreground">Roh verkaufen bei: </span>
-                {formatSell(row.raw_sell)}
+                {row.raw_sell?.location_id ? (
+                  <button
+                    type="button"
+                    className={linkCls}
+                    title="Route in EVE setzen"
+                    onClick={() => setRoute(row.raw_sell!.location_id!, formatSell(row.raw_sell))}
+                  >
+                    {formatSell(row.raw_sell)}
+                  </button>
+                ) : (
+                  formatSell(row.raw_sell)
+                )}
               </div>
             )}
           </td>

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -355,6 +355,7 @@ export interface SellLocation {
   station_name?: string;
   system_name?: string;
   is_structure: boolean;
+  location_id?: number;
 }
 
 export interface RefineMaterial {

--- a/frontend/tests/components/OreRankingTable.test.tsx
+++ b/frontend/tests/components/OreRankingTable.test.tsx
@@ -1,7 +1,24 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, within, fireEvent } from "@testing-library/react";
 import { OreRankingTable } from "@/components/trading/OreRankingTable";
 import { OreRankRow } from "@/types/trading";
+import { openMarketDetails, setWaypoint } from "@/lib/api-client";
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+vi.mock("@/lib/api-client", () => ({
+  openMarketDetails: vi.fn().mockResolvedValue(undefined),
+  setWaypoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+const openMarketMock = vi.mocked(openMarketDetails);
+const setWaypointMock = vi.mocked(setWaypoint);
+
+beforeEach(() => {
+  openMarketMock.mockClear();
+  setWaypointMock.mockClear();
+});
 
 function makeRow(overrides: Partial<OreRankRow> = {}): OreRankRow {
   return {
@@ -202,5 +219,45 @@ describe("OreRankingTable", () => {
     const detail = screen.getByTestId("ore-ranking-detail");
     expect(within(detail).getByText(/Zyklus/)).toBeInTheDocument();
     expect(within(detail).getByText(/Amarr/)).toBeInTheDocument();
+  });
+
+  it("opens the ore market on ore-name click without expanding the row", () => {
+    render(<OreRankingTable rows={[makeRow({ ore_type_id: 1230, ore_name: "Veldspar" })]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Veldspar" }));
+    expect(openMarketMock).toHaveBeenCalledWith(1230);
+    expect(screen.queryByTestId("ore-ranking-detail")).not.toBeInTheDocument();
+  });
+
+  it("routes to the reprocess station and opens/routes minerals in the refine detail", () => {
+    const r = makeRow({
+      ore_type_id: 1230, ore_name: "Veldspar", best: "refine",
+      best_station_id: 60003760, best_station_name: "Jita IV-4", best_station_system: "Jita",
+      materials: [{
+        material_type_id: 34, material_name: "Tritanium", effective_qty: 100, buy_price: 5,
+        sell: { station_name: "Amarr VIII", system_name: "Amarr", is_structure: false, location_id: 60008494 },
+      }],
+    });
+    render(<OreRankingTable rows={[r]} />);
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+
+    fireEvent.click(screen.getByRole("button", { name: /Jita IV-4 — Jita/ }));
+    expect(setWaypointMock).toHaveBeenCalledWith(60003760, { clearOtherWaypoints: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Tritanium" }));
+    expect(openMarketMock).toHaveBeenCalledWith(34);
+
+    fireEvent.click(screen.getByRole("button", { name: /Amarr VIII — Amarr/ }));
+    expect(setWaypointMock).toHaveBeenCalledWith(60008494, { clearOtherWaypoints: true });
+  });
+
+  it("routes to the raw ore sell location in the raw detail", () => {
+    const r = makeRow({
+      ore_type_id: 1228, ore_name: "Scordite", best: "raw",
+      raw_sell: { station_name: "Dodixie IX", system_name: "Dodixie", is_structure: false, location_id: 60011866 },
+    });
+    render(<OreRankingTable rows={[r]} />);
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+    fireEvent.click(screen.getByRole("button", { name: /Dodixie IX — Dodixie/ }));
+    expect(setWaypointMock).toHaveBeenCalledWith(60011866, { clearOtherWaypoints: true });
   });
 });


### PR DESCRIPTION
## Was

Aus der Mining-Rangliste heraus direkt im EVE-Client agieren (**nur Web**):
- **Name anklicken → Marktfenster öffnen:** Erz-Name und jeder Mineral-Name (`openMarketDetails(type_id)`).
- **Ort anklicken → Autopilot-Route setzen:** Reprocess-Station, Roherz-Verkaufsort und je Mineral der Verkaufsort (`setWaypoint(dest, {clearOtherWaypoints:true})`).

## Wie

- **Backend:** `models.SellLocation` bekommt `location_id` (in `locResolver.resolve` befüllt) — Routenziel für Verkaufsorte (NPC-Station **und** Citadel). Reprocess-Route nutzt das vorhandene `best_station_id`. Kein neuer Endpoint.
- **Web** (`OreRankingTable.tsx`): zwei geteilte Handler (`openMarket`/`setRoute`) mit ROI-identischer Toast-Sprache; Name- und Ort-Buttons. Erz-Name-Button macht `stopPropagation` (öffnet Markt, klappt die Zeile nicht auf). Fehlende ID → reiner Text; ESI-Fehler → Fehler-Toast (kein stiller No-Op).
- **Reuse:** `openMarketDetails`/`setWaypoint` existieren bereits (ROI-Table); Web-SSO hat `esi-ui.open_window.v1` + `esi-ui.write_waypoint.v1` schon → **kein neuer Scope, kein Re-Login, kein Deploy-Gate, kein Flutter**.

## Tests

- Backend: `mining_location_test` prüft `location_id` (NPC + Citadel). `go test`/`vet`/`golangci-lint` = 0 issues.
- Web: 95 vitest grün — inkl. Erz-Name → `openMarketDetails` **ohne** Aufklappen (stopPropagation), Reprocess-/Sell-Ort → `setWaypoint`, Mineral-Name → Markt. `next build` ok.

Spec: `docs/superpowers/specs/2026-06-01-mining-ingame-links-design.md`
Plan: `docs/superpowers/plans/2026-06-01-mining-ingame-links.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)