### PR TITLE
feat(frontend): Trading sub-tabs across the five trading tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Trading-Sub-Tabs (Frontend).** Die fünf Trading-Werkzeuge (Routes · Hauling · ROI · Multi-Hub · Sell Assets) haben jetzt eine gemeinsame **Tab-Leiste** auf jeder der Seiten — man wechselt das Werkzeug direkt, ohne über die Top-Nav zu gehen; die Trading-Sektion liest sich als ein Hub (analog zum Flutter-Client). Jeder Tab bleibt eine echte Route (Deep-Links funktionieren weiter), der aktive Tab ist routen-bewusst (`usePathname`). Neue Komponente `components/trading/TradingTabs`, eingebunden in die fünf Seiten; Top-Nav-Dropdown unverändert. Verifiziert via eslint/tsc/`next build`/vitest + Real-Browser-Check.
+
 ### Removed
 
 - **Verwaiste `/calculations/*`-Endpunkte entfernt (Backend).** `POST /api/v1/calculations/cargo` und `POST /api/v1/calculations/warp` (samt `CalculationHandler`, ~260 LOC, und den nur dafür genutzten Modellen `Cargo/WarpCalculationRequest/Response` + Helfer) hatten **keinen Consumer** — weder Web noch Flutter rufen sie auf. Die zugrundeliegenden Domänen-Funktionen (`CalculateWarpTime`/`CalculateCargoFit` in `pkg/evedb/*`, vom Route-Calculator genutzt) bleiben unangetastet. Spec via `make swagger` mit-bereinigt. `deadcode`/`golangci-lint` weiterhin 0, alle BE-Tests grün.

