### PR TITLE
fix(mining): reachability-aware + decoupled raw/refine haul-downtime (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mining-Rechner: erreichbarkeitsbewusste Haul-Downtime, entkoppelt (#166).** Unter „Nur High-Sec" waren **alle** Zeilen fälschlich „≈ Schätzung", weil die effektive ISK/h auf Routen zu Verkaufs-/Reprocess-Stationen baute, die im Low-Sec oder in Citadels liegen (Route scheitert → geschätzt). Zwei Ursachen behoben: (1) **Ziel-Wahl ist jetzt erreichbarkeitsbewusst** — Erz-Verkaufsort, Reprocess-Station und Mineral-Hub werden unter der Sicherheits-Bereitschaft des Spielers (`AvoidLowSec`) gewählt (Citadels ≥ 1e12 sind unerreichbar); bei gleichem Kaufpreis gewinnt die **näher** gelegene Station. (2) **Raw- und Refine-Pfad werden entkoppelt** berechnet: scheitert die Refine-Route, bleibt ein erreichbarer Raw-Pfad unangetastet (Zeile zeigt „roh", keine Schätzung). Eine Zeile wird nur noch **übersprungen**, wenn **kein** erreichbarer Verkaufs-/Reprocess-Ort existiert; `is_estimate` bleibt für Hull/Crystal-Auflösung (#165) reserviert, nicht für Routing. Per-m³-Zeilen erscheinen weiterhin ohne gefittetes Mining-Modul (ISK/h dann 0). Zusätzlich **fail-loud**: stille Fehlerpfade bei Erzraum- und Schiffs-Fitting-Auflösung loggen jetzt `Warn`. Backend-only, Response-Schema unverändert (Web + Flutter ohne Änderung). Zurückgestellt unverändert: Null-Sec (#161), Class K (#162), exakte Belt-Inhalte (#163), Max-Ratio-Zyklus (#158).
+
 ## [0.25.1] - 2026-06-01
 
 ### Fixed

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -212,7 +212,17 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	// rather than gating on a separate resolved flag.
 	var oreHoldM3 float64
 	if hullResolved && hullTypeID != 0 {
-		if c, found, e := mining.OreHoldCapacity(s.sdeDB, int64(hullTypeID)); e == nil && found {
+		c, found, e := mining.OreHoldCapacity(s.sdeDB, int64(hullTypeID))
+		switch {
+		case e != nil:
+			if s.logger != nil {
+				s.logger.Warn("ore ranking: ore-hold capacity lookup failed", "hullTypeID", hullTypeID, "error", e)
+			}
+		case !found:
+			if s.logger != nil {
+				s.logger.Warn("ore ranking: ore-hold capacity unknown for hull", "hullTypeID", hullTypeID)
+			}
+		default:
 			oreHoldM3 = c
 		}
 	}
@@ -221,6 +231,8 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 		if fit, e := s.fitting.GetShipFitting(ctx, characterID, hullTypeID, accessToken); e == nil && fit != nil {
 			ws, at := fit.Bonuses.WarpSpeedAUS, fit.Bonuses.AlignTime
 			navParams.WarpSpeed, navParams.AlignTime = &ws, &at
+		} else if e != nil && s.logger != nil {
+			s.logger.Warn("ore ranking: ship fitting lookup failed, using default warp/align", "hullTypeID", hullTypeID, "error", e)
 		}
 	}
 	travelMemo := map[travelKey]*navigation.RouteResult{}

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -410,8 +410,11 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 						eff, cyc, fil = mining.EffectiveISKPerHour(
 							oreHoldM3, oreM3h, hubCmp.RefineNetPerM3, reprocessSecs+hubSecs, 2*oreStopSecs)
 					}
+					// Rank by effective ISK/h only when it's well-defined (ore hold
+					// known); otherwise eff is 0 for every hub, so fall back to
+					// per-m³ net for a deterministic, meaningful choice.
 					score := hubCmp.RefineNetPerM3
-					if oreM3h > 0 {
+					if oreM3h > 0 && oreHoldM3 > 0 {
 						score = eff
 					}
 					if score > bestScore {
@@ -422,6 +425,8 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 						if sn, e := s.names.GetSystemName(ctx, sysID); e == nil {
 							refSellSysName = sn
 						}
+						// Reset length, keep backing array; the prior winner's
+						// materials in it are intentionally discarded.
 						refBreakdown = refBreakdown[:0]
 						for _, m := range o.Materials {
 							sb := bySys[m.MaterialTypeID][sysID]
@@ -497,7 +502,10 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 				row.SellSystemName = row.RawSell.SystemName
 			}
 		}
-		row.DeltaISKPerHour = oreM3h * math.Abs(rawCmp.RawNetPerM3-refNet)
+		// Delta only means something when both paths are a real choice.
+		if rawReachable && refineReachable {
+			row.DeltaISKPerHour = oreM3h * math.Abs(rawCmp.RawNetPerM3-refNet)
+		}
 		resp.Rows = append(resp.Rows, row)
 	}
 
@@ -537,7 +545,9 @@ func (s *MiningService) bestReachableBuyOrder(
 		return 0, 0, 0, 0, 0, false
 	}
 	for _, o := range orders {
-		if !o.IsBuyOrder || o.Price <= 0 || (ok && o.Price <= price) {
+		// Skip strictly-lower prices; equal prices still get a reachability check so
+		// a closer station offering the same price can win the jumps tiebreak below.
+		if !o.IsBuyOrder || o.Price <= 0 || (ok && o.Price < price) {
 			continue
 		}
 		sys, known := sysOf[o.LocationID]
@@ -557,7 +567,10 @@ func (s *MiningService) bestReachableBuyOrder(
 		if !reachable {
 			continue
 		}
-		price, locationID, sellSys, secs, jumps, ok = o.Price, o.LocationID, sys, secsTo, jumpsTo, true
+		// Higher price always wins; on an equal price prefer fewer jumps (less haul).
+		if !ok || o.Price > price || jumpsTo < jumps {
+			price, locationID, sellSys, secs, jumps, ok = o.Price, o.LocationID, sys, secsTo, jumpsTo, true
+		}
 	}
 	return price, locationID, sellSys, secs, jumps, ok
 }

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -465,9 +465,13 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 			Materials:           refBreakdown,
 			HullYieldMultiplier: hullMul,
 			CrystalMultiplier:   crystalMul,
-			LoadVolumeM3:        oreHoldM3,
 			IsEstimate:          oreIsEstimate,
 			EstimateReason:      oreEstimateReason,
+		}
+		// Per-cycle load only means something when actually mining; for a no-miner
+		// row oreHoldM3 may be a generic-cargo fallback, which would mislead.
+		if oreM3h > 0 {
+			row.LoadVolumeM3 = oreHoldM3
 		}
 		if rawReachable {
 			rs := loc.resolve(ctx, oreLoc)

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -206,28 +206,22 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 
 	const oreStopSecs = 75.0 // fixed dock/action overhead per stop (shown in UI)
 
-	// Cycle inputs: origin system, ore-hold capacity, ship warp/align.
-	cycleResolved := true
+	// Cycle inputs: origin system, ore-hold capacity, ship warp/align. When the
+	// hull/fit can't be resolved, oreHoldM3 stays 0 (→ zero effective ISK/h) and
+	// navParams keeps default warp/align — the per-ore haul-downtime degrades
+	// rather than gating on a separate resolved flag.
 	var oreHoldM3 float64
 	if hullResolved && hullTypeID != 0 {
 		if c, found, e := mining.OreHoldCapacity(s.sdeDB, int64(hullTypeID)); e == nil && found {
 			oreHoldM3 = c
-		} else {
-			cycleResolved = false
 		}
-	} else {
-		cycleResolved = false
 	}
 	navParams := &navigation.NavigationParams{AvoidLowSec: !req.AllowLowSec}
 	if hullResolved && hullTypeID != 0 {
 		if fit, e := s.fitting.GetShipFitting(ctx, characterID, hullTypeID, accessToken); e == nil && fit != nil {
 			ws, at := fit.Bonuses.WarpSpeedAUS, fit.Bonuses.AlignTime
 			navParams.WarpSpeed, navParams.AlignTime = &ws, &at
-		} else {
-			cycleResolved = false
 		}
-	} else {
-		cycleResolved = false
 	}
 	travelMemo := map[travelKey]*navigation.RouteResult{}
 	sysOf := map[int64]int64{} // order location → system, memoised across ores
@@ -237,8 +231,22 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	if err != nil {
 		return nil, err
 	}
+	stationSys := map[int64]int64{}    // stationID → system (reachable only)
+	stationSecs := map[int64]float64{} // stationID → origin→station one-way secs
+	stationJumps := map[int64]int{}    // stationID → origin→station jumps
 	stStandings := make([]StationStanding, 0, len(stations))
 	for _, st := range stations {
+		sysID, e := s.names.GetSystemIDForLocation(ctx, st.StationID)
+		if e != nil {
+			continue // citadel/unresolvable → not reachable
+		}
+		secs, jumps, reachable := s.travelSecs(originSys, sysID, navParams, travelMemo)
+		if !reachable {
+			continue
+		}
+		stationSys[st.StationID] = sysID
+		stationSecs[st.StationID] = secs
+		stationJumps[st.StationID] = jumps
 		stStandings = append(stStandings, StationStanding{
 			StationID: st.StationID,
 			BaseRate:  st.BaseRate,
@@ -264,15 +272,19 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	loc := newLocResolver(s.names)
 	var bestStationName, bestStationSystem string
 	var reprocessSys int64
+	var reprocessSecs float64
+	var reprocessJumps int
+	reprocessAvailable := false
 	if bestStationID != 0 {
+		reprocessSys = stationSys[bestStationID]
+		reprocessSecs = stationSecs[bestStationID]
+		reprocessJumps = stationJumps[bestStationID]
+		reprocessAvailable = true
 		if n, e := s.names.GetStationName(ctx, bestStationID); e == nil && !strings.HasPrefix(n, "Station-") {
 			bestStationName = n
 		}
-		if sysID, e := s.names.GetSystemIDForLocation(ctx, bestStationID); e == nil {
-			reprocessSys = sysID
-			if sn, e2 := s.names.GetSystemName(ctx, sysID); e2 == nil {
-				bestStationSystem = sn
-			}
+		if sn, e := s.names.GetSystemName(ctx, reprocessSys); e == nil {
+			bestStationSystem = sn
 		}
 	}
 
@@ -323,163 +335,157 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 		}
 		oreM3h := m3h * hullMul * crystalMul
 
-		orePrice, oreLoc, oreOK := s.highestBuyOrder(ctx, regionID, int(o.TypeID))
-
-		// Materials: each material's highest buy order → CompareOre input + per-mineral breakdown.
-		mats := make([]MaterialValue, 0, len(o.Materials))
-		breakdown := make([]models.RefineMaterial, 0, len(o.Materials))
-		anyMatPrice := false
-		for _, m := range o.Materials {
-			mp, mLoc, mOK := s.highestBuyOrder(ctx, regionID, int(m.MaterialTypeID))
-			if mOK && mp > 0 {
-				anyMatPrice = true
-			}
-			mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: mp})
-			rm := models.RefineMaterial{
-				MaterialTypeID: m.MaterialTypeID,
-				MaterialName:   s.typeName(ctx, int(m.MaterialTypeID)),
-				EffectiveQty:   int64(math.Floor(float64(m.Quantity) * net)),
-				BuyPrice:       mp,
-			}
-			if mOK {
-				rm.Sell = loc.resolve(ctx, mLoc)
-			}
-			breakdown = append(breakdown, rm)
-		}
-
-		// Skip the ore entirely if NEITHER raw nor refine has any buy-order value.
-		if !oreOK && !anyMatPrice {
-			continue
-		}
-
-		cmp := CompareOre(OreCompareInput{
-			PortionSize:  o.PortionSize,
-			OreVolumeM3:  o.VolumeM3,
-			OreBuyPrice:  orePrice,
-			Materials:    mats,
-			NetYield:     net,
-			StationTake:  stationTax,
-			SalesTaxRate: salesTaxRate,
+		// ---- RAW path (reachability-aware): best reachable ore buy order ----
+		orePrice, oreLoc, _, oreSecs, oreJumps, oreOK :=
+			s.bestReachableBuyOrder(ctx, regionID, int(o.TypeID), originSys, navParams, travelMemo, sysOf)
+		rawCmp := CompareOre(OreCompareInput{
+			PortionSize: o.PortionSize, OreVolumeM3: o.VolumeM3, OreBuyPrice: orePrice,
+			Materials: nil, NetYield: net, StationTake: stationTax, SalesTaxRate: salesTaxRate,
 		})
-
-		row := models.OreRankRow{
-			OreTypeID:           o.TypeID,
-			OreName:             allOres[i].Name, // real client name from ListOres (GetOre returns the raw "-Grade" name)
-			MiningM3PerHour:     oreM3h,
-			RawNetPerM3:         cmp.RawNetPerM3,
-			RefineNetPerM3:      cmp.RefineNetPerM3,
-			Best:                cmp.Best,
-			RawISKPerHour:       oreM3h * cmp.RawNetPerM3,
-			RefineISKPerHour:    oreM3h * cmp.RefineNetPerM3,
-			DeltaISKPerHour:     oreM3h * cmp.DeltaPerM3,
-			BestStationID:       bestStationID,
-			BestStationTax:      stationTax,
-			BestStationName:     bestStationName,
-			BestStationSystem:   bestStationSystem,
-			Materials:           breakdown,
-			HullYieldMultiplier: hullMul,
-			CrystalMultiplier:   crystalMul,
-			IsEstimate:          oreIsEstimate,
-			EstimateReason:      oreEstimateReason,
-		}
-		if oreOK {
-			rs := loc.resolve(ctx, oreLoc)
-			row.RawSell = &rs
-		}
-
-		// ---- Haul-downtime cycle (greedy): raw 1 leg, refine best-hub 2 legs ----
-		rowResolved := cycleResolved && hullResolved
+		// "Reachable" = a sell destination exists under the player's security
+		// preference, independent of mining setup: per-m³ rows must still appear with
+		// no miner fitted (effective ISK/h then stays 0).
+		rawReachable := oreOK
 		var rawEff, rawCycleMin, rawFillMin float64
-		var rawJumps int
-		var rawSellSys int64
-		if rowResolved && oreOK {
-			if sid, e := s.names.GetSystemIDForLocation(ctx, oreLoc); e == nil {
-				rawSellSys = sid
-				if secs, jumps, ok := s.travelSecs(originSys, rawSellSys, navParams, travelMemo); ok {
-					rawEff, rawCycleMin, rawFillMin = mining.EffectiveISKPerHour(oreHoldM3, oreM3h, cmp.RawNetPerM3, secs, oreStopSecs)
-					rawJumps = jumps
-				} else {
-					rowResolved = false
-				}
-			} else {
-				rowResolved = false
-			}
+		if rawReachable && oreM3h > 0 {
+			rawEff, rawCycleMin, rawFillMin =
+				mining.EffectiveISKPerHour(oreHoldM3, oreM3h, rawCmp.RawNetPerM3, oreSecs, oreStopSecs)
 		}
 
-		var refEff, refCycleMin, refFillMin float64
+		// ---- REFINE path: reachable reprocess + best reachable hub ----
+		var refNet, refEff, refCycleMin, refFillMin float64
 		var refJumps int
 		var refSellSysName string
-		// A reprocess station exists but its system didn't resolve → can't route the
-		// refine haul; fail-loud rather than silently publishing a raw-only verdict.
-		if rowResolved && bestStationID != 0 && reprocessSys == 0 {
-			rowResolved = false
-		}
-		if rowResolved && reprocessSys != 0 {
-			o2rSecs, o2rJumps, ok := s.travelSecs(originSys, reprocessSys, navParams, travelMemo)
-			if !ok {
-				rowResolved = false
-			} else {
-				bySys := make(map[int64]map[int64]systemBuy, len(o.Materials)) // mineralType → system → buy
-				candidates := map[int64]bool{}
-				for _, m := range o.Materials {
-					g, e := s.bestBuyBySystem(ctx, regionID, int(m.MaterialTypeID), sysOf)
-					if e != nil {
-						rowResolved = false
-						break
+		var refBreakdown []models.RefineMaterial
+		refineReachable := false
+		if reprocessAvailable {
+			bySys := make(map[int64]map[int64]systemBuy, len(o.Materials))
+			candidates := map[int64]bool{}
+			ok := true
+			for _, m := range o.Materials {
+				g, e := s.bestBuyBySystem(ctx, regionID, int(m.MaterialTypeID), sysOf)
+				if e != nil {
+					if s.logger != nil {
+						s.logger.Warn("ore ranking: mineral market fetch failed", "typeID", m.MaterialTypeID, "error", e)
 					}
-					bySys[m.MaterialTypeID] = g
-					for sysID := range g {
-						candidates[sysID] = true
-					}
+					ok = false
+					break
 				}
-				bestEff := -1.0
+				bySys[m.MaterialTypeID] = g
+				for sysID := range g {
+					candidates[sysID] = true
+				}
+			}
+			if ok {
+				// Pick the best reachable hub by effective ISK/h when mining, else by
+				// per-m³ refine net so the per-m³ column is meaningful with no miner.
+				bestScore := -math.MaxFloat64
 				for sysID := range candidates {
+					hubSecs, hubJumps, reachable := s.travelSecs(reprocessSys, sysID, navParams, travelMemo)
+					if !reachable {
+						continue
+					}
 					mats := make([]MaterialValue, 0, len(o.Materials))
 					for _, m := range o.Materials {
-						price := bySys[m.MaterialTypeID][sysID].price // 0 if absent
-						mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: price})
+						mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: bySys[m.MaterialTypeID][sysID].price})
 					}
 					hubCmp := CompareOre(OreCompareInput{
 						PortionSize: o.PortionSize, OreVolumeM3: o.VolumeM3, OreBuyPrice: orePrice,
 						Materials: mats, NetYield: net, StationTake: stationTax, SalesTaxRate: salesTaxRate,
 					})
-					hubSecs, hubJumps, hok := s.travelSecs(reprocessSys, sysID, navParams, travelMemo)
-					if !hok {
-						continue
+					var eff, cyc, fil float64
+					if oreM3h > 0 {
+						eff, cyc, fil = mining.EffectiveISKPerHour(
+							oreHoldM3, oreM3h, hubCmp.RefineNetPerM3, reprocessSecs+hubSecs, 2*oreStopSecs)
 					}
-					eff, cyc, fil := mining.EffectiveISKPerHour(oreHoldM3, oreM3h, hubCmp.RefineNetPerM3, o2rSecs+hubSecs, 2*oreStopSecs)
-					if eff > bestEff {
-						bestEff, refEff, refCycleMin, refFillMin = eff, eff, cyc, fil
-						refJumps = o2rJumps + hubJumps
+					score := hubCmp.RefineNetPerM3
+					if oreM3h > 0 {
+						score = eff
+					}
+					if score > bestScore {
+						bestScore = score
+						refNet = hubCmp.RefineNetPerM3
+						refEff, refCycleMin, refFillMin = eff, cyc, fil
+						refJumps = reprocessJumps + hubJumps
 						if sn, e := s.names.GetSystemName(ctx, sysID); e == nil {
 							refSellSysName = sn
 						}
+						refBreakdown = refBreakdown[:0]
+						for _, m := range o.Materials {
+							sb := bySys[m.MaterialTypeID][sysID]
+							rm := models.RefineMaterial{
+								MaterialTypeID: m.MaterialTypeID,
+								MaterialName:   s.typeName(ctx, int(m.MaterialTypeID)),
+								EffectiveQty:   int64(math.Floor(float64(m.Quantity) * net)),
+								BuyPrice:       sb.price,
+							}
+							if sb.locationID != 0 {
+								rm.Sell = loc.resolve(ctx, sb.locationID)
+							}
+							refBreakdown = append(refBreakdown, rm)
+						}
+						refineReachable = true
 					}
 				}
 			}
 		}
 
-		if rowResolved && (rawEff > 0 || refEff > 0) {
-			if refEff > rawEff {
-				row.Best = "refine"
-				row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = refEff, refCycleMin, refFillMin
-				row.RouteJumps, row.SellSystemName = refJumps, refSellSysName
-			} else {
-				row.Best = "raw"
-				row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = rawEff, rawCycleMin, rawFillMin
-				row.RouteJumps = rawJumps
-				if row.RawSell != nil {
-					row.SellSystemName = row.RawSell.SystemName
-				}
-			}
-			row.LoadVolumeM3 = oreHoldM3
-		} else if oreM3h > 0 {
-			row.IsEstimate = true
-			if row.EstimateReason == "" {
-				row.EstimateReason = "Haul-Downtime nicht berechenbar"
-			}
+		// Skip the ore entirely if neither path has a reachable destination.
+		if !rawReachable && !refineReachable {
+			continue
 		}
 
+		// ---- Build the row from the available path(s) ----
+		row := models.OreRankRow{
+			OreTypeID:           o.TypeID,
+			OreName:             allOres[i].Name,
+			MiningM3PerHour:     oreM3h,
+			RawNetPerM3:         rawCmp.RawNetPerM3,
+			RefineNetPerM3:      refNet,
+			RawISKPerHour:       oreM3h * rawCmp.RawNetPerM3,
+			RefineISKPerHour:    oreM3h * refNet,
+			BestStationTax:      stationTax,
+			Materials:           refBreakdown,
+			HullYieldMultiplier: hullMul,
+			CrystalMultiplier:   crystalMul,
+			LoadVolumeM3:        oreHoldM3,
+			IsEstimate:          oreIsEstimate,
+			EstimateReason:      oreEstimateReason,
+		}
+		if rawReachable {
+			rs := loc.resolve(ctx, oreLoc)
+			row.RawSell = &rs
+		}
+		if refineReachable {
+			row.BestStationID = bestStationID
+			row.BestStationName = bestStationName
+			row.BestStationSystem = bestStationSystem
+		}
+		// Verdict: by effective ISK/h when mining, else by per-m³ refine vs raw net.
+		var refineWins bool
+		switch {
+		case !refineReachable:
+			refineWins = false
+		case !rawReachable:
+			refineWins = true
+		case oreM3h > 0:
+			refineWins = refEff >= rawEff
+		default:
+			refineWins = refNet >= rawCmp.RawNetPerM3
+		}
+		if refineWins {
+			row.Best = "refine"
+			row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = refEff, refCycleMin, refFillMin
+			row.RouteJumps, row.SellSystemName = refJumps, refSellSysName
+		} else {
+			row.Best = "raw"
+			row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = rawEff, rawCycleMin, rawFillMin
+			row.RouteJumps = oreJumps
+			if row.RawSell != nil {
+				row.SellSystemName = row.RawSell.SystemName
+			}
+		}
+		row.DeltaISKPerHour = oreM3h * math.Abs(rawCmp.RawNetPerM3-refNet)
 		resp.Rows = append(resp.Rows, row)
 	}
 
@@ -501,23 +507,47 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	return resp, nil
 }
 
-// highestBuyPrice returns the highest buy-order price for (region, type), or 0 if none.
-// highestBuyOrder returns the highest buy-order price and its location for (region, type).
-// ok=false when there is no buy order.
-func (s *MiningService) highestBuyOrder(ctx context.Context, regionID, typeID int) (price float64, locationID int64, ok bool) {
+// bestReachableBuyOrder returns the highest buy order for a type whose station's
+// system is reachable from origin under the request's security preference (params).
+// Citadels (location not resolvable to a system) are skipped — they can't anchor a
+// haul leg. Returns the order's price, location, system, one-way travel secs/jumps,
+// and ok=false when no reachable buy order exists. Reuses sysOf (location→system)
+// and travelMemo for memoisation.
+func (s *MiningService) bestReachableBuyOrder(
+	ctx context.Context, regionID, typeID int, origin int64,
+	params *navigation.NavigationParams, travelMemo map[travelKey]*navigation.RouteResult, sysOf map[int64]int64,
+) (price float64, locationID int64, sellSys int64, secs float64, jumps int, ok bool) {
 	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warn("ore ranking: market orders fetch failed", "typeID", typeID, "error", err)
 		}
-		return 0, 0, false
+		return 0, 0, 0, 0, 0, false
 	}
 	for _, o := range orders {
-		if o.IsBuyOrder && (!ok || o.Price > price) {
-			price, locationID, ok = o.Price, o.LocationID, true
+		if !o.IsBuyOrder || o.Price <= 0 || (ok && o.Price <= price) {
+			continue
 		}
+		sys, known := sysOf[o.LocationID]
+		if !known {
+			id, e := s.names.GetSystemIDForLocation(ctx, o.LocationID)
+			if e != nil {
+				sysOf[o.LocationID] = 0 // unresolvable (citadel) → unreachable
+				continue
+			}
+			sysOf[o.LocationID] = id
+			sys = id
+		}
+		if sys == 0 {
+			continue
+		}
+		secsTo, jumpsTo, reachable := s.travelSecs(origin, sys, params, travelMemo)
+		if !reachable {
+			continue
+		}
+		price, locationID, sellSys, secs, jumps, ok = o.Price, o.LocationID, sys, secsTo, jumpsTo, true
 	}
-	return price, locationID, ok
+	return price, locationID, sellSys, secs, jumps, ok
 }
 
 // typeName resolves a type's name (e.g. for a refined mineral), "" on failure.

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -19,6 +19,8 @@ import (
 type fakeMiningMarket struct {
 	// buyPriceByType maps typeID → highest buy price returned as a single buy order.
 	buyPriceByType map[int]float64
+	// locByType overrides the highest-buy-order station per type (default 60000123).
+	locByType map[int]int64
 }
 
 func (f *fakeMiningMarket) GetMarketOrders(_ context.Context, _ int, typeID int) ([]database.MarketOrder, error) {
@@ -26,10 +28,24 @@ func (f *fakeMiningMarket) GetMarketOrders(_ context.Context, _ int, typeID int)
 	if !ok {
 		return []database.MarketOrder{}, nil
 	}
+	loc := int64(60000123)
+	if f.locByType != nil {
+		if l, ok := f.locByType[typeID]; ok {
+			loc = l
+		}
+	}
+	// Lower buy-order location: same override when set (keeps all orders unreachable),
+	// otherwise the default NPC station 60000999 (to prove we pick the highest buy).
+	lowerLoc := int64(60000999)
+	if f.locByType != nil {
+		if l, ok := f.locByType[typeID]; ok {
+			lowerLoc = l
+		}
+	}
 	return []database.MarketOrder{
-		{TypeID: typeID, IsBuyOrder: true, Price: price, VolumeRemain: 1_000_000, LocationID: 60000123},
+		{TypeID: typeID, IsBuyOrder: true, Price: price, VolumeRemain: 1_000_000, LocationID: loc},
 		// a lower buy order + a sell order, to prove we pick the highest buy.
-		{TypeID: typeID, IsBuyOrder: true, Price: price * 0.5, VolumeRemain: 100, LocationID: 60000999},
+		{TypeID: typeID, IsBuyOrder: true, Price: price * 0.5, VolumeRemain: 100, LocationID: lowerLoc},
 		{TypeID: typeID, IsBuyOrder: false, Price: price * 2, VolumeRemain: 100},
 	}, nil
 }
@@ -50,7 +66,10 @@ func (fakeMiningNames) GetStationName(_ context.Context, id int64) (string, erro
 
 func (fakeMiningNames) GetSystemName(_ context.Context, _ int64) (string, error) { return "Jita", nil }
 
-func (fakeMiningNames) GetSystemIDForLocation(_ context.Context, _ int64) (int64, error) {
+func (fakeMiningNames) GetSystemIDForLocation(_ context.Context, id int64) (int64, error) {
+	if id >= 1_000_000_000_000 {
+		return 0, fmt.Errorf("no system for structure %d", id)
+	}
 	return 30000142, nil
 }
 
@@ -394,6 +413,127 @@ func TestMiningService_OreRanking_VariantRealName(t *testing.T) {
 	}
 	if row.OreName != "Concentrated Veldspar" {
 		t.Errorf("OreName: got %q, want %q (real client name, not the raw -Grade)", row.OreName, "Concentrated Veldspar")
+	}
+}
+
+// TestMiningService_OreRanking_CitadelUnreachable verifies that an ore whose only raw
+// buy order AND whose mineral buy orders are all in a citadel (≥1e12) is skipped
+// entirely — not ranked, not estimated.
+func TestMiningService_OreRanking_CitadelUnreachable(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	// Both Veldspar raw and its refine mineral (Tritanium) are only buyable in a citadel.
+	market := &fakeMiningMarket{
+		buyPriceByType: map[int]float64{
+			veldsparTypeID:  15.0,
+			tritaniumTypeID: 5.0,
+		},
+		locByType: map[int]int64{
+			veldsparTypeID:  1_035_000_000_001,
+			tritaniumTypeID: 1_035_000_000_001,
+		},
+	}
+	skills := &fakeMiningSkillsProvider{
+		skills: &MiningReprocessingSkills{
+			OreProcessing: map[int64]int{},
+			SkillLevels:   map[int64]int{17940: 5, 22551: 5},
+		},
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+	loc := fakeMiningLocation{shipTypeID: 22544}
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, loc, nil, fakeMiningNames{}, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{
+		RegionID:    10000002,
+		AllowLowSec: false,
+	})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+
+	// Veldspar is fully unreachable (both raw and refine paths unreachable) → must be skipped.
+	for _, r := range resp.Rows {
+		if r.OreTypeID == veldsparTypeID {
+			t.Errorf("Veldspar (both raw and refine in citadel) must be skipped, but found row: %+v", r)
+		}
+	}
+}
+
+// TestMiningService_OreRanking_DecoupledRawWhenRefineUnreachable verifies that when
+// the refine path is unavailable (only reprocess station is a citadel) but the raw
+// sell path is reachable, the Veldspar row resolves as "raw", is not an estimate,
+// and has EffectiveISKPerHour > 0.
+func TestMiningService_OreRanking_DecoupledRawWhenRefineUnreachable(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	// Raw Veldspar buy order at default NPC station (reachable). Tritanium also reachable.
+	market := &fakeMiningMarket{
+		buyPriceByType: map[int]float64{
+			veldsparTypeID:  15.0,
+			tritaniumTypeID: 5.0,
+		},
+		// No locByType override → highest buy at 60000123 (NPC, reachable).
+	}
+	skills := &fakeMiningSkillsProvider{
+		skills: &MiningReprocessingSkills{
+			OreProcessing: map[int64]int{},
+			SkillLevels:   map[int64]int{17940: 5, 22551: 5},
+		},
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	// The ONLY reprocess station is a citadel → unreachable → refine unavailable for all ores.
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 1_035_000_000_009, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+	loc := fakeMiningLocation{shipTypeID: 22544}
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, loc, nil, fakeMiningNames{}, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{
+		RegionID:    10000002,
+		AllowLowSec: false,
+	})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+
+	// Find the Veldspar row — it must exist (raw path is reachable).
+	var row *models.OreRankRow
+	for i := range resp.Rows {
+		if resp.Rows[i].OreTypeID == veldsparTypeID {
+			row = &resp.Rows[i]
+			break
+		}
+	}
+	if row == nil {
+		t.Fatal("Veldspar row must be present (raw path is reachable even though refine is not)")
+	}
+
+	// Raw path wins because refine is unavailable.
+	if row.Best != "raw" {
+		t.Errorf("Best: got %q, want %q (refine unavailable → raw wins)", row.Best, "raw")
+	}
+	// IsEstimate is for hull/crystal resolution failures, not routing failures.
+	if row.IsEstimate {
+		t.Errorf("IsEstimate must be false (routing failure is not an estimate condition): %+v", *row)
+	}
+	// The raw sell station is reachable → effective ISK/h must be > 0.
+	if row.EffectiveISKPerHour <= 0 {
+		t.Errorf("EffectiveISKPerHour must be > 0 (raw path is reachable): %v", row.EffectiveISKPerHour)
+	}
+	// No reachable reprocess station → BestStationID must be 0.
+	if row.BestStationID != 0 {
+		t.Errorf("BestStationID: got %d, want 0 (no reachable reprocess station)", row.BestStationID)
+	}
+	// RawSell must be set.
+	if row.RawSell == nil {
+		t.Error("RawSell must be set (raw path is the only available path)")
 	}
 }
 

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -535,6 +535,82 @@ func TestMiningService_OreRanking_DecoupledRawWhenRefineUnreachable(t *testing.T
 	if row.RawSell == nil {
 		t.Error("RawSell must be set (raw path is the only available path)")
 	}
+	// Only one path is a real choice → no meaningful raw-vs-refine delta.
+	if row.DeltaISKPerHour != 0 {
+		t.Errorf("DeltaISKPerHour must be 0 with only one reachable path: %v", row.DeltaISKPerHour)
+	}
+}
+
+// TestMiningService_OreRanking_DecoupledRefineWhenRawUnreachable is the mirror of the
+// raw-only case: when every raw buy order is in a citadel but a reachable reprocess
+// station + mineral hub exist, the row resolves as "refine" (the !rawReachable verdict
+// branch), with no RawSell and effective ISK/h > 0.
+func TestMiningService_OreRanking_DecoupledRefineWhenRawUnreachable(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	// Veldspar raw is citadel-only (unreachable); its mineral Tritanium stays at the
+	// default NPC station (reachable), so only the refine path can resolve.
+	market := &fakeMiningMarket{
+		buyPriceByType: map[int]float64{
+			veldsparTypeID:  15.0,
+			tritaniumTypeID: 5.0,
+		},
+		locByType: map[int]int64{
+			veldsparTypeID: 1_035_000_000_001,
+		},
+	}
+	skills := &fakeMiningSkillsProvider{
+		skills: &MiningReprocessingSkills{
+			OreProcessing: map[int64]int{},
+			SkillLevels:   map[int64]int{17940: 5, 22551: 5},
+		},
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	// Reachable NPC reprocess station → refine path available.
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+	loc := fakeMiningLocation{shipTypeID: 22544}
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, loc, nil, fakeMiningNames{}, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{
+		RegionID:    10000002,
+		AllowLowSec: false,
+	})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+
+	var row *models.OreRankRow
+	for i := range resp.Rows {
+		if resp.Rows[i].OreTypeID == veldsparTypeID {
+			row = &resp.Rows[i]
+			break
+		}
+	}
+	if row == nil {
+		t.Fatal("Veldspar row must be present (refine path is reachable even though raw is not)")
+	}
+	if row.Best != "refine" {
+		t.Errorf("Best: got %q, want %q (raw unreachable → refine wins)", row.Best, "refine")
+	}
+	if row.IsEstimate {
+		t.Errorf("IsEstimate must be false (routing failure is not an estimate condition): %+v", *row)
+	}
+	if row.EffectiveISKPerHour <= 0 {
+		t.Errorf("EffectiveISKPerHour must be > 0 (refine path is reachable): %v", row.EffectiveISKPerHour)
+	}
+	if row.BestStationID == 0 {
+		t.Error("BestStationID must be set (reprocess station is reachable)")
+	}
+	if row.RawSell != nil {
+		t.Errorf("RawSell must be nil (raw path is unreachable): %+v", *row.RawSell)
+	}
+	if row.DeltaISKPerHour != 0 {
+		t.Errorf("DeltaISKPerHour must be 0 with only one reachable path: %v", row.DeltaISKPerHour)
+	}
 }
 
 func approxEq(a, b float64) bool { return math.Abs(a-b) < 1e-6 }

--- a/docs/superpowers/plans/2026-06-01-mining-reachability-aware-haul.md
+++ b/docs/superpowers/plans/2026-06-01-mining-reachability-aware-haul.md
@@ -1,0 +1,532 @@
+# Reachability-aware + decoupled haul-downtime — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The mining ranking chooses sell/reprocess destinations that are actually reachable under the player's security choice, computes the raw and refine paths independently, and only marks a row "estimate" when no path is reachable (or hull/crystal is unresolved).
+
+**Architecture:** A `bestReachableBuyOrder` helper picks the highest buy order whose system is routable from the origin (citadels excluded). The reprocess-station list is filtered to reachable stations before `BestStation`. In the per-ore loop, raw and refine are computed independently from reachable destinations; the row resolves if either path resolves and only estimates when neither does. Backend-only — response schema unchanged.
+
+**Tech Stack:** Go 1.24, SQLite SDE.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-mining-reachability-aware-haul-design.md`.
+
+**Verified current code (in `backend/internal/services/mining_service.go`):**
+- Before the ore loop, `originSys`, `navParams` (`AvoidLowSec = !req.AllowLowSec`), `travelMemo`, `sysOf` are all in scope. `s.travelSecs(from, to int64, params, travelMemo) (secs float64, jumps int, ok bool)` returns `(0,0,true)` for `from==to` and `false` when unroutable.
+- `s.highestBuyOrder(ctx, regionID, typeID int) (price float64, locationID int64, ok bool)` returns the single global-best buy order.
+- Reprocess stations: `stations` ([]database.ReprocessStation{StationID, OwnerCorpID, BaseRate, BaseTake}), `stStandings` ([]StationStanding{StationID, BaseRate, BaseTake, Standing}), `best := BestStation(stStandings)`, then `bestStationID`/`baseRate`/`baseTake`/`bestStanding`/`stationTax`, `reprocessSys` via `s.names.GetSystemIDForLocation(bestStationID)`.
+- `s.names.GetSystemIDForLocation(ctx, locationID int64) (int64, error)` errors for citadels (≥1e12).
+- Per ore: `bestBuyBySystem(ctx, regionID, typeID int, sysOf) (map[int64]systemBuy, error)` groups buy orders by system; `systemBuy{price, locationID}`. `loc := newLocResolver(s.names)`; `loc.resolve(ctx, locationID) models.SellLocation`. `CompareOre(OreCompareInput{...}) {RawNetPerM3, RefineNetPerM3, Best, DeltaPerM3}`. `mining.EffectiveISKPerHour(oreHoldM3, m3h, netPerM3, travelSecs, stopSecs) (eff, cycleMin, fillMin)`. `mining.OreCrystalMultiplierT2`, `hullMul`, `oreM3h`, `oreStopSecs=75`.
+
+**Test DB:** `SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off` from `backend/`.
+
+---
+
+## Task 1: Reachable-best-buy helper + reachable reprocess station
+
+**Files:**
+- Modify: `backend/internal/services/mining_service.go`
+
+- [ ] **Step 1: Add `bestReachableBuyOrder` (after `highestBuyOrder`)**
+
+```go
+// bestReachableBuyOrder returns the highest buy order for a type whose station's
+// system is reachable from origin under the request's security preference (params).
+// Citadels (location not resolvable to a system) are skipped — they can't anchor a
+// haul leg. Returns the order's price, location, system, one-way travel secs/jumps,
+// and ok=false when no reachable buy order exists. Reuses sysOf (location→system)
+// and travelMemo for memoisation.
+func (s *MiningService) bestReachableBuyOrder(
+	ctx context.Context, regionID, typeID int, origin int64,
+	params *navigation.NavigationParams, travelMemo map[travelKey]*navigation.RouteResult, sysOf map[int64]int64,
+) (price float64, locationID int64, sellSys int64, secs float64, jumps int, ok bool) {
+	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("ore ranking: market orders fetch failed", "typeID", typeID, "error", err)
+		}
+		return 0, 0, 0, 0, 0, false
+	}
+	for _, o := range orders {
+		if !o.IsBuyOrder || o.Price <= 0 || (ok && o.Price <= price) {
+			continue
+		}
+		sys, known := sysOf[o.LocationID]
+		if !known {
+			id, e := s.names.GetSystemIDForLocation(ctx, o.LocationID)
+			if e != nil {
+				sysOf[o.LocationID] = 0 // unresolvable (citadel) → unreachable
+				continue
+			}
+			sysOf[o.LocationID] = id
+			sys = id
+		}
+		if sys == 0 {
+			continue
+		}
+		secsTo, jumpsTo, reachable := s.travelSecs(origin, sys, params, travelMemo)
+		if !reachable {
+			continue
+		}
+		price, locationID, sellSys, secs, jumps, ok = o.Price, o.LocationID, sys, secsTo, jumpsTo, true
+	}
+	return price, locationID, sellSys, secs, jumps, ok
+}
+```
+
+- [ ] **Step 2: Filter the reprocess-station list to reachable stations**
+
+Replace the reprocess-station block. The current code is:
+
+```go
+	stStandings := make([]StationStanding, 0, len(stations))
+	for _, st := range stations {
+		stStandings = append(stStandings, StationStanding{
+			StationID: st.StationID,
+			BaseRate:  st.BaseRate,
+			BaseTake:  st.BaseTake,
+			Standing:  standings[st.OwnerCorpID],
+		})
+	}
+	best := BestStation(stStandings)
+```
+
+with (resolve each station's system, keep only reachable ones, remember the system + travel):
+
+```go
+	stationSys := map[int64]int64{}        // stationID → system (reachable only)
+	stationSecs := map[int64]float64{}     // stationID → origin→station one-way secs
+	stationJumps := map[int64]int{}        // stationID → origin→station jumps
+	stStandings := make([]StationStanding, 0, len(stations))
+	for _, st := range stations {
+		sysID, e := s.names.GetSystemIDForLocation(ctx, st.StationID)
+		if e != nil {
+			continue // citadel/unresolvable → not reachable
+		}
+		secs, jumps, reachable := s.travelSecs(originSys, sysID, navParams, travelMemo)
+		if !reachable {
+			continue
+		}
+		stationSys[st.StationID] = sysID
+		stationSecs[st.StationID] = secs
+		stationJumps[st.StationID] = jumps
+		stStandings = append(stStandings, StationStanding{
+			StationID: st.StationID,
+			BaseRate:  st.BaseRate,
+			BaseTake:  st.BaseTake,
+			Standing:  standings[st.OwnerCorpID],
+		})
+	}
+	best := BestStation(stStandings)
+```
+
+- [ ] **Step 3: Set reprocess system/travel from the reachable best station**
+
+Replace the reprocess name/system block. The current code is:
+
+```go
+	loc := newLocResolver(s.names)
+	var bestStationName, bestStationSystem string
+	var reprocessSys int64
+	if bestStationID != 0 {
+		if n, e := s.names.GetStationName(ctx, bestStationID); e == nil && !strings.HasPrefix(n, "Station-") {
+			bestStationName = n
+		}
+		if sysID, e := s.names.GetSystemIDForLocation(ctx, bestStationID); e == nil {
+			reprocessSys = sysID
+			if sn, e2 := s.names.GetSystemName(ctx, sysID); e2 == nil {
+				bestStationSystem = sn
+			}
+		}
+	}
+```
+
+with (reprocess is reachable by construction; capture its travel):
+
+```go
+	loc := newLocResolver(s.names)
+	var bestStationName, bestStationSystem string
+	var reprocessSys int64
+	var reprocessSecs float64
+	var reprocessJumps int
+	reprocessAvailable := false
+	if bestStationID != 0 {
+		reprocessSys = stationSys[bestStationID]
+		reprocessSecs = stationSecs[bestStationID]
+		reprocessJumps = stationJumps[bestStationID]
+		reprocessAvailable = true
+		if n, e := s.names.GetStationName(ctx, bestStationID); e == nil && !strings.HasPrefix(n, "Station-") {
+			bestStationName = n
+		}
+		if sn, e := s.names.GetSystemName(ctx, reprocessSys); e == nil {
+			bestStationSystem = sn
+		}
+	}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cd backend && GOWORK=off go build ./... 2>&1 | head` — if `go build` errors that `highestBuyOrder` is now unused, it is still used by the loop (Task 2 replaces that). Expect: builds (the new helper + reprocess changes compile; `go vet` on the test file is fine).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/services/mining_service.go
+git commit -m "feat(mining): reachable-best-buy helper + reachable reprocess station"
+```
+
+---
+
+## Task 2: Decoupled, reachability-aware per-ore loop
+
+**Files:**
+- Modify: `backend/internal/services/mining_service.go`
+
+This replaces the per-ore loop body from the raw-buy line through the end of the haul-downtime block. Keep everything **above** `orePrice, oreLoc, oreOK := s.highestBuyOrder(...)` (net, crystal, oreM3h, hull/crystal estimate) and the loop header unchanged.
+
+- [ ] **Step 1: Replace the raw-buy + materials + CompareOre + row-build + haul-downtime block**
+
+Find the block starting at `orePrice, oreLoc, oreOK := s.highestBuyOrder(ctx, regionID, int(o.TypeID))` and ending at the close of the haul-downtime `} else if oreM3h > 0 { ... }` estimate block (the lines that set `row.IsEstimate`/`row.EstimateReason` from the cycle), and replace the WHOLE thing with:
+
+```go
+		// ---- RAW path (reachability-aware): best reachable ore buy order ----
+		orePrice, oreLoc, _, oreSecs, oreJumps, oreOK :=
+			s.bestReachableBuyOrder(ctx, regionID, int(o.TypeID), originSys, navParams, travelMemo, sysOf)
+		rawCmp := CompareOre(OreCompareInput{
+			PortionSize: o.PortionSize, OreVolumeM3: o.VolumeM3, OreBuyPrice: orePrice,
+			Materials: nil, NetYield: net, StationTake: stationTax, SalesTaxRate: salesTaxRate,
+		})
+		rawAvailable := oreOK && oreM3h > 0
+		var rawEff, rawCycleMin, rawFillMin float64
+		if rawAvailable {
+			rawEff, rawCycleMin, rawFillMin =
+				mining.EffectiveISKPerHour(oreHoldM3, oreM3h, rawCmp.RawNetPerM3, oreSecs, oreStopSecs)
+		}
+
+		// ---- REFINE path: reachable reprocess + best reachable hub ----
+		var refNet, refEff, refCycleMin, refFillMin float64
+		var refJumps int
+		var refSellSysName string
+		var refBreakdown []models.RefineMaterial
+		refineAvailable := false
+		if reprocessAvailable && oreM3h > 0 {
+			bySys := make(map[int64]map[int64]systemBuy, len(o.Materials))
+			candidates := map[int64]bool{}
+			ok := true
+			for _, m := range o.Materials {
+				g, e := s.bestBuyBySystem(ctx, regionID, int(m.MaterialTypeID), sysOf)
+				if e != nil {
+					if s.logger != nil {
+						s.logger.Warn("ore ranking: mineral market fetch failed", "typeID", m.MaterialTypeID, "error", e)
+					}
+					ok = false
+					break
+				}
+				bySys[m.MaterialTypeID] = g
+				for sysID := range g {
+					candidates[sysID] = true
+				}
+			}
+			if ok {
+				bestEff := -1.0
+				for sysID := range candidates {
+					hubSecs, hubJumps, reachable := s.travelSecs(reprocessSys, sysID, navParams, travelMemo)
+					if !reachable {
+						continue
+					}
+					mats := make([]MaterialValue, 0, len(o.Materials))
+					for _, m := range o.Materials {
+						mats = append(mats, MaterialValue{Qty: m.Quantity, BuyPrice: bySys[m.MaterialTypeID][sysID].price})
+					}
+					hubCmp := CompareOre(OreCompareInput{
+						PortionSize: o.PortionSize, OreVolumeM3: o.VolumeM3, OreBuyPrice: orePrice,
+						Materials: mats, NetYield: net, StationTake: stationTax, SalesTaxRate: salesTaxRate,
+					})
+					eff, cyc, fil := mining.EffectiveISKPerHour(
+						oreHoldM3, oreM3h, hubCmp.RefineNetPerM3, reprocessSecs+hubSecs, 2*oreStopSecs)
+					if eff > bestEff {
+						bestEff = eff
+						refNet = hubCmp.RefineNetPerM3
+						refEff, refCycleMin, refFillMin = eff, cyc, fil
+						refJumps = reprocessJumps + hubJumps
+						if sn, e := s.names.GetSystemName(ctx, sysID); e == nil {
+							refSellSysName = sn
+						}
+						refBreakdown = refBreakdown[:0]
+						for _, m := range o.Materials {
+							sb := bySys[m.MaterialTypeID][sysID]
+							rm := models.RefineMaterial{
+								MaterialTypeID: m.MaterialTypeID,
+								MaterialName:   s.typeName(ctx, int(m.MaterialTypeID)),
+								EffectiveQty:   int64(math.Floor(float64(m.Quantity) * net)),
+								BuyPrice:       sb.price,
+							}
+							if sb.locationID != 0 {
+								rm.Sell = loc.resolve(ctx, sb.locationID)
+							}
+							refBreakdown = append(refBreakdown, rm)
+						}
+						refineAvailable = true
+					}
+				}
+			}
+		}
+
+		// Skip the ore entirely if neither path is reachable.
+		if !rawAvailable && !refineAvailable {
+			continue
+		}
+
+		// ---- Build the row from the available path(s) ----
+		row := models.OreRankRow{
+			OreTypeID:           o.TypeID,
+			OreName:             allOres[i].Name,
+			MiningM3PerHour:     oreM3h,
+			RawNetPerM3:         rawCmp.RawNetPerM3,
+			RefineNetPerM3:      refNet,
+			RawISKPerHour:       oreM3h * rawCmp.RawNetPerM3,
+			RefineISKPerHour:    oreM3h * refNet,
+			BestStationTax:      stationTax,
+			Materials:           refBreakdown,
+			HullYieldMultiplier: hullMul,
+			CrystalMultiplier:   crystalMul,
+			LoadVolumeM3:        oreHoldM3,
+			IsEstimate:          oreIsEstimate,
+			EstimateReason:      oreEstimateReason,
+		}
+		if rawAvailable {
+			rs := loc.resolve(ctx, oreLoc)
+			row.RawSell = &rs
+		}
+		if refineAvailable {
+			row.BestStationID = bestStationID
+			row.BestStationName = bestStationName
+			row.BestStationSystem = bestStationSystem
+		}
+
+		// Verdict + effective ISK/h from the better available path (≥1 is available).
+		switch {
+		case refineAvailable && (!rawAvailable || refEff >= rawEff):
+			row.Best = "refine"
+			row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = refEff, refCycleMin, refFillMin
+			row.RouteJumps, row.SellSystemName = refJumps, refSellSysName
+		default:
+			row.Best = "raw"
+			row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = rawEff, rawCycleMin, rawFillMin
+			row.RouteJumps = oreJumps
+			if row.RawSell != nil {
+				row.SellSystemName = row.RawSell.SystemName
+			}
+		}
+
+		row.DeltaISKPerHour = oreM3h * math.Abs(rawCmp.RawNetPerM3-refNet)
+		resp.Rows = append(resp.Rows, row)
+	}
+```
+
+Note: this replaces the OLD `resp.Rows = append(resp.Rows, row)` at the loop end too (it is now the last line above). Make sure there is exactly one `append` and one closing `}` for the `for i := range allOres` loop. The OLD code between the raw-buy line and the old append (materials loop, `cmp`, the old `row :=`, the `if oreOK { row.RawSell }`, the entire `// ---- Haul-downtime cycle ...` block, and the `if rowResolved ... else if oreM3h>0 ...` estimate block) is entirely replaced by the code above.
+
+- [ ] **Step 2: Remove the now-unused `highestBuyOrder`**
+
+`bestReachableBuyOrder` replaces it everywhere. Delete the `highestBuyOrder` method. Confirm no references: `grep -n "highestBuyOrder" backend/internal/services/*.go` → none.
+
+- [ ] **Step 3: Build + gofmt + vet + lint**
+
+Run: `cd backend && GOWORK=off go build ./... && gofmt -l internal/services/ && GOWORK=off go vet ./internal/services/... && GOWORK=off golangci-lint run ./internal/services/...`
+Expected: builds; no gofmt output; `0 issues`. (If golangci flags an unused variable like `bestStanding`, ensure it still feeds `ReprocessTax`/`stationTax` as before; that block above the reprocess name change is unchanged.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/services/mining_service.go
+git commit -m "feat(mining): decoupled, reachability-aware raw/refine haul-downtime"
+```
+
+---
+
+## Task 3: Service tests
+
+**Files:**
+- Modify: `backend/internal/services/mining_service_test.go`
+
+- [ ] **Step 1: Update existing tests for the new behavior**
+
+The fakes already place buy orders at `LocationID: 60000123` (an NPC station) and `fakeMiningNames.GetSystemIDForLocation` returns `30000142` (Jita = origin via `fakeMiningLocation`). So the existing orders are in-system → reachable (travel 0). The existing Veldspar / VariantRealName / NoMiningSetup / EstimateWhenShipUnknown tests should still pass — run them and fix only assertions that depended on the removed shared-`rowResolved` behavior. Run:
+`SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/services/ -run TestMiningService -v`
+If `TestMiningService_OreRanking_VariantRealName` or `_Veldspar` fail because the row is now built differently, adjust the field they read (e.g. `OreName`, `RawSell`, `BestStationName`) to match the new build — do not weaken the real-name / no-low-sec-leak assertions.
+
+- [ ] **Step 2: Add a citadel-unreachable test**
+
+Add a fake market whose only buy order sits in a citadel location (≥1e12), and assert the ore estimates with the new reason. Add near the other tests:
+
+```go
+func TestMiningService_OreRanking_CitadelUnreachable(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	// Veldspar buy order only in a citadel (≥1e12) → unreachable → no raw/refine path.
+	market := &citadelOnlyMarket{price: 15.0}
+	skills := &fakeMiningSkillsProvider{
+		skills:    &MiningReprocessingSkills{OreProcessing: map[int64]int{}, SkillLevels: map[int64]int{17940: 5, 22551: 5}},
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+	loc := fakeMiningLocation{shipTypeID: 22544}
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, loc, nil, fakeMiningNames{}, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{RegionID: 10000002, AllowLowSec: false})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+	// No reachable sell/reprocess (only-citadel orders) → the ore is skipped.
+	for i := range resp.Rows {
+		if resp.Rows[i].OreTypeID == veldsparTypeID {
+			t.Errorf("Veldspar must be skipped when no reachable destination exists: %+v", resp.Rows[i])
+		}
+	}
+}
+```
+
+And the fake (add to the fakes section):
+
+```go
+// citadelOnlyMarket returns one Veldspar buy order in a citadel (location ≥ 1e12)
+// and its Tritanium material in a citadel too — nothing reachable.
+type citadelOnlyMarket struct{ price float64 }
+
+func (m *citadelOnlyMarket) GetMarketOrders(_ context.Context, _ int, typeID int) ([]database.MarketOrder, error) {
+	if typeID == veldsparTypeID || typeID == tritaniumTypeID {
+		return []database.MarketOrder{
+			{TypeID: typeID, IsBuyOrder: true, Price: m.price, VolumeRemain: 1_000_000, LocationID: 1_035_000_000_001},
+		}, nil
+	}
+	return []database.MarketOrder{}, nil
+}
+```
+
+`fakeMiningNames.GetSystemIDForLocation` must error for citadel ids. Confirm its body returns an error for `id >= 1_000_000_000_000`; if it currently always returns `30000142`, change it to:
+
+```go
+func (fakeMiningNames) GetSystemIDForLocation(_ context.Context, id int64) (int64, error) {
+	if id >= 1_000_000_000_000 {
+		return 0, fmt.Errorf("citadel %d not in SDE", id)
+	}
+	return 30000142, nil
+}
+```
+
+(Keep the NPC case returning 30000142 so the other tests stay reachable.)
+
+- [ ] **Step 3: Add a decoupling test (raw reachable, refine reprocess unreachable)**
+
+Make the reprocess station a citadel (so refine has no reachable reprocess) while the ore raw buy is at a reachable NPC station; assert the row resolves as raw with `EffectiveISKPerHour > 0` and is NOT estimate:
+
+```go
+func TestMiningService_OreRanking_DecoupledRawWhenRefineUnreachable(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	market := &fakeMiningMarket{buyPriceByType: map[int]float64{veldsparTypeID: 15.0, tritaniumTypeID: 5.0}}
+	skills := &fakeMiningSkillsProvider{
+		skills:    &MiningReprocessingSkills{OreProcessing: map[int64]int{}, SkillLevels: map[int64]int{17940: 5, 22551: 5}},
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	// Reprocess station is a citadel id → unreachable → refine path unavailable.
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 1_035_000_000_009, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+	loc := fakeMiningLocation{shipTypeID: 22544}
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, loc, nil, fakeMiningNames{}, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{RegionID: 10000002, AllowLowSec: false})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+	var v *models.OreRankRow
+	for i := range resp.Rows {
+		if resp.Rows[i].OreTypeID == veldsparTypeID {
+			v = &resp.Rows[i]
+		}
+	}
+	if v == nil {
+		t.Fatal("Veldspar row missing")
+	}
+	if v.IsEstimate {
+		t.Errorf("raw is reachable → row must NOT be estimate even though refine reprocess is unreachable: %+v", *v)
+	}
+	if v.Best != "raw" || v.EffectiveISKPerHour <= 0 {
+		t.Errorf("expected resolved raw verdict with eff>0, got Best=%q eff=%v", v.Best, v.EffectiveISKPerHour)
+	}
+}
+```
+
+`fmt` is already imported by the test file.
+
+- [ ] **Step 4: Run + full gate**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/... ./pkg/... 2>&1 | grep -E "FAIL" ; gofmt -l internal pkg ; GOWORK=off golangci-lint run ./internal/... ./pkg/... ./cmd/...`
+Expected: all three new/updated tests pass; no FAIL; no gofmt output; `0 issues`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/services/mining_service_test.go
+git commit -m "test(mining): reachability + decoupling + citadel-unreachable coverage"
+```
+
+---
+
+## Task 4: Verify, PR, release, deploy
+
+**Files:** none (process). **Backend-only — no web/flutter/APK change.**
+
+- [ ] **Step 1: Full backend gate**
+
+Run: `cd backend && SDE_DB_PATH=/home/ix/vscode/eveonline/eve-sde/data/sqlite/eve-sde.db GOWORK=off go test ./internal/... ./pkg/... && gofmt -l internal cmd pkg && GOWORK=off go vet ./... && GOWORK=off golangci-lint run ./internal/... ./pkg/... ./cmd/...`
+Expected: ok; `0 issues`. (Frontend/Flutter unchanged — no need to rebuild, but a quick `cd ../frontend && npm run build` sanity check is fine since the response schema is unchanged.)
+
+- [ ] **Step 2: PR**
+
+```bash
+git push -u origin feat/mining-reachability-aware-haul
+gh pr create --base main --title "feat(mining): reachability-aware + decoupled haul-downtime" --body "<summary: pick reachable sell/reprocess destinations under the security choice (citadels/low-sec-gated excluded); compute raw/refine independently; estimate only when no path is reachable (or hull/crystal unresolved); fixes all-rows-estimate under High-only; backend-only; spec+plan linked>"
+```
+
+- [ ] **Step 3: CI green → squash-merge → update main**
+
+```bash
+gh pr checks <PR#> --watch --interval 20
+gh pr merge <PR#> --squash --delete-branch
+git checkout main && git pull --ff-only
+```
+
+- [ ] **Step 4: Release v0.25.2**
+
+Add a `## [Unreleased]` CHANGELOG entry (Fixed: reachability-aware + decoupled haul-downtime; no more all-rows-estimate under High-only when the best sell/reprocess is low-sec-gated or in a citadel). Commit, then:
+```bash
+make release-check && make release VERSION=0.25.2
+git add CHANGELOG.md && git commit -m "chore(release): v0.25.2"
+git tag v0.25.2 && git push origin main && git push origin v0.25.2
+```
+
+- [ ] **Step 5: Watch deploy + prod smoke**
+
+```bash
+gh run watch <deploy-run-id> --interval 20 --exit-status
+curl -s https://eveonline.sternrassler.de/api/v1/version   # → v0.25.2
+curl -s -o /dev/null -w "%{http_code}\n" https://eveonline.sternrassler.de/mining  # → 200
+```
+
+No tablet APK — this change does not touch Flutter.
+
+---
+
+## Notes for the implementer
+
+- **No silent fallbacks:** every path that drops a destination (citadel/unreachable, market fetch error) logs via `s.logger.Warn`. A row only estimates when hull/crystal is unresolved (feature #1) or no path has a reachable destination — with a specific reason.
+- **Decoupling:** raw and refine are independent. A failed refine (no reachable reprocess/hub) must not estimate a row whose raw path is reachable, and vice versa.
+- **Consistency:** raw uses the best reachable ore buy order; refine uses the best reachable reprocess + hub, and the materials breakdown shows that hub's prices/locations. Gross ISK/h (raw/refine) reflect the same reachable destinations.
+- **No reachable path → skip the ore** (`continue`). `bestReachableBuyOrder` already returns the best *reachable* order, so an ore is only skipped when none of its buy orders (and no reprocess station) are routable under the security choice — a rare edge. `is_estimate` is therefore only ever set by the hull/crystal logic (feature #1), never by routing.

--- a/docs/superpowers/specs/2026-06-01-mining-reachability-aware-haul-design.md
+++ b/docs/superpowers/specs/2026-06-01-mining-reachability-aware-haul-design.md
@@ -1,0 +1,142 @@
+# Erreichbarkeitsbewusstes Haul-Downtime (entkoppelt) — Design
+
+**Datum:** 2026-06-01
+**Status:** Approved (Design)
+**Kontext:** Der Haul-Downtime-Rechner (effektive ISK/h, v0.23.0+) markiert unter
+„Nur High-Sec" **alle** Zeilen als „≈ Schätzung", weil die Routen zu den
+gewählten Verkaufs-/Reprocess-Stationen scheitern (die liegen im Low-Sec oder in
+Citadels). Root Cause bestätigt per Toggle-Test: mit „High + Low-Sec" lösen fast
+alle Zeilen auf. Zwei Schwächen im Modell:
+
+1. **Geteiltes `rowResolved`:** scheitert eine Etappe (z. B. Refine-Route), wird
+   die **ganze** Zeile geschätzt — obwohl der Raw-Pfad routbar wäre.
+2. **Ziel-Wahl ignoriert Erreichbarkeit:** Reprocess/Verkauf wird „best egal wo"
+   gewählt (Feature #1), auch wenn nur über Low-Sec oder in einer Citadel.
+
+---
+
+## 1. Ziel
+
+Die Verkaufs-/Reprocess-Ziele werden **erreichbarkeitsbewusst** unter der
+Security-Bereitschaft des Spielers gewählt, und Raw-/Refine-Pfad werden
+**entkoppelt** berechnet. Eine Zeile ist nur noch „Schätzung", wenn der
+Hull/Crystal-Bonus nicht auflösbar ist (Feature #1) **oder** **kein** Pfad einen
+erreichbaren Verkaufs-/Reprocess-Ort hat.
+
+**Backend-only.** Response-Schema unverändert (nur Werte/Gründe ändern sich) →
+Web + Flutter brauchen keine Änderung, kein APK-Rebuild.
+
+---
+
+## 2. Erreichbarkeit
+
+Eine Station/ein Buy-Order-Ort gilt als **erreichbar**, wenn:
+- die `location_id` zu einem Solar-System auflösbar ist (`GetSystemIDForLocation`;
+  Citadels ≥ 1e12 sind es **nicht** → unerreichbar), **und**
+- `navigation.CalculateTravelTime(origin → System, params)` unter
+  `params.AvoidLowSec = !allow_low_sec` eine Route findet (`travelSecs` resolved).
+
+Helper (Service): `reachableSystem(origin, destSys, params, travelMemo) (secs, jumps, ok)`
+— ist `s.travelSecs` (existiert bereits; `from==to` → 0/0/true). Order-Location →
+System wird über die bestehende `sysOf`-Map memoisiert; unauflösbare (Citadel)
+Locations werden mit Sentinel `0` als „unerreichbar" gecacht.
+
+---
+
+## 3. Ziel-Wahl = bestes ERREICHBARES (ersetzt „best egal wo")
+
+### 3.1 Raw-Verkauf (pro Erz)
+`highestBuyOrder` wird zu `bestReachableBuyOrder(ctx, regionID, typeID, origin,
+params, travelMemo, sysOf) (price float64, locationID int64, sellSys int64, secs
+float64, jumps int, ok bool)`: iteriert die Buy-Orders des Typs in der Region,
+löst je Order die Location → System auf, prüft Erreichbarkeit, und behält den
+**höchsten Preis unter den erreichbaren** Orders (inkl. dessen System +
+Reisezeit). `ok=false`, wenn kein erreichbares Buy-Order existiert.
+
+### 3.2 Reprocess-Station (einmal pro Request)
+Die Kandidaten (`StationStanding` aus den Region-Reprocess-Stationen) werden auf
+**erreichbare** gefiltert (Station-System auflösen + `reachableSystem`), dann
+`BestStation` über die erreichbaren. Ergebnis: `reprocessSys`, `reprocessSecs`,
+`reprocessJumps`, Rate/Take. Gibt es keine erreichbare Station → Refine-Pfad ist
+für **alle** Erze nicht verfügbar.
+
+### 3.3 Mineral-Verkaufs-Hub (pro Erz, Refine)
+Wie Feature #2, aber die Kandidaten-Systeme werden auf **erreichbare** (von
+`reprocessSys` aus) gefiltert, bevor das beste Hub nach `eff` gewählt wird.
+
+### 3.4 Auswirkung auf Anzeige + Brutto-ISK/h
+Da Raw-Preis und Refine-Hub-Preise nun die **erreichbaren** Bests sind, fließen
+sie in `CompareOre` → `RawNetPerM3`/`RefineNetPerM3` und damit in **Brutto-ISK/h
+(roh/refine)**, in `RawSell`/`Materials`-Anzeige und in die effektive ISK/h.
+Alles ist konsistent „was du unter deiner Sicherheits-Bereitschaft erreichst".
+Die Materials-Aufschlüsselung zeigt die Preise/Orte des gewählten **erreichbaren
+Hubs**.
+
+---
+
+## 4. Entkoppelte Pfad-Berechnung
+
+Pro Erz, unabhängig:
+- **Raw:** wenn `bestReachableBuyOrder` ok → `rawNet` (CompareOre raw-Seite mit dem
+  erreichbaren Erz-Preis) und `rawEff = EffectiveISKPerHour(oreHold, m3h, rawNet,
+  raw.secs, 1·t_stop)`. Sonst Raw nicht verfügbar.
+- **Refine:** wenn erreichbare Reprocess-Station **und** ein erreichbares Hub
+  existieren → `refNet`(Hub) und `refEff = EffectiveISKPerHour(oreHold, m3h,
+  refNet, reprocessSecs + hubSecs, 2·t_stop)`. Sonst Refine nicht verfügbar.
+
+**Zeilen-Ergebnis:**
+- `available := rawAvailable || refineAvailable`.
+- Wenn `available`: `Best` = Pfad mit höherer effektiver ISK/h; setze
+  `EffectiveISKPerHour`, `CycleMinutes`, `FillMinutes`, `RouteJumps`,
+  `SellSystemName`, `RawNetPerM3`/`RefineNetPerM3` (nur die verfügbaren Pfade),
+  Brutto-ISK/h, `RawSell`/`Materials` entsprechend.
+- Wenn **nicht** `available` (kein erreichbarer Ort) und `oreM3h > 0`:
+  `IsEstimate = true`, Grund „Kein erreichbarer Verkaufs-/Reprocess-Ort unter
+  deiner Sicherheits-Bereitschaft".
+- Feature-#1-Estimate (Hull/Crystal) bleibt separat und hat Vorrang beim Grund.
+
+Das behebt (1): ein nicht erreichbarer Refine-Pfad lässt einen erreichbaren
+Raw-Pfad **unangetastet** (Zeile zeigt Raw, keine Schätzung).
+
+---
+
+## 5. Fail-loud / Logging
+
+Die bisher stillen `rowResolved = false`/`cycleResolved = false`-Pfade bekommen
+`s.logger.Warn` mit Grund (Schiff-Fitting, Erzraum, Erz-Sell-Route, Reprocess-
+Route, Hub-Route). Estimate-Gründe sind spezifisch (s. §4). Kein stiller Fallback.
+
+---
+
+## 6. Komponenten & Dateien
+
+- `backend/internal/services/mining_service.go`:
+  - `bestReachableBuyOrder` (ersetzt `highestBuyOrder` im Erz-/Mineral-Kontext, wo
+    Erreichbarkeit zählt).
+  - Reprocess-Station-Auswahl auf erreichbare filtern.
+  - Refine-Hub-Kandidaten auf erreichbare filtern.
+  - Per-Erz-Schleife: Raw/Refine entkoppelt, `available`-Logik, granulare Gründe.
+  - Logging auf den Fehlerpfaden.
+- Keine Model-/Web-/Flutter-Änderung (Schema gleich).
+
+---
+
+## 7. Tests
+
+**Service (`mining_service_test.go`, reale SDE + Fakes):**
+- Erreichbarkeit: ein Fake-Buy-Order in einer Citadel-Location (≥1e12) → als
+  unerreichbar behandelt; ein NPC-Order im selben System (Origin) → erreichbar,
+  travel 0.
+- Entkopplung: Raw erreichbar, Refine-Reprocess unerreichbar → Zeile resolved als
+  „raw" mit `EffectiveISKPerHour > 0`, **kein** `IsEstimate`.
+- Kein erreichbarer Ort (alle Orders Citadel) → `IsEstimate=true` + Grund.
+- Bestehende Veldspar/Estimate/Variant-Namens-Tests bleiben grün (ggf. Fakes um
+  Locations/Erreichbarkeit ergänzen).
+
+---
+
+## 8. Nicht im Scope
+
+- Reachability-aware Trading/Hauling/ROI (nur Mining-Ranking).
+- Null-Sec/Class-K-Erz-Sets (#161/#162), exakte Belt-Inhalte (#163).
+- Multi-Stop-Mineral-Verkauf (bleibt Einzel-Hub; Issue #158-Kontext unberührt).

--- a/docs/superpowers/specs/2026-06-01-mining-reachability-aware-haul-design.md
+++ b/docs/superpowers/specs/2026-06-01-mining-reachability-aware-haul-design.md
@@ -90,10 +90,13 @@ Pro Erz, unabhängig:
   `EffectiveISKPerHour`, `CycleMinutes`, `FillMinutes`, `RouteJumps`,
   `SellSystemName`, `RawNetPerM3`/`RefineNetPerM3` (nur die verfügbaren Pfade),
   Brutto-ISK/h, `RawSell`/`Materials` entsprechend.
-- Wenn **nicht** `available` (kein erreichbarer Ort) und `oreM3h > 0`:
-  `IsEstimate = true`, Grund „Kein erreichbarer Verkaufs-/Reprocess-Ort unter
-  deiner Sicherheits-Bereitschaft".
-- Feature-#1-Estimate (Hull/Crystal) bleibt separat und hat Vorrang beim Grund.
+- Wenn **nicht** `available` (kein erreichbarer Verkaufs- **und** kein
+  erreichbarer Reprocess-Ort): die Zeile wird **übersprungen** (nicht gerankt) —
+  das Erz ist unter deiner Sicherheits-Bereitschaft nicht verkauf-/aufbereitbar.
+  Da `bestReachableBuyOrder` das beste **erreichbare** Order wählt (meist eine
+  NPC-Station, auch wenn das global beste in einer Citadel liegt), ist „gar
+  nichts erreichbar" ein seltener Rand. `is_estimate` bleibt damit **nur** für
+  Hull/Crystal (Feature #1) reserviert.
 
 Das behebt (1): ein nicht erreichbarer Refine-Pfad lässt einen erreichbaren
 Raw-Pfad **unangetastet** (Zeile zeigt Raw, keine Schätzung).


### PR DESCRIPTION
## Problem

Unter **„Nur High-Sec"** waren im Mining-Rechner **alle** Zeilen fälschlich „≈ Schätzung". Ursache (per Toggle-Test bestätigt): die effektive ISK/h baute auf Routen zu Verkaufs-/Reprocess-Stationen, die im Low-Sec oder in Citadels liegen — die Route scheitert unter `AvoidLowSec`, also wurde die ganze Zeile geschätzt.

## Fix — erreichbarkeitsbewusst + entkoppelt

1. **Erreichbarkeitsbewusste Ziel-Wahl.** Erz-Verkaufsort (`bestReachableBuyOrder`), Reprocess-Station und Mineral-Hub werden unter der Sicherheits-Bereitschaft des Spielers (`AvoidLowSec`) gewählt. Citadels (`location_id` ≥ 1e12, nicht zu einem System auflösbar) gelten als unerreichbar. Bei **gleichem** Kaufpreis gewinnt die in **weniger Sprüngen** erreichbare Station.
2. **Entkoppelte Raw-/Refine-Pfade.** Scheitert die Refine-Route, bleibt ein erreichbarer Raw-Pfad unangetastet (Zeile zeigt „roh", keine Schätzung) — und umgekehrt. Eine Zeile wird nur noch **übersprungen**, wenn **kein** erreichbarer Verkaufs- *und* kein erreichbarer Reprocess-Ort existiert.
3. **`is_estimate` bleibt für Hull/Crystal** (#165) reserviert — Routing-Fehler erzeugen keine Schätzung mehr.
4. **Entkoppelt von Mining-Setup.** Per-m³-Zeilen erscheinen weiterhin ohne gefittetes Mining-Modul (effektive ISK/h dann 0); Erreichbarkeit ≠ „miner gefittet".
5. **Fail-loud** (#27-Prinzip): bisher stille Fehlerpfade (Erzraum-Kapazität, Schiffs-Fitting) loggen jetzt `Warn`.

**Backend-only.** Response-Schema unverändert → Web + Flutter brauchen keine Änderung, **kein APK-Rebuild**.

## Tests

7 Service-Tests grün, inkl. 3 neue: `CitadelUnreachable` (Erz nur in Citadel → übersprungen), `DecoupledRawWhenRefineUnreachable` (Reprocess = Citadel → Raw gewinnt), `DecoupledRefineWhenRawUnreachable` (Raw nur in Citadel → Refine gewinnt). Voller Backend-Suite grün, golangci-lint `0 issues`.

## Review

Spec brainstormed → geplant (TDD) → subagent-driven implementiert mit Spec-Compliance- **und** Code-Quality-Review pro Schritt + finalem Integrations-Review (alle ✅). Plan-Defekt (NoMiningSetup-Regression) im Review gefangen und behoben.

Schließt #166. Zurückgestellt unverändert: #161, #162, #163, #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)