### PR TITLE
fix(mining): Pyroxeres only in Amarr/Caldari high-sec (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mining-Rechner: Pyroxeres nur noch in Amarr-/Caldari-High-Sec (#168).** Das Ranking listete Pyroxeres fälschlich in **jedem** High-Sec-System (0.5–0.9). Tatsächlich kommt Pyroxeres im High-Sec **nur in Amarr- und Caldari-Quarter** vor — Gallente/Minmatar haben dort stattdessen Plagioclase (Quelle: EVE-University „Ore"-Tabelle, in-game gegen Bodenwahrheit geprüft: Alentene/Gallente hat kein Pyroxeres, Tar/Ourapheh/Amarr schon). Weder angezeigte Security noch `securityClass` trennen die Fälle — allein der **Empire-Quarter** tut es. `AvailableOreGroups` schärft die High-Sec-Regel entsprechend nach; Low-Sec war bereits korrekt. **Daten-Grenze (unverändert):** die exakte Gürtel-Zusammensetzung *innerhalb* eines Systems kennt nur der In-Game-Client („The Agency"/Survey-Scanner) — SDE/ESI enthalten keine Erz↔Gürtel-Zuordnung. Backend-only.
+
 ## [0.25.3] - 2026-06-01
 
 ### Changed

--- a/backend/pkg/evedb/mining/availability.go
+++ b/backend/pkg/evedb/mining/availability.go
@@ -67,6 +67,12 @@ func displaySec(sec float64) float64 {
 // security decide the set. allowLow gates low-sec systems: in a low-sec system
 // with allowLow=false the result is empty (the player won't operate there).
 // Null-sec (sec<=0) is out of scope (empty); see issue #161.
+//
+// High-sec is empire-specific (source: EVE-Uni "Ore" distribution table,
+// wiki.eveuniversity.org/Ore, cross-checked against in-game belts): Veldspar +
+// Scordite everywhere; Pyroxeres ONLY in Amarr+Caldari high-sec (0.9–0.5);
+// Plagioclase in Gallente+Minmatar (0.9–0.5) and Caldari (≤0.7). An unknown
+// quarter ("") yields only the quarter-independent Veldspar+Scordite.
 func AvailableOreGroups(quarter string, sec float64, allowLow bool) map[int64]bool {
 	out := map[int64]bool{}
 	d := displaySec(sec)
@@ -74,19 +80,22 @@ func AvailableOreGroups(quarter string, sec float64, allowLow bool) map[int64]bo
 	case d >= 0.5: // high-sec
 		out[grpVeldspar] = true
 		out[grpScordite] = true
-		if d <= 0.9 {
-			out[grpPyroxeres] = true
-		}
 		switch quarter {
+		case "amarr":
+			if d <= 0.9 {
+				out[grpPyroxeres] = true
+			}
+		case "caldari":
+			if d <= 0.9 {
+				out[grpPyroxeres] = true
+			}
+			if d <= 0.7 {
+				out[grpPlagioclase] = true
+			}
 		case "gallente", "minmatar":
 			if d <= 0.9 {
 				out[grpPlagioclase] = true
 			}
-		case "caldari":
-			if d <= 0.7 {
-				out[grpPlagioclase] = true
-			}
-			// amarr: no Plagioclase in high-sec
 		}
 	case d > 0 && allowLow: // low-sec, player willing
 		switch quarter {

--- a/backend/pkg/evedb/mining/availability_test.go
+++ b/backend/pkg/evedb/mining/availability_test.go
@@ -37,15 +37,24 @@ func TestAvailableOreGroups(t *testing.T) {
 	if !has(g, 462, 460, 459) || g[458] || len(g) != 3 {
 		t.Errorf("caldari 0.9: got %v", g)
 	}
-	// Gallente 0.7 hi-sec: + Plagioclase.
+	// Gallente 0.7 hi-sec: Veldspar, Scordite, Plagioclase — NO Pyroxeres (459).
 	g = AvailableOreGroups("gallente", 0.7, false)
-	if !has(g, 462, 460, 459, 458) || len(g) != 4 {
+	if !has(g, 462, 460, 458) || g[459] || len(g) != 3 {
 		t.Errorf("gallente 0.7: got %v", g)
 	}
-	// Amarr 0.6 hi-sec: no Plagioclase.
+	// Amarr 0.6 hi-sec: Veldspar, Scordite, Pyroxeres; no Plagioclase.
 	g = AvailableOreGroups("amarr", 0.6, false)
 	if !has(g, 462, 460, 459) || g[458] {
 		t.Errorf("amarr 0.6: got %v", g)
+	}
+	// Pyroxeres is Amarr/Caldari only — verified in-game (EVE-Uni "Ore" table):
+	// Alentene (Gallente, 0.87→0.9) has Veldspar/Scordite/Plagioclase, NO Pyroxeres;
+	// Ourapheh/Tar (Amarr, ~0.9/0.8) DO have Pyroxeres.
+	if g := AvailableOreGroups("gallente", 0.87, false); g[459] {
+		t.Errorf("gallente 0.9 (Alentene) must NOT have Pyroxeres: %v", g)
+	}
+	if g := AvailableOreGroups("amarr", 0.86, false); !g[459] {
+		t.Errorf("amarr 0.9 (Ourapheh) must have Pyroxeres: %v", g)
 	}
 	// Amarr 0.3 low-sec, allowLow=true: Pyroxeres 459, Kernite 457, Jaspet 456; no Hemorphite 455, no Veldspar.
 	g = AvailableOreGroups("amarr", 0.3, true)
@@ -64,8 +73,9 @@ func TestAvailableOreGroups(t *testing.T) {
 	if g := AvailableOreGroups("amarr", 0.0, true); len(g) != 0 {
 		t.Errorf("null must be empty: %v", g)
 	}
-	// Unknown quarter, hi-sec: quarter-independent ores only.
-	if g := AvailableOreGroups("", 0.8, false); !has(g, 462, 460, 459) || g[458] {
+	// Unknown quarter, hi-sec: only quarter-independent Veldspar+Scordite
+	// (Pyroxeres/Plagioclase are empire-specific, so we can't claim them).
+	if g := AvailableOreGroups("", 0.8, false); !has(g, 462, 460) || g[459] || g[458] || len(g) != 2 {
 		t.Errorf("unknown quarter: got %v", g)
 	}
 }


### PR DESCRIPTION
## Bug

Der Mining-Rechner listete **Pyroxeres in jedem High-Sec-System** (0.5–0.9). Vom Owner in-game widerlegt: **Alentene** (Gallente, 0.9) hat in den Gürteln nur Veldspar/Scordite/Plagioclase — **kein Pyroxeres**; die Agency zeigt das nächste Pyroxeres erst 2 Sprünge weiter (Tar, Amarr).

## Root Cause

`AvailableOreGroups` setzte Pyroxeres quarter-unabhängig (`if d <= 0.9`). Tatsächlich ist die High-Sec-Verteilung **empire-spezifisch**.

## Quelle + Validierung

**EVE-University „Ore"-Tabelle** (https://wiki.eveuniversity.org/Ore):

| Security | Amarr | Caldari | Gallente | Minmatar |
|----------|-------|---------|----------|----------|
| 1.0–0.5 | Veld, Scord | Veld, Scord | Veld, Scord | Veld, Scord |
| 0.9–0.5 | **Pyroxeres** | **Pyroxeres** (≤0.7 auch Plag) | **Plagioclase** | **Plagioclase** |

Gegen 7 in-game-geprüfte Systeme verifiziert: Alentene (Gallente) → kein Pyroxeres ✓; Tar/Ourapheh/Pakhshi/Manarq/Diaderi/Tekaima (alle Amarr) → Pyroxeres ✓. Weder angezeigte Security noch `securityClass` trennen die Fälle (Tar & Alentene sind beide Klasse B) — **nur der Empire-Quarter**.

## Fix

`AvailableOreGroups`: Pyroxeres nur für `amarr`/`caldari` High-Sec; unbekannter Quarter → nur Veldspar+Scordite. **Low-Sec war bereits korrekt** (Zeile-für-Zeile gegen EVE-Uni gegengeprüft).

## Grenze (unverändert)

Die **exakte Gürtel-Zusammensetzung** kennt nur der Client (Agency/Survey) — SDE/ESI haben keine Erz↔Gürtel-Daten (`mapAsteroidBelts` = nur Geometrie). System-genau stimmt jetzt; gürtel-genau bleibt datenbedingt außen vor.

## Tests

`TestAvailableOreGroups` erweitert (Alentene-Gallente-no-Pyroxeres + Amarr-Gegenbeispiel); zwei alte Assertions an die korrekte Regel angepasst. Volle Backend-Suite grün, golangci `0 issues`. Backend-only, kein APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)