### PR TITLE
feat(mining): market_loads — full ore-hold loads the best order absorbs (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mining-Rechner: Markt-Mengen-Cap als „volle Ladungen" pro Zeile (#169).** Jede Erz-Zeile zeigt jetzt, **wie viele komplette Erzraum-Ladungen** (bezogen auf dein aktuelles Schiff) die gewählte Buy-Order aufnimmt — abgeleitet aus deren `VolumeRemain`. **Roh:** Kapazität der Erz-Order; **Refine:** das zuerst erschöpfte Mineral bindet (Minimum über alle Minerale). Trägt der **Bestpreis nicht mal eine volle Ladung** (`< 1`), wird die Zeile fail-loud markiert („⚠ Bestpreis nur ~X Ladungen — ISK/h optimistisch"), denn die ISK/h nimmt bislang an, du könntest unbegrenzt zum Bestpreis verkaufen. **Reine Anzeige** — ISK/h und Ranking unverändert. Neues Response-Feld `market_loads`. Web **und** Flutter. (Nicht im Scope: Order-Book-Tiefe, echtes ISK/h-Capping — bewusst zurückgestellt.)
+
 ## [0.25.4] - 2026-06-02
 
 ### Fixed

--- a/app/lib/api/mining_models.dart
+++ b/app/lib/api/mining_models.dart
@@ -140,6 +140,7 @@ class OreRankRow {
     this.cycleMinutes = 0.0,
     this.routeJumps = 0,
     this.sellSystemName,
+    this.marketLoads,
   });
 
   /// Backend: `ore_type_id`
@@ -218,6 +219,11 @@ class OreRankRow {
   /// Backend: `sell_system_name` — nullable; name of the sell system.
   final String? sellSystemName;
 
+  /// Backend: `market_loads` — how many complete ore-hold loads the best buy
+  /// order can absorb. Absent when not applicable. < 1 means the best price
+  /// won't take a full load → shown ISK/h is optimistic.
+  final double? marketLoads;
+
   factory OreRankRow.fromJson(Map<String, dynamic> json) {
     final rawMaterials = json['materials'] as List<dynamic>? ?? const [];
     return OreRankRow(
@@ -253,6 +259,7 @@ class OreRankRow {
       cycleMinutes: (json['cycle_minutes'] as num?)?.toDouble() ?? 0.0,
       routeJumps: (json['route_jumps'] as num?)?.toInt() ?? 0,
       sellSystemName: json['sell_system_name'] as String?,
+      marketLoads: (json['market_loads'] as num?)?.toDouble(),
     );
   }
 }

--- a/app/lib/features/mining/mining_screen.dart
+++ b/app/lib/features/mining/mining_screen.dart
@@ -486,6 +486,23 @@ class _OreRankTile extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall,
             ),
           ),
+        if (row.marketLoads != null && row.marketLoads! > 0)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: row.marketLoads! >= 1
+                ? Text(
+                    'Markt: ~${row.marketLoads!.toStringAsFixed(1)} volle Ladungen',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  )
+                : Text(
+                    '⚠ Bestpreis nur ~${row.marketLoads!.toStringAsFixed(2)} Ladungen — ISK/h optimistisch',
+                    style: const TextStyle(
+                      color: Color(0xFFFFB300),
+                      fontWeight: FontWeight.w500,
+                      fontSize: 12,
+                    ),
+                  ),
+          ),
         _detailLine(
           context,
           'Aufbereiten bei',
@@ -553,6 +570,23 @@ class _OreRankTile extends StatelessWidget {
               '${row.sellSystemName != null ? ' · Verkauf in ${row.sellSystemName}' : ''}',
               style: Theme.of(context).textTheme.bodySmall,
             ),
+          ),
+        if (row.marketLoads != null && row.marketLoads! > 0)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: row.marketLoads! >= 1
+                ? Text(
+                    'Markt: ~${row.marketLoads!.toStringAsFixed(1)} volle Ladungen',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  )
+                : Text(
+                    '⚠ Bestpreis nur ~${row.marketLoads!.toStringAsFixed(2)} Ladungen — ISK/h optimistisch',
+                    style: const TextStyle(
+                      color: Color(0xFFFFB300),
+                      fontWeight: FontWeight.w500,
+                      fontSize: 12,
+                    ),
+                  ),
           ),
         _detailLine(context, 'Roh verkaufen bei', _formatSell(row.rawSell)),
       ],

