### PR TITLE
fix(mining): real ore-variant names + Pioneer hull bonus

### DIFF
--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -364,7 +364,7 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 
 		row := models.OreRankRow{
 			OreTypeID:           o.TypeID,
-			OreName:             o.Name,
+			OreName:             allOres[i].Name, // real client name from ListOres (GetOre returns the raw "-Grade" name)
 			MiningM3PerHour:     oreM3h,
 			RawNetPerM3:         cmp.RawNetPerM3,
 			RefineNetPerM3:      cmp.RefineNetPerM3,

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -352,4 +352,49 @@ func TestMiningService_OreRanking_EstimateWhenShipUnknown(t *testing.T) {
 	}
 }
 
+// TestMiningService_OreRanking_VariantRealName verifies an ore VARIANT row shows its
+// real in-game name (from ListOres' blueprint-derived rename), not the raw SDE
+// "<Ore> II-Grade" name. 17470 = SDE "Veldspar II-Grade" → client "Concentrated Veldspar".
+func TestMiningService_OreRanking_VariantRealName(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	const concentratedVeldsparTypeID = 17470 // group 462 (Veldspar), in Jita's hi-sec set
+	market := &fakeMiningMarket{buyPriceByType: map[int]float64{
+		concentratedVeldsparTypeID: 20.0,
+		tritaniumTypeID:            5.0,
+	}}
+	skills := &fakeMiningSkillsProvider{
+		skills:    &MiningReprocessingSkills{OreProcessing: map[int64]int{}, SkillLevels: map[int64]int{}},
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+	loc := fakeMiningLocation{shipTypeID: 22544}
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, loc, nil, fakeMiningNames{}, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{
+		RegionID:    10000002,
+		AllowLowSec: false,
+	})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+	var row *models.OreRankRow
+	for i := range resp.Rows {
+		if resp.Rows[i].OreTypeID == concentratedVeldsparTypeID {
+			row = &resp.Rows[i]
+			break
+		}
+	}
+	if row == nil {
+		t.Fatal("Concentrated Veldspar (17470) row not found")
+	}
+	if row.OreName != "Concentrated Veldspar" {
+		t.Errorf("OreName: got %q, want %q (real client name, not the raw -Grade)", row.OreName, "Concentrated Veldspar")
+	}
+}
+
 func approxEq(a, b float64) bool { return math.Abs(a-b) < 1e-6 }

--- a/backend/pkg/evedb/mining/hull_bonus.go
+++ b/backend/pkg/evedb/mining/hull_bonus.go
@@ -6,15 +6,22 @@ import (
 	"fmt"
 )
 
+// roleBonusOnce marks a recognised effect as a flat role bonus (applied once, not
+// scaled per skill level). Skill type ids are never 0, so it is a safe sentinel.
+const roleBonusOnce = 0
+
 // recognisedHullYieldEffects maps a ship-bonus effect (by dogmaEffects.name)
-// that modifies ore-mining yield (attr 77) to the skill whose level scales it.
-// The modifier's own skillTypeID is a constant (3386) in the SDE and must be ignored.
-// A hull whose attr-77 ship bonus is NOT in this set is reported unresolved, so the
-// caller marks the row as an estimate instead of computing a partial (wrong) value.
+// that modifies ore-mining yield (attr 77) to the skill whose level scales it, or
+// roleBonusOnce for flat role bonuses. The modifier's own skillTypeID is a constant
+// (3386) in the SDE and must be ignored. A hull whose attr-77 ship bonus is NOT in
+// this set is reported unresolved, so the caller marks the row as an estimate
+// instead of computing a partial (wrong) value.
 var recognisedHullYieldEffects = map[string]int64{
-	"miningBargeBonusOreMiningYield":   17940, // Mining Barge
-	"exhumersBonusOreMiningYield":      22551, // Exhumers
-	"miningFrigateBonusOreMiningYield": 32918, // Mining Frigate
+	"miningBargeBonusOreMiningYield":            17940,         // Mining Barge
+	"exhumersBonusOreMiningYield":               22551,         // Exhumers
+	"miningFrigateBonusOreMiningYield":          32918,         // Mining Frigate
+	"shipMiningYieldBonusOreDestroyer1":         89241,         // Mining Destroyer (Pioneer)
+	"shipMiningBonusYieldOreDestroyerRoleBonus": roleBonusOnce, // Pioneer role bonus
 }
 
 const attrMiningAmountModified = 77
