### PR TITLE
fix(mining): live ESI market prices (was using days-stale DB snapshot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mining: veraltete Marktpreise → Live-ESI-Abfrage (Backend).** Der Mining-Erz-Ranking las Order-Books aus der `market_orders`-DB-Momentaufnahme (`MarketRepository.GetMarketOrders`), die **nur on-demand** von Trading-Routen-Abfragen aufgefrischt wird (kein Hintergrund-Refresher) — für eine Region, gegen die länger keine Trading-Abfrage lief, war sie **tagealt** (real beobachtet: Verge Vendor **~3,5 Tage**). Folge: falsche Verkaufsstation/ISK (z. B. Alentene 10.50 statt der aktuellen Best-Order). Mining holt die Order-Books jetzt **live von ESI** (`FetchMarketOrdersForType`, ETag-/Redis-validiert) wie Trading/Multi-Hub/Sell-Assets — pro Request einmal je Typ memoisiert (wiederkehrende Mineral-Typen). ESI-Fehler werden **fail-loud** propagiert (kein stilles Zurückfallen auf alte Daten), Prinzip [[no-silent-fallbacks]].
+
+### Added
+
+- **Mining: aktueller Schiff-Standort in der Antwort (Backend).** `OreRankingResponse` liefert jetzt `origin_system_id`/`origin_system_name` (+ `origin_station_name` falls angedockt) — das System, von dem aus gerankt/geroutet wird. Grundlage für die Standort-Anzeige im UI.
+
 ## [0.28.0] - 2026-06-04
 
 ### Added

--- a/backend/cmd/api/container.go
+++ b/backend/cmd/api/container.go
@@ -175,7 +175,10 @@ func NewContainer(ctx context.Context) (*AppContainer, error) {
 	if !ok {
 		return nil, fmt.Errorf("skills service does not implement MiningSkillsProvider")
 	}
-	miningService := services.NewMiningService(c.DB.SDE, c.SDERepo, c.MarketRepo, miningSkillsProvider, fittingService, characterHelper, c.SDERepo, c.SDERepo, c.AppLogger)
+	// Mining ranks against LIVE ESI prices (not the on-demand-refreshed market_orders
+	// DB snapshot, which can be days stale for a region nobody has run trading on).
+	miningMarket := services.NewLiveMarketBuyProvider(c.ESIClient)
+	miningService := services.NewMiningService(c.DB.SDE, c.SDERepo, miningMarket, miningSkillsProvider, fittingService, characterHelper, c.SDERepo, c.SDERepo, c.AppLogger)
 	c.MiningHandler = handlers.NewMiningHandler(miningService)
 
 	// Start the competition collector in the background (lazy-tracked pairs).

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1968,6 +1968,18 @@ const docTemplate = `{
                     "description": "set when no ores apply here",
                     "type": "string"
                 },
+                "origin_station_name": {
+                    "description": "docked station name, if any",
+                    "type": "string"
+                },
+                "origin_system_id": {
+                    "description": "character's current system (ranking origin)",
+                    "type": "integer"
+                },
+                "origin_system_name": {
+                    "description": "resolved name of the current system",
+                    "type": "string"
+                },
                 "quarter": {
                     "description": "amarr|caldari|gallente|minmatar|\"\"",
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1962,6 +1962,18 @@
                     "description": "set when no ores apply here",
                     "type": "string"
                 },
+                "origin_station_name": {
+                    "description": "docked station name, if any",
+                    "type": "string"
+                },
+                "origin_system_id": {
+                    "description": "character's current system (ranking origin)",
+                    "type": "integer"
+                },
+                "origin_system_name": {
+                    "description": "resolved name of the current system",
+                    "type": "string"
+                },
                 "quarter": {
                     "description": "amarr|caldari|gallente|minmatar|\"\"",
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -604,6 +604,15 @@ definitions:
       not_available_reason:
         description: set when no ores apply here
         type: string
+      origin_station_name:
+        description: docked station name, if any
+        type: string
+      origin_system_id:
+        description: character's current system (ranking origin)
+        type: integer
+      origin_system_name:
+        description: resolved name of the current system
+        type: string
       quarter:
         description: amarr|caldari|gallente|minmatar|""
         type: string

--- a/backend/internal/models/mining.go
+++ b/backend/internal/models/mining.go
@@ -67,8 +67,11 @@ type OreRankRow struct {
 // still populated; isk/h is 0). Rows is always non-nil (never JSON null).
 type OreRankingResponse struct {
 	RegionID           int          `json:"region_id"`
-	SystemSecurity     float64      `json:"system_security,omitempty"` // current system, displayed sec
-	Quarter            string       `json:"quarter,omitempty"`         // amarr|caldari|gallente|minmatar|""
+	OriginSystemID     int64        `json:"origin_system_id,omitempty"`    // character's current system (ranking origin)
+	OriginSystemName   string       `json:"origin_system_name,omitempty"`  // resolved name of the current system
+	OriginStationName  string       `json:"origin_station_name,omitempty"` // docked station name, if any
+	SystemSecurity     float64      `json:"system_security,omitempty"`     // current system, displayed sec
+	Quarter            string       `json:"quarter,omitempty"`             // amarr|caldari|gallente|minmatar|""
 	NoMiningSetup      bool         `json:"no_mining_setup"`
 	NotAvailableReason string       `json:"not_available_reason,omitempty"` // set when no ores apply here
 	Rows               []OreRankRow `json:"rows"`

--- a/backend/internal/services/mining_market.go
+++ b/backend/internal/services/mining_market.go
@@ -1,0 +1,59 @@
+package services
+
+import (
+	"context"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+)
+
+// miningMarketFetcher is the live ESI market source (subset of *esi.Client).
+type miningMarketFetcher interface {
+	FetchMarketOrdersForType(ctx context.Context, regionID, typeID int) ([]esi.ESIMarketOrder, error)
+}
+
+// LiveMarketBuyProvider implements MarketBuyProvider by fetching LIVE order books
+// from ESI (ETag/Redis-validated at the ESI layer) instead of reading the
+// market_orders DB snapshot.
+//
+// Why: the DB snapshot is only refreshed on-demand by trading-route queries
+// (route_finder upsert) — there is no background refresher — so for a region no
+// one has recently run a trading query against, it can be days stale. Mining then
+// ranks ores against stale prices and recommends the wrong (stale-best) sell
+// location. All other market consumers (trading, multi-hub, sell-assets,
+// competition) already fetch live; mining was the lone DB reader.
+type LiveMarketBuyProvider struct {
+	esi miningMarketFetcher
+}
+
+// NewLiveMarketBuyProvider returns a MarketBuyProvider backed by live ESI fetches.
+func NewLiveMarketBuyProvider(f miningMarketFetcher) LiveMarketBuyProvider {
+	return LiveMarketBuyProvider{esi: f}
+}
+
+// GetMarketOrders fetches the live order book for (region, type) and maps it to
+// the database.MarketOrder shape the mining ranking consumes. An ESI error is
+// propagated (fail-loud) — the caller skips the ore rather than fabricating a
+// price from stale data.
+func (p LiveMarketBuyProvider) GetMarketOrders(ctx context.Context, regionID, typeID int) ([]database.MarketOrder, error) {
+	eos, err := p.esi.FetchMarketOrdersForType(ctx, regionID, typeID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]database.MarketOrder, len(eos))
+	for i, o := range eos {
+		out[i] = database.MarketOrder{
+			OrderID:      o.OrderID,
+			TypeID:       o.TypeID,
+			RegionID:     regionID,
+			LocationID:   o.LocationID,
+			IsBuyOrder:   o.IsBuyOrder,
+			Price:        o.Price,
+			VolumeTotal:  o.VolumeTotal,
+			VolumeRemain: o.VolumeRemain,
+			Issued:       o.Issued,
+			Duration:     o.Duration,
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/services/mining_market_test.go
+++ b/backend/internal/services/mining_market_test.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Sternrassler/eve-o-provit/backend/pkg/esi"
+)
+
+type fakeMarketFetcher struct {
+	orders []esi.ESIMarketOrder
+	err    error
+	calls  int
+}
+
+func (f *fakeMarketFetcher) FetchMarketOrdersForType(_ context.Context, _, _ int) ([]esi.ESIMarketOrder, error) {
+	f.calls++
+	return f.orders, f.err
+}
+
+func TestLiveMarketBuyProvider_MapsLiveOrders(t *testing.T) {
+	f := &fakeMarketFetcher{orders: []esi.ESIMarketOrder{
+		{OrderID: 1, TypeID: 1228, LocationID: 60003760, IsBuyOrder: true, Price: 15.76, VolumeTotal: 1_000_000, VolumeRemain: 985_407},
+	}}
+	p := NewLiveMarketBuyProvider(f)
+
+	got, err := p.GetMarketOrders(context.Background(), 10000068, 1228)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	o := got[0]
+	if !o.IsBuyOrder || o.Price != 15.76 || o.LocationID != 60003760 || o.VolumeRemain != 985_407 || o.RegionID != 10000068 {
+		t.Errorf("bad mapping: %+v", o)
+	}
+}
+
+// The fix's core invariant: an ESI failure is propagated (fail-loud), never
+// swallowed into a fabricated/stale price.
+func TestLiveMarketBuyProvider_PropagatesError(t *testing.T) {
+	f := &fakeMarketFetcher{err: errors.New("esi unavailable")}
+	p := NewLiveMarketBuyProvider(f)
+
+	if _, err := p.GetMarketOrders(context.Background(), 1, 1); err == nil {
+		t.Fatal("expected the ESI error to propagate, got nil")
+	}
+}

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -125,11 +125,20 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	if err != nil {
 		return nil, fmt.Errorf("system ore class: %w", err)
 	}
+	// Current ship location (best-effort display context; the ranking origin).
+	originName, _ := s.names.GetSystemName(ctx, originSys)
+	var originStation string
+	if curLoc.StationID != nil {
+		originStation, _ = s.names.GetStationName(ctx, *curLoc.StationID)
+	}
 	resp := &models.OreRankingResponse{
-		RegionID:       regionID,
-		SystemSecurity: math.Round(sec*10) / 10,
-		Quarter:        quarter,
-		Rows:           []models.OreRankRow{},
+		RegionID:          regionID,
+		OriginSystemID:    originSys,
+		OriginSystemName:  originName,
+		OriginStationName: originStation,
+		SystemSecurity:    math.Round(sec*10) / 10,
+		Quarter:           quarter,
+		Rows:              []models.OreRankRow{},
 	}
 
 	// 2. Ore set that actually spawns in this system (deterministic).
@@ -236,7 +245,8 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 		}
 	}
 	travelMemo := map[travelKey]*navigation.RouteResult{}
-	sysOf := map[int64]int64{} // order location → system, memoised across ores
+	sysOf := map[int64]int64{}                  // order location → system, memoised across ores
+	ordMemo := map[int][]database.MarketOrder{} // type → live order book, fetched once per request
 
 	// 4. Best reprocessing station (lowest tax given the player's owner-corp standing).
 	stations, err := s.stations.GetRegionReprocessStations(ctx, regionID)
@@ -354,7 +364,7 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 
 		// ---- RAW path (reachability-aware): best reachable ore buy order ----
 		orePrice, oreLoc, _, oreSecs, oreJumps, oreVR, oreOK :=
-			s.bestReachableBuyOrder(ctx, regionID, int(o.TypeID), originSys, navParams, travelMemo, sysOf)
+			s.bestReachableBuyOrder(ctx, regionID, int(o.TypeID), originSys, navParams, travelMemo, sysOf, ordMemo)
 		rawCmp := CompareOre(OreCompareInput{
 			PortionSize: o.PortionSize, OreVolumeM3: o.VolumeM3, OreBuyPrice: orePrice,
 			Materials: nil, NetYield: net, StationTake: stationTax, SalesTaxRate: salesTaxRate,
@@ -386,7 +396,7 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 			candidates := map[int64]bool{}
 			ok := true
 			for _, m := range o.Materials {
-				g, e := s.bestBuyBySystem(ctx, regionID, int(m.MaterialTypeID), sysOf)
+				g, e := s.bestBuyBySystem(ctx, regionID, int(m.MaterialTypeID), sysOf, ordMemo)
 				if e != nil {
 					if s.logger != nil {
 						s.logger.Warn("ore ranking: mineral market fetch failed", "typeID", m.MaterialTypeID, "error", e)
@@ -563,6 +573,22 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	return resp, nil
 }
 
+// ordersFor returns the order book for (region, type), fetched once per request
+// and memoised in ordMemo (mineral types recur across ores). The provider fetches
+// LIVE from ESI — never the stale market_orders snapshot — so the ranking reflects
+// current prices.
+func (s *MiningService) ordersFor(ctx context.Context, regionID, typeID int, ordMemo map[int][]database.MarketOrder) ([]database.MarketOrder, error) {
+	if o, ok := ordMemo[typeID]; ok {
+		return o, nil
+	}
+	o, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
+	if err != nil {
+		return nil, err
+	}
+	ordMemo[typeID] = o
+	return o, nil
+}
+
 // bestReachableBuyOrder returns the highest buy order for a type whose station's
 // system is reachable from origin under the request's security preference (params).
 // Citadels (location not resolvable to a system) are skipped — they can't anchor a
@@ -572,8 +598,9 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 func (s *MiningService) bestReachableBuyOrder(
 	ctx context.Context, regionID, typeID int, origin int64,
 	params *navigation.NavigationParams, travelMemo map[travelKey]*navigation.RouteResult, sysOf map[int64]int64,
+	ordMemo map[int][]database.MarketOrder,
 ) (price float64, locationID int64, sellSys int64, secs float64, jumps int, volumeRemain int, ok bool) {
-	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
+	orders, err := s.ordersFor(ctx, regionID, typeID, ordMemo)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warn("ore ranking: market orders fetch failed", "typeID", typeID, "error", err)
@@ -641,8 +668,8 @@ type systemBuy struct {
 // bestBuyBySystem groups a type's region buy-orders by solar system and keeps the
 // highest price per system (with its station location). Locations that can't be
 // resolved to a system (e.g. citadels) are skipped — they can't anchor a haul leg.
-func (s *MiningService) bestBuyBySystem(ctx context.Context, regionID, typeID int, sysOf map[int64]int64) (map[int64]systemBuy, error) {
-	orders, err := s.marketRepo.GetMarketOrders(ctx, regionID, typeID)
+func (s *MiningService) bestBuyBySystem(ctx context.Context, regionID, typeID int, sysOf map[int64]int64, ordMemo map[int][]database.MarketOrder) (map[int64]systemBuy, error) {
+	orders, err := s.ordersFor(ctx, regionID, typeID, ordMemo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Bug
Du hast richtig vermutet: **veraltete Preise.** Der Mining-Erz-Ranking las Order-Books aus der `market_orders`-**DB-Momentaufnahme**, die nur **on-demand** von Trading-Routen-Abfragen aufgefrischt wird (kein Hintergrund-Refresher). Für Verge Vendor (Region 10000068) war sie **~3,5 Tage alt** (`/market/staleness`: `age_minutes: 5138`, letzter Fetch 2026-05-31) → das Ranking empfahl die *stale-beste* Verkaufsstation **Alentene (10.50)** statt der aktuellen Best-Order **Cistuvaert (15.76, ✓ Station)**, die im veralteten Snapshot fehlte.

Mining war der **einzige** Markt-Verbraucher, der die DB las — Trading/Multi-Hub/Sell-Assets/Competition holen alle live.

## Fix
- **`LiveMarketBuyProvider`** holt Order-Books **live von ESI** (`FetchMarketOrdersForType`, ETag/Redis-validiert), gemappt auf `MarketOrder`. ESI-Fehler werden **fail-loud** propagiert (kein stilles Zurückfallen auf alte Daten → [[no-silent-fallbacks]]).
- **Per-Request-Memo**: jeder Typ wird pro Ranking nur einmal geholt (wiederkehrende Mineral-Typen im Refine-Pfad).
- **Bonus (für die Standort-Anzeige):** `OreRankingResponse` liefert jetzt `origin_system_id`/`origin_system_name` (+ `origin_station_name`) — das aktuelle System, von dem aus gerankt/geroutet wird.

## Verifikation
- Neuer Test `mining_market_test.go`: korrektes ESI→MarketOrder-Mapping **+ fail-loud bei ESI-Fehler**.
- Services-Tests · `go build`/`vet`/gofmt · golangci-lint **0** · `deadcode` **0** · Swagger via `make swagger` mit-regeneriert (Drift-Guard grün).

Die UI-Anzeige des Schiff-Standorts folgt im nächsten PR (Web + Flutter), nutzt die neuen `origin_*`-Felder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)