### PR TITLE
feat(mining): show current ship location in the mining view (web + Flutter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Mining: aktueller Schiff-Standort in der Antwort (Backend).** `OreRankingResponse` liefert jetzt `origin_system_id`/`origin_system_name` (+ `origin_station_name` falls angedockt) — das System, von dem aus gerankt/geroutet wird. Grundlage für die Standort-Anzeige im UI.
+- **Mining: Schiff-Standort im UI (Web + Flutter).** Die Mining-Ansicht zeigt im Ergebnis-Header „Aktueller Standort: \<System\>" (bzw. „\<Station\> (\<System\>)" falls angedockt) aus den neuen `origin_*`-Feldern — Web (`mining/page.tsx`) und Flutter (`mining_screen.dart`).
 
 ## [0.28.0] - 2026-06-04
 

--- a/app/lib/api/mining_models.dart
+++ b/app/lib/api/mining_models.dart
@@ -281,6 +281,8 @@ class OreRankingResponse {
     this.systemSecurity = 0.0,
     this.quarter = '',
     this.notAvailableReason,
+    this.originSystemName,
+    this.originStationName,
   });
 
   /// Backend: `region_id`
@@ -299,6 +301,12 @@ class OreRankingResponse {
   /// Backend: `no_mining_setup` — true when the character has no mining lasers.
   final bool noMiningSetup;
 
+  /// Backend: `origin_system_name` — the character's current system (ranking origin).
+  final String? originSystemName;
+
+  /// Backend: `origin_station_name` — docked station, if any.
+  final String? originStationName;
+
   /// Backend: `rows` — pre-sorted by best ISK/h desc.
   final List<OreRankRow> rows;
 
@@ -313,6 +321,8 @@ class OreRankingResponse {
       quarter: json['quarter'] as String? ?? '',
       notAvailableReason: json['not_available_reason'] as String?,
       noMiningSetup: json['no_mining_setup'] as bool? ?? false,
+      originSystemName: json['origin_system_name'] as String?,
+      originStationName: json['origin_station_name'] as String?,
       rows: rawRows
           .whereType<Map<String, dynamic>>()
           .map(OreRankRow.fromJson)

--- a/app/lib/features/mining/mining_screen.dart
+++ b/app/lib/features/mining/mining_screen.dart
@@ -374,6 +374,15 @@ class OreRankingTable extends StatelessWidget {
             ' · ${result.systemSecurity.toStringAsFixed(1)}',
             style: Theme.of(context).textTheme.bodySmall,
           ),
+          if (result.originSystemName != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              result.originStationName != null
+                  ? 'Standort: ${result.originStationName} (${result.originSystemName})'
+                  : 'Standort: ${result.originSystemName}',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
           const SizedBox(height: 16),
           Column(
             key: const Key('mining-ore-table'),

--- a/frontend/src/app/mining/page.tsx
+++ b/frontend/src/app/mining/page.tsx
@@ -118,6 +118,16 @@ function MiningPageContent() {
 
           {miningMutation.isSuccess && miningMutation.data && (
             <div className="space-y-4">
+              {miningMutation.data.origin_system_name && (
+                <p className="text-sm">
+                  <span className="text-muted-foreground">Aktueller Standort: </span>
+                  <span className="font-medium">
+                    {miningMutation.data.origin_station_name
+                      ? `${miningMutation.data.origin_station_name} (${miningMutation.data.origin_system_name})`
+                      : miningMutation.data.origin_system_name}
+                  </span>
+                </p>
+              )}
               {(miningMutation.data.quarter || miningMutation.data.system_security != null) && (
                 <p className="text-sm text-muted-foreground">
                   {[

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -369,6 +369,9 @@ export interface OreRankRow {
 
 export interface OreRankingResponse {
   region_id: number;
+  origin_system_id?: number;
+  origin_system_name?: string;
+  origin_station_name?: string;
   system_security?: number;
   quarter?: string;
   not_available_reason?: string;


### PR DESCRIPTION
## Was
Zeigt an, **wo sich das Schiff gerade befindet** — das System, von dem aus das Erz-Ranking/Routing rechnet. Nutzt die neuen `origin_*`-Felder aus #179.

- **Web** (`mining/page.tsx`): „Aktueller Standort: \<System\>" (bzw. „\<Station\> (\<System\>)" falls angedockt) im Ergebnis-Header.
- **Flutter** (`mining_screen.dart` + `mining_models.dart`): dieselbe Zeile.
- `OreRankingResponse`-TS-Typ um die `origin_*`-Felder ergänzt.

## Verifikation
- Web: eslint `--max-warnings=0` · tsc · `next build` ✓ · 97 vitest ✓
- Flutter: `dart analyze` → **No issues found!**

Die echte On-Device-/Browser-Anzeige zeigt Daten erst, wenn das Backend (#179) deployed ist — daher zusammen mit der nächsten Release verifizieren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)