### PR TITLE
feat(mining): in-game ore name + our translation in parens (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Mining-Rechner: Erz-Varianten zeigen In-Game-Namen + unsere Übersetzung (#167).** Varianten werden jetzt als **„Veldspar II-Grade (Concentrated)"** angezeigt — der **In-Game-Name** (den der EVE-Client zeigt) plus unser unterscheidendes Adjektiv in Klammern. Vorher zeigte die App nur den abgeleiteten Client-Namen („Concentrated Veldspar"), was sich nicht mit dem Übersichts-/Marktfenster im Spiel abgleichen ließ. Das Adjektiv ist das führende Wort des Kompressions-Blueprint-Namens; Basis-Erze (ohne „-Grade") bleiben unverändert. Reine Anzeige — Erz-Verfügbarkeit/Banding läuft über die GroupID, nicht den Namen. Backend-only (Web + Flutter rendern das Namensfeld unverändert).
+
 ## [0.25.2] - 2026-06-01
 
 ### Fixed

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -371,9 +371,9 @@ func TestMiningService_OreRanking_EstimateWhenShipUnknown(t *testing.T) {
 	}
 }
 
-// TestMiningService_OreRanking_VariantRealName verifies an ore VARIANT row shows its
-// real in-game name (from ListOres' blueprint-derived rename), not the raw SDE
-// "<Ore> II-Grade" name. 17470 = SDE "Veldspar II-Grade" → client "Concentrated Veldspar".
+// TestMiningService_OreRanking_VariantRealName verifies an ore VARIANT row shows the
+// in-game "<Ore> II-Grade" name paired with our client-name adjective in parens.
+// 17470 = SDE "Veldspar II-Grade", client "Concentrated Veldspar" → "Veldspar II-Grade (Concentrated)".
 func TestMiningService_OreRanking_VariantRealName(t *testing.T) {
 	sdeDB := testutil.OpenTestDB(t)
 	defer func() { _ = sdeDB.Close() }()
@@ -411,8 +411,8 @@ func TestMiningService_OreRanking_VariantRealName(t *testing.T) {
 	if row == nil {
 		t.Fatal("Concentrated Veldspar (17470) row not found")
 	}
-	if row.OreName != "Concentrated Veldspar" {
-		t.Errorf("OreName: got %q, want %q (real client name, not the raw -Grade)", row.OreName, "Concentrated Veldspar")
+	if row.OreName != "Veldspar II-Grade (Concentrated)" {
+		t.Errorf("OreName: got %q, want %q (in-game name + our adjective)", row.OreName, "Veldspar II-Grade (Concentrated)")
 	}
 }
 

--- a/backend/pkg/evedb/reprocessing/reprocessing.go
+++ b/backend/pkg/evedb/reprocessing/reprocessing.go
@@ -72,14 +72,35 @@ func ListOres(db *sql.DB) ([]Ore, error) {
 		if err := rows.Scan(&o.TypeID, &o.Name, &o.GroupID, &o.PortionSize, &o.VolumeM3); err != nil {
 			return nil, err
 		}
-		if name, ok := disp[o.TypeID]; ok {
-			o.Name = name // real in-game name (Concentrated Veldspar, Vivid Hemorphite, …)
-		} else if strings.Contains(o.Name, "-Grade") {
-			continue // un-belt-able variant (IV-Grade/0-Grade): not mined, drop it
+		// Base ores (no grade suffix) keep their plain in-game name.
+		if !strings.Contains(o.Name, "-Grade") {
+			out = append(out, o)
+			continue
+		}
+		// Variant: pair the in-game "-Grade" name (what the client shows) with our
+		// client-name adjective in parens, e.g. "Veldspar II-Grade (Concentrated)".
+		// The adjective is the leading word of the compression-blueprint name
+		// ("Concentrated Veldspar" → "Concentrated").
+		derived, ok := disp[o.TypeID]
+		if !ok {
+			continue // IV-Grade/0-Grade: no compression blueprint → un-belt-able, drop it
+		}
+		if adj := firstWord(derived); adj != "" {
+			o.Name = o.Name + " (" + adj + ")"
 		}
 		out = append(out, o)
 	}
 	return out, rows.Err()
+}
+
+// firstWord returns the leading whitespace-delimited token of s — the distinguishing
+// adjective of an ore variant's client name (e.g. "Concentrated" from "Concentrated
+// Veldspar", "Onyx" from "Onyx Ochre").
+func firstWord(s string) string {
+	if i := strings.IndexByte(s, ' '); i > 0 {
+		return s[:i]
+	}
+	return s
 }
 
 // oreDisplayNames maps a raw ore variant typeID to its real in-game name, derived

--- a/backend/pkg/evedb/reprocessing/reprocessing_test.go
+++ b/backend/pkg/evedb/reprocessing/reprocessing_test.go
@@ -61,18 +61,20 @@ func TestListOres_RealNamesAndNoGrade(t *testing.T) {
 	byID := map[int64]string{}
 	for _, o := range ores {
 		byID[o.TypeID] = o.Name
-		if strings.Contains(o.Name, "-Grade") {
-			t.Errorf("'-Grade' name leaked: %d %q", o.TypeID, o.Name)
+		// A "-Grade" variant must always pair the in-game name with our adjective in
+		// parens; a bare "-Grade" name (no translation) must never reach the client.
+		if strings.Contains(o.Name, "-Grade") && !strings.Contains(o.Name, "(") {
+			t.Errorf("bare '-Grade' name without translation: %d %q", o.TypeID, o.Name)
 		}
 	}
-	if byID[17470] != "Concentrated Veldspar" {
-		t.Errorf("17470: got %q, want Concentrated Veldspar", byID[17470])
+	if byID[17470] != "Veldspar II-Grade (Concentrated)" {
+		t.Errorf("17470: got %q, want %q", byID[17470], "Veldspar II-Grade (Concentrated)")
 	}
-	if byID[17444] != "Vivid Hemorphite" {
-		t.Errorf("17444: got %q, want Vivid Hemorphite", byID[17444])
+	if byID[17444] != "Hemorphite II-Grade (Vivid)" {
+		t.Errorf("17444: got %q, want %q", byID[17444], "Hemorphite II-Grade (Vivid)")
 	}
 	if byID[1230] != "Veldspar" {
-		t.Errorf("1230: got %q, want Veldspar", byID[1230])
+		t.Errorf("1230: got %q, want Veldspar (base ore, no suffix)", byID[1230])
 	}
 	if _, ok := byID[46689]; ok { // Veldspar IV-Grade — no blueprint name → filtered
 		t.Errorf("Veldspar IV-Grade (46689) must be filtered out")


### PR DESCRIPTION
## Warum

Erz-Varianten werden im **EVE-Client als „Veldspar II-Grade"** angezeigt — unsere App zeigte aber nur unseren abgeleiteten Client-Namen „Concentrated Veldspar". Das ließ sich nicht mit dem In-Game-Übersichts-/Marktfenster abgleichen.

## Was

Varianten zeigen jetzt **beides**: den In-Game-Namen plus unser unterscheidendes Adjektiv in Klammern.

| typeID | vorher | nachher |
|--------|--------|---------|
| 17470 | Concentrated Veldspar | **Veldspar II-Grade (Concentrated)** |
| 17471 | Dense Veldspar | **Veldspar III-Grade (Dense)** |
| 17444 | Vivid Hemorphite | **Hemorphite II-Grade (Vivid)** |
| 1230 | Veldspar | Veldspar *(Basis, unverändert)* |

Das Adjektiv ist das führende Wort des Kompressions-Blueprint-Namens (gilt für alle 36 Varianten). Basis-Erze (ohne „-Grade") bleiben unverändert.

**Reine Anzeige:** Erz-Verfügbarkeit/Banding läuft über die `GroupID`, nicht den Namen → keine Logik betroffen. **Backend-only** (`reprocessing.ListOres`), Web + Flutter rendern das Namensfeld unverändert → **kein APK-Rebuild**.

## Tests

`reprocessing`- und `services`-Tests auf das neue Format umgestellt (inkl. „kein blankes -Grade ohne Übersetzung"-Invariante); volle Backend-Suite grün, golangci-lint `0 issues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)