--- a/app/test/mining_models_test.dart
+++ b/app/test/mining_models_test.dart
@@ -201,6 +201,37 @@ void main() {
       expect(d.effectiveIskPerHour, 0.0);
       expect(d.routeJumps, 0);
     });
+
+    test('market_loads: parses double value when present', () {
+      final r = OreRankRow.fromJson(const {
+        'ore_type_id': 1230, 'ore_name': 'Veldspar', 'best': 'refine',
+        'market_loads': 3.7,
+      });
+      expect(r.marketLoads, closeTo(3.7, 0.001));
+    });
+
+    test('market_loads: parses int value (num-robust)', () {
+      final r = OreRankRow.fromJson(const {
+        'ore_type_id': 1230, 'ore_name': 'Veldspar', 'best': 'refine',
+        'market_loads': 2,
+      });
+      expect(r.marketLoads, 2.0);
+    });
+
+    test('market_loads: absent maps to null', () {
+      final r = OreRankRow.fromJson(const {
+        'ore_type_id': 1230, 'ore_name': 'Veldspar', 'best': 'refine',
+      });
+      expect(r.marketLoads, isNull);
+    });
+
+    test('market_loads: < 1 (partial load) parses correctly', () {
+      final r = OreRankRow.fromJson(const {
+        'ore_type_id': 1228, 'ore_name': 'Scordite', 'best': 'raw',
+        'market_loads': 0.42,
+      });
+      expect(r.marketLoads, closeTo(0.42, 0.001));
+    });
   });
 
   group('OreRankingResponse.fromJson', () {

--- a/backend/internal/models/mining.go
+++ b/backend/internal/models/mining.go
@@ -55,6 +55,7 @@ type OreRankRow struct {
 	// Haul-downtime cycle (effective ISK/h, greedy one cycle from current system):
 	EffectiveISKPerHour float64 `json:"effective_isk_per_hour,omitempty"` // sort key; 0 when not resolvable
 	LoadVolumeM3        float64 `json:"load_volume_m3,omitempty"`         // ore-hold m³ filled per load
+	MarketLoads         float64 `json:"market_loads,omitempty"`           // full ore-hold loads the Best path's best reachable order(s) can absorb (VolumeRemain cap); 0<x<1 means the best price won't even take one load
 	FillMinutes         float64 `json:"fill_minutes,omitempty"`           // time to fill the hold
 	CycleMinutes        float64 `json:"cycle_minutes,omitempty"`          // fill + legs + stops
 	RouteJumps          int     `json:"route_jumps,omitempty"`            // jumps over the cycle's legs

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -346,9 +346,14 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 			}
 		}
 		oreM3h := m3h * hullMul * crystalMul
+		// Ore units that fill one full ore hold (0 when hold/volume not resolved).
+		var unitsPerLoad float64
+		if oreHoldM3 > 0 && o.VolumeM3 > 0 {
+			unitsPerLoad = oreHoldM3 / o.VolumeM3
+		}
 
 		// ---- RAW path (reachability-aware): best reachable ore buy order ----
-		orePrice, oreLoc, _, oreSecs, oreJumps, oreOK :=
+		orePrice, oreLoc, _, oreSecs, oreJumps, oreVR, oreOK :=
 			s.bestReachableBuyOrder(ctx, regionID, int(o.TypeID), originSys, navParams, travelMemo, sysOf)
 		rawCmp := CompareOre(OreCompareInput{
 			PortionSize: o.PortionSize, OreVolumeM3: o.VolumeM3, OreBuyPrice: orePrice,
@@ -359,14 +364,20 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 		// no miner fitted (effective ISK/h then stays 0).
 		rawReachable := oreOK
 		var rawEff, rawCycleMin, rawFillMin float64
+		// rawLoads: how many full ore-hold loads the chosen ore buy order absorbs.
+		var rawLoads float64
 		if rawReachable && oreM3h > 0 {
 			rawEff, rawCycleMin, rawFillMin =
 				mining.EffectiveISKPerHour(oreHoldM3, oreM3h, rawCmp.RawNetPerM3, oreSecs, oreStopSecs)
+			if unitsPerLoad > 0 {
+				rawLoads = float64(oreVR) / unitsPerLoad
+			}
 		}
 
 		// ---- REFINE path: reachable reprocess + best reachable hub ----
 		var refNet, refEff, refCycleMin, refFillMin float64
 		var refJumps int
+		var refLoads float64
 		var refSellSysName string
 		var refBreakdown []models.RefineMaterial
 		refineReachable := false
@@ -441,6 +452,25 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 							}
 							refBreakdown = append(refBreakdown, rm)
 						}
+						// refLoads: full ore-hold loads the binding (first-exhausted)
+						// mineral buy order at this hub can absorb.
+						refLoads = 0
+						if oreM3h > 0 && unitsPerLoad > 0 && o.PortionSize > 0 {
+							batchesPerLoad := unitsPerLoad / float64(o.PortionSize)
+							minLoads := math.MaxFloat64
+							for _, m := range o.Materials {
+								perLoad := batchesPerLoad * float64(m.Quantity) * net
+								if perLoad <= 0 {
+									continue
+								}
+								if l := float64(bySys[m.MaterialTypeID][sysID].volumeRemain) / perLoad; l < minLoads {
+									minLoads = l
+								}
+							}
+							if minLoads != math.MaxFloat64 {
+								refLoads = minLoads
+							}
+						}
 						refineReachable = true
 					}
 				}