--- a/frontend/src/app/hauling/page.tsx
+++ b/frontend/src/app/hauling/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { TradingTabs } from "@/components/trading/TradingTabs";
 import { useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/lib/auth-context";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -80,6 +81,7 @@ function HaulingPageContent() {
 
   return (
     <div className="container mx-auto px-4 py-8">
+      <TradingTabs />
       <div className="mb-8">
         <h1 className="mb-2 text-3xl font-bold">Neighborhood Hauling Routes</h1>
         <p className="text-muted-foreground">

--- a/frontend/src/app/multi-hub/page.tsx
+++ b/frontend/src/app/multi-hub/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { TradingTabs } from "@/components/trading/TradingTabs";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/lib/auth-context";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -54,6 +55,7 @@ function MultiHubPageContent() {
 
   return (
     <div className="container mx-auto px-4 py-8">
+      <TradingTabs />
       <div className="mb-8">
         <h1 className="mb-2 text-3xl font-bold">Multi-Hub Comparison</h1>
         <p className="text-muted-foreground">

--- a/frontend/src/app/roi-calculator/page.tsx
+++ b/frontend/src/app/roi-calculator/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { TradingTabs } from "@/components/trading/TradingTabs";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/lib/auth-context";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -129,6 +130,7 @@ function ROICalculatorContent() {
 
   return (
     <div className="container mx-auto px-4 py-8">
+      <TradingTabs />
       <div className="mb-8">
         <h1 className="mb-2 text-3xl font-bold">
           ROI Calculator & Capital Optimizer

--- a/frontend/src/app/sell-assets/page.tsx
+++ b/frontend/src/app/sell-assets/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
+import { TradingTabs } from "@/components/trading/TradingTabs";
 import { useAuth } from "@/lib/auth-context";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -27,6 +28,7 @@ function SellAssetsPageContent() {
 
   return (
     <div className="container mx-auto px-4 py-8">
+      <TradingTabs />
       <div className="mb-8">
         <h1 className="mb-2 text-3xl font-bold">Sell from Assets</h1>
         <p className="text-muted-foreground">

--- a/frontend/src/app/trading/page.tsx
+++ b/frontend/src/app/trading/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { TradingTabs } from "@/components/trading/TradingTabs";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useAuth } from "@/lib/auth-context";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -147,6 +148,7 @@ function TradingPageContent() {
 
   return (
     <div className="container mx-auto px-4 py-8">
+      <TradingTabs />
       <div className="mb-8">
         <h1 className="mb-2 text-3xl font-bold">Trading</h1>
         <p className="text-muted-foreground">

--- a/frontend/src/components/trading/TradingTabs.tsx
+++ b/frontend/src/components/trading/TradingTabs.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+// Sub-tabs shared across the five trading tools, so the Trading section reads as
+// one hub (switch tools without going back to the top-nav). Mirrors the Flutter
+// client's Trading section. Each tab is a real route — deep links keep working.
+const tabs = [
+  { href: "/trading", label: "Routes" },
+  { href: "/hauling", label: "Hauling" },
+  { href: "/roi-calculator", label: "ROI" },
+  { href: "/multi-hub", label: "Multi-Hub" },
+  { href: "/sell-assets", label: "Sell Assets" },
+] as const;
+
+export function TradingTabs() {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="Trading-Werkzeuge"
+      className="mb-6 flex gap-1 overflow-x-auto border-b"
+    >
+      {tabs.map((tab) => {
+        const active = pathname === tab.href;
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+              active
+                ? "border-primary text-primary"
+                : "border-transparent text-muted-foreground hover:border-muted-foreground/40 hover:text-foreground",
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/tests/e2e/public/pages.spec.ts
+++ b/frontend/tests/e2e/public/pages.spec.ts
@@ -71,4 +71,22 @@ test.describe('Public pages load', () => {
     // Unauthenticated: a "Login with EVE" affordance is reachable (nav or page body).
     await expect(page.getByRole('button', { name: /login with eve/i }).first()).toBeVisible();
   });
+
+  test('trading sub-tabs link the five tools, active tab is route-aware', async ({ page }) => {
+    await page.goto('/roi-calculator');
+    const tabs = page.getByRole('navigation', { name: 'Trading-Werkzeuge' });
+    for (const [name, path] of [
+      ['Routes', '/trading'],
+      ['Hauling', '/hauling'],
+      ['ROI', '/roi-calculator'],
+      ['Multi-Hub', '/multi-hub'],
+      ['Sell Assets', '/sell-assets'],
+    ] as const) {
+      await expect(tabs.getByRole('link', { name, exact: true })).toHaveAttribute('href', path);
+    }
+    // The tab for the current route is marked active.
+    await expect(
+      tabs.getByRole('link', { name: 'ROI', exact: true }),
+    ).toHaveAttribute('aria-current', 'page');
+  });
 });


### PR DESCRIPTION
## Was

Letzter Punkt aus der View/UX-Analyse (der „mittlere Block"): die fünf Trading-Werkzeuge bekommen eine gemeinsame **Sub-Tab-Leiste**, sodass sich die Trading-Sektion als ein **Hub** liest — Werkzeug-Wechsel direkt, ohne Umweg über die Top-Nav. Spiegelt die Trading-Sub-Tabs des Flutter-Clients.

**Tabs:** Routes · Hauling · ROI · Multi-Hub · Sell Assets

## Ansatz (bewusst minimal/risikoarm)
- Neue Komponente `components/trading/TradingTabs` — aktiver Tab routen-bewusst (`usePathname`).
- In die fünf Trading-Seiten oben eingebunden. **Kein** Routing-Umbau: jeder Tab bleibt eine echte Route → Deep-Links + der Top-Nav-Dropdown (#173) funktionieren unverändert weiter.
- Public-E2E-Spec prüft die Tab-Links + den routen-bewussten Aktiv-Zustand.

## Verifikation
- eslint `--max-warnings=0` · `tsc` · `next build` (14 Routes) · **97 vitest** ✓
- **Real-Browser** gegen frischen Build: Tab-Leiste rendert, **ROI** aktiv auf `/roi-calculator`, **Multi-Hub** aktiv auf `/multi-hub` (Aktiv-Zustand ist nicht hardcodiert).

Damit sind alle offenen Punkte der Analyse abgearbeitet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)