### PR TITLE
ci: guard against swagger drift (make swagger + CI check + release sync)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
         run: gofmt -l . | tee /dev/stderr | (! grep .)
       - name: go vet
         run: go vet ./...
+      - name: Swagger spec up to date
+        run: |
+          make -C .. swagger
+          git diff --exit-code -- docs \
+            || { echo "::error::backend/docs is stale — run 'make swagger' and commit the result"; exit 1; }
 
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Swagger-Drift dauerhaft verhindert (Build/CI).** Neues `make swagger`-Target regeneriert die OpenAPI-Spec reproduzierbar via `go run github.com/swaggo/swag/cmd/swag@<pinned>` (Version in `SWAG_VERSION` einmalig gepinnt). `make release` zieht jetzt die Swagger-`@version` automatisch mit (`// @version` = Release-Version) und regeneriert die Spec. Ein CI-Schritt (`lint`-Job) führt `make swagger` aus und failt bei einem Diff in `backend/docs` — so kann eine veraltete Spec nicht mehr committet werden (gleicher Geist wie „nie zwei Schema-Quellen"). Verhindert die Wiederholung der 7-Monats-Drift aus dem vorigen Eintrag.
 - **Swagger/OpenAPI-Doku neu generiert (Backend).** Die unter `/swagger` ausgelieferte API-Spec war seit 2025-11-13 nicht mehr regeneriert (`info.version` hing auf `0.1.0`) und beschrieb weder neuere Endpunkte noch Felder — u. a. fehlte `market_loads` in der Ore-Ranking-Antwort. `swag init -g cmd/api/main.go --parseInternal` neu erzeugt (`docs/{docs.go,swagger.json,swagger.yaml}`), `@version` auf `0.27.0` gesetzt. Reine Doku-Regeneration aus den vorhandenen Annotationen/Structs, kein Verhaltens-/API-Change.
 
 ## [0.27.0] - 2026-06-04

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile – Zentrale Orchestrierung für Projekt-Automationen
 
-.PHONY: help test test-be test-be-unit test-be-int test-be-bench test-be-examples test-be-ex-cargo test-be-ex-nav test-fe lint lint-be lint-fe lint-ci adr-ref commit-lint release-check security-blockers scan scan-json secrets-scan secrets-check pr-check release ci-local clean ensure-trivy ensure-gitleaks push-ci pr-quality-gates-ci sde docker-up docker-down docker-logs docker-ps docker-build docker-clean docker-shell-api docker-shell-db docker-shell-redis migrate migrate-up migrate-down migrate-create
+.PHONY: help test test-be test-be-unit test-be-int test-be-bench test-be-examples test-be-ex-cargo test-be-ex-nav test-fe lint lint-be lint-fe lint-ci adr-ref commit-lint release-check security-blockers scan scan-json secrets-scan secrets-check pr-check release ci-local clean ensure-trivy ensure-gitleaks push-ci pr-quality-gates-ci swagger sde docker-up docker-down docker-logs docker-ps docker-build docker-clean docker-shell-api docker-shell-db docker-shell-redis migrate migrate-up migrate-down migrate-create
 
 # Standardwerte
 TRIVY_FAIL_ON ?= HIGH,CRITICAL
@@ -20,6 +20,9 @@ SDE_TARGET := $(BACKEND_DIR)/data/sde/eve-sde.db
 # wird in den Backend-Build injiziert (siehe backend/Dockerfile ARG APP_VERSION).
 APP_VERSION ?= $(shell grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -n1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 export APP_VERSION
+# swaggo/swag version for OpenAPI generation — pinned so `make swagger` is reproducible
+# (local + CI drift-check produce byte-identical output). Bump deliberately.
+SWAG_VERSION ?= v1.16.4
 
 .DEFAULT_GOAL := help
 
@@ -280,7 +283,15 @@ release: ## Version bump + CHANGELOG Transform (Beispiel: make release VERSION=0
 	fi
 	@echo "[make release] Bump Version auf $(VERSION)..."
 	@sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$(VERSION)] - $$(date +%Y-%m-%d)/" CHANGELOG.md
-	@echo "[make release] CHANGELOG aktualisiert – bitte commit + tag (v$(VERSION)) erstellen"
+	@echo "[make release] Synchronisiere Swagger @version + regeneriere Spec..."
+	@sed -i -E "s|^// @version .*|// @version $(VERSION)|" $(BACKEND_DIR)/cmd/api/main.go
+	@$(MAKE) --no-print-directory swagger
+	@echo "[make release] CHANGELOG + Swagger aktualisiert – bitte commit + tag (v$(VERSION)) erstellen"
+
+swagger: ## Regeneriert die OpenAPI-Spec (backend/docs) aus den swag-Annotationen
+	@echo "[make swagger] Regeneriere OpenAPI-Spec (swag $(SWAG_VERSION))..."
+	@cd $(BACKEND_DIR) && go run github.com/swaggo/swag/cmd/swag@$(SWAG_VERSION) init -g cmd/api/main.go --parseInternal -o docs
+	@echo "[make swagger] ✅ backend/docs aktualisiert"
 
 ci-local: ## Simulation definierter CI-Gates lokal
 	@echo "[make ci-local] Simuliere CI Pipeline lokal..."

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -469,8 +469,7 @@ const docTemplate = `{
                                     "type": "boolean"
                                 },
                                 "destination_id": {
-                                    "type": "integer",
-                                    "format": "int64"
+                                    "type": "integer"
                                 }
                             }
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -463,8 +463,7 @@
                                     "type": "boolean"
                                 },
                                 "destination_id": {
-                                    "type": "integer",
-                                    "format": "int64"
+                                    "type": "integer"
                                 }
                             }
                         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1372,7 +1372,6 @@ paths:
             clear_other_waypoints:
               type: boolean
             destination_id:
-              format: int64
               type: integer
           type: object
       produces:


### PR DESCRIPTION
## Was

Folge-Idee zu #175: die OpenAPI-Spec war ~7 Monate unbemerkt veraltet. Dieser PR macht eine veraltete Spec **unmöglich zu committen**.

## Drei Bausteine
1. **`make swagger`** — regeneriert `backend/docs` reproduzierbar via `go run github.com/swaggo/swag/cmd/swag@$(SWAG_VERSION)` (Version **einmalig** in der Makefile-Var `SWAG_VERSION` gepinnt → lokal == CI byte-identisch).
2. **CI-Drift-Check** (`lint`-Job): führt `make swagger` aus und failt bei jedem Diff in `backend/docs` → wer Annotationen/Structs ändert, muss die Spec mit-regenerieren.
3. **`make release`-Sync**: setzt `// @version` automatisch auf die Release-Version und regeneriert die Spec → die `info.version` kann nicht mehr auf `0.1.0` festhängen.

## Hinweis zur Baseline
Die Spec wurde über den gepinnten `go run`-Generator neu erzeugt (lässt vs. der zuvor per Binary committeten Spec ein kosmetisches `format: int64` an *einem* Inline-Param weg) — damit CI und lokal exakt dasselbe produzieren.

## Verifikation
- **CI-Drift-Check lokal exakt simuliert** (`make -C .. swagger && git diff --exit-code -- docs`) → **passes**.
- `make swagger` idempotent · `go build` grün · Pre-Commit-Hooks grün.

Im Geist deines „nie zwei Schema-Quellen"-Prinzips: die Annotationen/Structs sind die einzige Quelle, die Spec wird daraus erzwungen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)