@@ -498,10 +528,12 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 			row.Best = "refine"
 			row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = refEff, refCycleMin, refFillMin
 			row.RouteJumps, row.SellSystemName = refJumps, refSellSysName
+			row.MarketLoads = refLoads
 		} else {
 			row.Best = "raw"
 			row.EffectiveISKPerHour, row.CycleMinutes, row.FillMinutes = rawEff, rawCycleMin, rawFillMin
 			row.RouteJumps = oreJumps
+			row.MarketLoads = rawLoads
 			if row.RawSell != nil {
 				row.SellSystemName = row.RawSell.SystemName
 			}
@@ -540,13 +572,13 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 func (s *MiningService) bestReachableBuyOrder(
 	ctx context.Context, regionID, typeID int, origin int64,
 	params *navigation.NavigationParams, travelMemo map[travelKey]*navigation.RouteResult, sysOf map[int64]int64,
-) (price float64, locationID int64, sellSys int64, secs float64, jumps int, ok bool) {
+) (price float64, locationID int64, sellSys int64, secs float64, jumps int, volumeRemain int, ok bool) {
 	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warn("ore ranking: market orders fetch failed", "typeID", typeID, "error", err)
 		}
-		return 0, 0, 0, 0, 0, false
+		return 0, 0, 0, 0, 0, 0, false
 	}
 	for _, o := range orders {
 		// Skip strictly-lower prices; equal prices still get a reachability check so
@@ -573,10 +605,11 @@ func (s *MiningService) bestReachableBuyOrder(
 		}
 		// Higher price always wins; on an equal price prefer fewer jumps (less haul).
 		if !ok || o.Price > price || jumpsTo < jumps {
-			price, locationID, sellSys, secs, jumps, ok = o.Price, o.LocationID, sys, secsTo, jumpsTo, true
+			price, locationID, sellSys, secs, jumps, volumeRemain, ok =
+				o.Price, o.LocationID, sys, secsTo, jumpsTo, o.VolumeRemain, true
 		}
 	}