@@ -49,9 +56,12 @@ func HullMiningYieldMultiplier(db *sql.DB, hullTypeID int64, skillLevels map[int
 			resolved = false // unrecognised mining bonus on this hull
 			continue
 		}
+		level := 1 // role bonus: applied once
+		if skillID != roleBonusOnce {
+			level = skillLevels[skillID]
+		}
 		for _, m := range mods {
-			value := hullAttrs[m.ModifyingAttributeID] // per-level % on this hull
-			level := skillLevels[skillID]
+			value := hullAttrs[m.ModifyingAttributeID] // per-level % (or flat % for role bonus)
 			mult *= 1.0 + (value/100.0)*float64(level)
 		}
 	}

--- a/backend/pkg/evedb/mining/hull_bonus_test.go
+++ b/backend/pkg/evedb/mining/hull_bonus_test.go
@@ -51,3 +51,30 @@ func TestHullMiningYieldMultiplier(t *testing.T) {
 		t.Error("Venture has an unrecognised attr-77 bonus → resolved must be false")
 	}
 }
+
+func TestHullMiningYieldMultiplier_Pioneer(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	// Pioneer (89240, mining destroyer): +10%/lvl Mining Destroyer (skill 89241) ×
+	// +50% role bonus (applied once). At Mining Destroyer V: 1.50 × 1.50 = 2.25.
+	mul, resolved, err := HullMiningYieldMultiplier(db, 89240, map[int64]int{89241: 5})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !resolved {
+		t.Error("Pioneer bonuses must be fully resolved")
+	}
+	if mul < 2.2499 || mul > 2.2501 {
+		t.Errorf("Pioneer MD V: got %v, want 2.25", mul)
+	}
+
+	// Mining Destroyer 0: skill bonus 1.0 × role bonus 1.50 = 1.50.
+	mul, resolved, err = HullMiningYieldMultiplier(db, 89240, map[int64]int{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !resolved || mul < 1.4999 || mul > 1.5001 {
+		t.Errorf("Pioneer MD 0: got mul=%v resolved=%v, want 1.5/true", mul, resolved)
+	}
+}


### PR DESCRIPTION
Zwei in Prod entdeckte Bugs (v0.25.0):

## 1. „-Grade"-Namen statt echter Namen
**Root cause (Code, nicht SDE):** Das Ranking zeigte `GetOre(typeID).Name` (roher SDE-Name „Veldspar II-Grade") statt des umbenannten Namens aus `ListOres` („Concentrated Veldspar"). Der Rename steuerte den IV-Grade-**Filter**, aber nicht den angezeigten **Namen**. Fix: `OreName` aus `allOres[i].Name` (umbenannt) statt `o.Name` (roh). Der bisherige Test prüfte nur den Basis-Namen „Veldspar" (roh=umbenannt identisch) → Lücke. Neuer Test: Variant 17470 → „Concentrated Veldspar".

## 2. „≈ Schätzung" auf allen Zeilen (Schiff: Pioneer)
**Root cause (gewollter fail-loud, jetzt erweitert):** Die **Pioneer** (Mining-Destroyer, typeID 89240) hat einen Mining-Bonus, der nicht in der erkannten Effekt-Menge stand → `resolved=false` → „Schiffs-Bonus nicht auflösbar". Sie nutzt `shipMiningYieldBonusOreDestroyer1` (+10%/Level Mining Destroyer) **und** einen **Rollen-Bonus** (+50%, einmalig). Letzteren konnte das Modell (nur per-Skill-Level) nicht abbilden. Fix: Rollen-Bonus-Behandlung (einmalig) + beide Pioneer-Effekte aufgenommen. Pioneer bei Mining Destroyer V → 2.25× Yield (Test).

## Tests
`go test`/`vet`/`golangci-lint` = 0 issues. Hulk (1.495), Venture (estimate), Ibis (1.0) unverändert.

Hinweis: andere Nicht-Barge/Exhumer-Hulls (Venture-Rollenbonus, Orca/Rorqual, Prospect/Endurance) bleiben weiterhin „Schätzung" (bekannt aus #157) — bei Bedarf analog einzeilig ergänzbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)