-	return price, locationID, sellSys, secs, jumps, ok
+	return price, locationID, sellSys, secs, jumps, volumeRemain, ok
 }
 
 // typeName resolves a type's name (e.g. for a refined mineral), "" on failure.
@@ -597,10 +630,12 @@ func maxFloat(a, b float64) float64 {
 // travelKey memoises CalculateTravelTime results within one OreRanking request.
 type travelKey struct{ from, to int64 }
 
-// systemBuy is the best buy price for a type in one system, with the order's station.
+// systemBuy is the best buy price for a type in one system, with the order's
+// station and its remaining capacity (units the order can still absorb).
 type systemBuy struct {
-	price      float64
-	locationID int64
+	price        float64
+	locationID   int64
+	volumeRemain int
 }
 
 // bestBuyBySystem groups a type's region buy-orders by solar system and keeps the
@@ -630,7 +665,7 @@ func (s *MiningService) bestBuyBySystem(ctx context.Context, regionID, typeID in
 			continue
 		}
 		if cur, exists := out[sysID]; !exists || o.Price > cur.price {
-			out[sysID] = systemBuy{price: o.Price, locationID: o.LocationID}
+			out[sysID] = systemBuy{price: o.Price, locationID: o.LocationID, volumeRemain: o.VolumeRemain}
 		}
 	}
 	return out, nil

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -21,6 +21,8 @@ type fakeMiningMarket struct {
 	buyPriceByType map[int]float64
 	// locByType overrides the highest-buy-order station per type (default 60000123).
 	locByType map[int]int64
+	// volByType overrides the highest buy order's VolumeRemain per type (default 1_000_000).
+	volByType map[int]int
 }
 
 func (f *fakeMiningMarket) GetMarketOrders(_ context.Context, _ int, typeID int) ([]database.MarketOrder, error) {
@@ -42,8 +44,14 @@ func (f *fakeMiningMarket) GetMarketOrders(_ context.Context, _ int, typeID int)
 			lowerLoc = l
 		}
 	}
+	topVol := 1_000_000
+	if f.volByType != nil {
+		if v, ok := f.volByType[typeID]; ok {
+			topVol = v
+		}
+	}
 	return []database.MarketOrder{
-		{TypeID: typeID, IsBuyOrder: true, Price: price, VolumeRemain: 1_000_000, LocationID: loc},
+		{TypeID: typeID, IsBuyOrder: true, Price: price, VolumeRemain: topVol, LocationID: loc},
 		// a lower buy order + a sell order, to prove we pick the highest buy.
 		{TypeID: typeID, IsBuyOrder: true, Price: price * 0.5, VolumeRemain: 100, LocationID: lowerLoc},
 		{TypeID: typeID, IsBuyOrder: false, Price: price * 2, VolumeRemain: 100},
@@ -610,6 +618,57 @@ func TestMiningService_OreRanking_DecoupledRefineWhenRawUnreachable(t *testing.T
 	}
 	if row.DeltaISKPerHour != 0 {
 		t.Errorf("DeltaISKPerHour must be 0 with only one reachable path: %v", row.DeltaISKPerHour)
+	}
+}
+
+// TestMiningService_OreRanking_MarketLoadsCap verifies the row reports how many full
+// ore-hold loads the chosen buy order can absorb (VolumeRemain cap), and that a thin
+// order yields <1 load (the fail-loud "best-price ISK/h is optimistic" signal).
+func TestMiningService_OreRanking_MarketLoadsCap(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	run := func(veldVol int) *models.OreRankRow {
+		market := &fakeMiningMarket{
+			buyPriceByType: map[int]float64{veldsparTypeID: 15.0, tritaniumTypeID: 5.0},
+			volByType:      map[int]int{veldsparTypeID: veldVol},
+		}
+		skills := &fakeMiningSkillsProvider{
+			skills:    &MiningReprocessingSkills{OreProcessing: map[int64]int{}, SkillLevels: map[int64]int{17940: 5, 22551: 5}},
+			standings: map[int64]float64{},
+		}
+		fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+		// Reprocess station is a citadel → refine unreachable → raw wins, so MarketLoads
+		// reflects the Veldspar ore order's VolumeRemain deterministically.
+		stations := &fakeStations{stations: []database.ReprocessStation{
+			{StationID: 1_035_000_000_009, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+		}}
+		loc := fakeMiningLocation{shipTypeID: 22544}
+		svc := NewMiningService(sdeDB, stations, market, skills, fitting, loc, nil, fakeMiningNames{}, logger.NewNoop())
+		resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{RegionID: 10000002, AllowLowSec: false})
+		if err != nil {
+			t.Fatalf("OreRanking error: %v", err)
+		}
+		for i := range resp.Rows {
+			if resp.Rows[i].OreTypeID == veldsparTypeID {
+				return &resp.Rows[i]
+			}
+		}
+		t.Fatal("Veldspar row not found")
+		return nil
+	}
+
+	// Fat order → many full loads absorbable at the best price.
+	fat := run(1_000_000_000)
+	if fat.Best != "raw" {
+		t.Fatalf("expected raw verdict (refine unreachable), got %q", fat.Best)
+	}
+	if fat.MarketLoads <= 1 {
+		t.Errorf("fat order: MarketLoads must be > 1, got %v", fat.MarketLoads)
+	}
+	// Thin order → less than one full load at the best price (fail-loud signal).
+	if thin := run(5); thin.MarketLoads <= 0 || thin.MarketLoads >= 1 {
+		t.Errorf("thin order: MarketLoads must be in (0,1), got %v", thin.MarketLoads)
 	}
 }
 

--- a/docs/superpowers/specs/2026-06-02-mining-market-loads-cap-design.md
+++ b/docs/superpowers/specs/2026-06-02-mining-market-loads-cap-design.md
@@ -1,0 +1,41 @@
+# Mining: Markt-Mengen-Cap als „volle Ladungen" pro Zeile — Design
+
+**Datum:** 2026-06-02
+**Status:** Approved (Design)
+
+## Problem
+
+Das Mining-Ranking nimmt den höchsten erreichbaren Buy-Preis und tut so, als ließe sich **unbegrenzt** dazu verkaufen — `VolumeRemain` (Order-Kapazität) wird im Mining-Pfad nirgends genutzt. Bei dünnen Orders ist die ISK/h ab der ersten Ladung Fiktion. Es fehlt zudem jede Mengen-/Ladungs-Anzeige.
+
+## Ziel
+
+Pro Zeile anzeigen, **wie viele komplette Erzraum-Ladungen** (bezogen auf das aktuelle Schiff) die gewählte Order aufnimmt — plus fail-loud-Warnung, wenn der Bestpreis nicht mal eine volle Ladung trägt.
+
+## Entscheidungen (vom Owner bestätigt)
+
+1. **Cap-Quelle:** die EINE beste erreichbare Buy-Order (deren `VolumeRemain`), passend zur bestehenden Bestpreis-Logik. Keine Order-Book-Tiefe.
+2. **ISK/h-Wirkung:** nur anzeigen — ISK/h und Ranking unverändert; ABER die Zeile wird fail-loud markiert, wenn `market_loads < 1` (Bestpreis-ISK/h dann optimistisch).
+3. **Plattform:** Web + Flutter (APK separat gebaut).
+
+## Berechnung
+
+Nur wenn tatsächlich gemint wird (`oreM3h > 0`, also Erzraum `oreHoldM3 > 0` aufgelöst). Sei `unitsPerLoad = oreHoldM3 / oreVolumeM3` (Erz-Einheiten pro voller Erzraum-Füllung).
+
+- **Roh:** `rawLoads = orderVolumeRemain / unitsPerLoad` (Order-`VolumeRemain` in Erz-Einheiten).
+- **Refine:** pro Mineral `m` am gewählten Hub: produzierte Einheiten pro Ladung `mPerLoad = (unitsPerLoad / portionSize) * matQty_m * net`; `loads_m = mineralVolumeRemain_m / mPerLoad`. **`refineLoads = min über alle m`** (das zuerst erschöpfte Mineral bindet).
+- Angezeigt wird der Cap des **`Best`-Pfads** (raw→rawLoads, refine→refineLoads) als `market_loads`.
+
+## Datenfluss / Felder
+
+- `systemBuy` + `bestReachableBuyOrder` führen zusätzlich `volumeRemain int` (der gewählten Order).
+- Neues Feld `OreRankRow.MarketLoads float64 json:"market_loads,omitempty"` — 0/weggelassen, wenn nicht mining oder Pfad nicht erreichbar.
+- Web + Flutter: in der aufgeklappten Zeile „Markt nimmt ~X.X Ladungen"; bei `0 < market_loads < 1` ein ⚠ „Bestpreis < 1 Ladung — ISK/h optimistisch".
+
+## Fail-loud / Tests
+
+- Service-Test: dünne Order (kleiner `VolumeRemain`) → `market_loads < 1`; fette Order → großer Wert; refine bindet am knappsten Mineral.
+- Reine Zusatzinfo; bestehende ISK/h-/Verdict-Tests bleiben unberührt.
+
+## Nicht im Scope
+
+- Order-Book-Tiefe / Preis-Floor; echtes ISK/h-Capping; absolute Mengen pro Mineral (Materials zeigt schon Effektiv-Qty pro Portion).

--- a/frontend/src/components/trading/OreRankingTable.tsx
+++ b/frontend/src/components/trading/OreRankingTable.tsx
@@ -179,6 +179,17 @@ function OreRankRow({ row }: { row: OreRankRow }) {
                     {row.sell_system_name ? ` · Verkauf in ${row.sell_system_name}` : ""}
                   </div>
                 )}
+                {row.market_loads != null && row.market_loads > 0 && (
+                  row.market_loads >= 1 ? (
+                    <div className="text-sm text-muted-foreground">
+                      Markt: ~{row.market_loads.toFixed(1)} volle Ladungen
+                    </div>
+                  ) : (
+                    <div className="text-sm text-amber-600 dark:text-amber-500">
+                      ⚠ Bestpreis nur ~{row.market_loads.toFixed(2)} Ladungen — ISK/h optimistisch
+                    </div>
+                  )
+                )}
                 <div className="text-sm">
                   <span className="text-muted-foreground">Aufbereiten bei: </span>
                   {row.best_station_id ? (
@@ -252,6 +263,17 @@ function OreRankRow({ row }: { row: OreRankRow }) {
                     Zyklus {row.cycle_minutes.toFixed(1)} min · {row.route_jumps ?? 0} Jumps
                     {row.sell_system_name ? ` · Verkauf in ${row.sell_system_name}` : ""}
                   </div>
+                )}
+                {row.market_loads != null && row.market_loads > 0 && (
+                  row.market_loads >= 1 ? (
+                    <div className="mb-2 text-sm text-muted-foreground">
+                      Markt: ~{row.market_loads.toFixed(1)} volle Ladungen
+                    </div>
+                  ) : (
+                    <div className="mb-2 text-sm text-amber-600 dark:text-amber-500">
+                      ⚠ Bestpreis nur ~{row.market_loads.toFixed(2)} Ladungen — ISK/h optimistisch
+                    </div>
+                  )
                 )}
                 <span className="text-muted-foreground">Roh verkaufen bei: </span>
                 {row.raw_sell?.location_id ? (

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -392,6 +392,7 @@ export interface OreRankRow {
   cycle_minutes?: number;
   route_jumps?: number;
   sell_system_name?: string;
+  market_loads?: number;
 }
 
 export interface OreRankingResponse {

--- a/frontend/tests/components/OreRankingTable.test.tsx
+++ b/frontend/tests/components/OreRankingTable.test.tsx
@@ -260,4 +260,28 @@ describe("OreRankingTable", () => {
     fireEvent.click(screen.getByRole("button", { name: /Dodixie IX — Dodixie/ }));
     expect(setWaypointMock).toHaveBeenCalledWith(60011866, { clearOtherWaypoints: true });
   });
+
+  it("shows market_loads >= 1 as a muted 'volle Ladungen' line in the refine detail", () => {
+    const r = makeRow({
+      ore_type_id: 1230, ore_name: "Veldspar", best: "refine",
+      cycle_minutes: 12.5, market_loads: 3.7,
+    });
+    render(<OreRankingTable rows={[r]} />);
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+    const detail = screen.getByTestId("ore-ranking-detail");
+    expect(within(detail).getByText(/Markt: ~3\.7 volle Ladungen/)).toBeInTheDocument();
+    expect(within(detail).queryByText(/ISK\/h optimistisch/)).not.toBeInTheDocument();
+  });
+
+  it("shows market_loads < 1 as a warning line in the raw detail", () => {
+    const r = makeRow({
+      ore_type_id: 1228, ore_name: "Scordite", best: "raw",
+      cycle_minutes: 10.0, market_loads: 0.42,
+    });
+    render(<OreRankingTable rows={[r]} />);
+    fireEvent.click(screen.getByTestId("ore-ranking-row"));
+    const detail = screen.getByTestId("ore-ranking-detail");
+    expect(within(detail).getByText(/ISK\/h optimistisch/)).toBeInTheDocument();
+    expect(within(detail).queryByText(/volle Ladungen/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Warum

Das Mining-Ranking nahm den höchsten erreichbaren Buy-Preis und tat so, als ließe sich **unbegrenzt** dazu verkaufen — `VolumeRemain` (Order-Kapazität) wurde im Mining-Pfad nirgends genutzt. Bei dünnen Orders ist die ISK/h ab der ersten Ladung Fiktion. Es fehlte zudem jede Mengen-/Ladungs-Anzeige.

## Was

Pro Zeile: **„Markt nimmt ~X.X volle Ladungen"** (bezogen auf das aktuelle Schiff), aus dem `VolumeRemain` der gewählten Order:
- **Roh:** Kapazität der Erz-Buy-Order.
- **Refine:** das **zuerst erschöpfte Mineral** bindet (Minimum über alle Minerale am gewählten Hub).
- Trägt der Bestpreis `< 1` volle Ladung → fail-loud-Marker „⚠ Bestpreis nur ~X Ladungen — ISK/h optimistisch".

**Reine Anzeige** — ISK/h und Ranking unverändert (Owner-Entscheidung). Cap-Quelle = die eine beste Order (keine Order-Book-Tiefe). Neues Response-Feld `market_loads`.

## Umfang

- Backend (`mining_service.go`): `VolumeRemain` durch `bestReachableBuyOrder`/`systemBuy` durchgereicht; Ladungs-Berechnung; neues Feld `OreRankRow.market_loads`. TDD-Test (dünn → <1 Ladung, fett → >1).
- Web (`OreRankingTable`) + Flutter (`mining_screen`): Anzeige in beiden Pfaden, muted ≥1 / amber <1. Je mit Model-/Type-Feld + Tests.

Volle Backend-Suite grün, golangci `0 issues`, ESLint clean, `flutter analyze` clean. **Flutter-APK wird separat gebaut** (nicht über die Deploy-Pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)