### PR TITLE
feat(mining): sold-loads tally (check off sold loads) — web + Flutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Mining: „Verkaufte Ladungen"-Strichliste (Web + Flutter).** Im aufgeklappten Erz-Detail kann man unter „Markt: ~X volle Ladungen" die bereits verkauften Ladungen abhaken und behält den Überblick: antippbare Pips (eine pro voller Ladung) mit Zähler „Verkauft: X / N"; bei > 24 Ladungen automatisch Zähler mit +/− und Fortschrittsbalken (statt zig Pips). Rein client-seitig/in-memory, **Reset bei jeder Neuberechnung**. Neue Komponente `SoldLoadsTally` (Web) bzw. `MiningLoadsTally` + `soldLoadsProvider` (Flutter).
+
 ## [0.29.0] - 2026-06-04
 
 ### Fixed

--- a/app/lib/features/mining/mining_providers.dart
+++ b/app/lib/features/mining/mining_providers.dart
@@ -36,6 +36,7 @@ class OreRankingNotifier extends AsyncNotifier<OreRankingResponse?> {
 
   /// Runs an ore ranking for [request].
   Future<void> run(OreRankingRequest request) async {
+    ref.read(soldLoadsProvider.notifier).reset(); // reset sold-loads tally on recalc
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
       final api = ref.read(miningApiProvider);
@@ -49,3 +50,20 @@ final oreRankingProvider =
     AsyncNotifierProvider<OreRankingNotifier, OreRankingResponse?>(
   OreRankingNotifier.new,
 );
+
+/// Per-ore "sold loads" tally (oreTypeId → number of loads marked sold). Reset
+/// on each new ranking (see [OreRankingNotifier.run]) so a recalculation starts
+/// the tally empty. In-memory only.
+class SoldLoadsNotifier extends Notifier<Map<int, int>> {
+  @override
+  Map<int, int> build() => {};
+
+  void setSold(int oreTypeId, int sold) {
+    state = {...state, oreTypeId: sold};
+  }
+
+  void reset() => state = {};
+}
+
+final soldLoadsProvider =
+    NotifierProvider<SoldLoadsNotifier, Map<int, int>>(SoldLoadsNotifier.new);

--- a/app/lib/features/mining/mining_screen.dart
+++ b/app/lib/features/mining/mining_screen.dart
@@ -18,6 +18,7 @@ import '../../core/breakpoint.dart';
 import '../../core/format.dart';
 import '../trading/current_ship_card.dart';
 import 'mining_providers.dart';
+import 'sold_loads_tally.dart';
 
 // ---------------------------------------------------------------------------
 // Public entry point
@@ -512,6 +513,11 @@ class _OreRankTile extends StatelessWidget {
                     ),
                   ),
           ),
+        if (row.marketLoads != null && row.marketLoads! >= 1)
+          MiningLoadsTally(
+            oreTypeId: row.oreTypeId,
+            total: row.marketLoads!.floor(),
+          ),
         _detailLine(
           context,
           'Aufbereiten bei',
@@ -596,6 +602,11 @@ class _OreRankTile extends StatelessWidget {
                       fontSize: 12,
                     ),
                   ),
+          ),
+        if (row.marketLoads != null && row.marketLoads! >= 1)
+          MiningLoadsTally(
+            oreTypeId: row.oreTypeId,
+            total: row.marketLoads!.floor(),
           ),
         _detailLine(context, 'Roh verkaufen bei', _formatSell(row.rawSell)),
       ],

--- a/app/lib/features/mining/sold_loads_tally.dart
+++ b/app/lib/features/mining/sold_loads_tally.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'mining_providers.dart';
+
+/// Above this many full loads, individual pips become unwieldy → counter + bar.
+const int _pipCap = 24;
+
+/// Per-ore tally for marking off loads already sold, so the miner keeps track
+/// while selling. Sold counts live in [soldLoadsProvider] and reset on every
+/// new ranking. Pips for small counts, a counter + progress bar for large ones.
+class MiningLoadsTally extends ConsumerWidget {
+  const MiningLoadsTally({
+    super.key,
+    required this.oreTypeId,
+    required this.total,
+  });
+
+  final int oreTypeId;
+  final int total;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (total < 1) return const SizedBox.shrink();
+
+    final int sold =
+        ((ref.watch(soldLoadsProvider)[oreTypeId] ?? 0).clamp(0, total)).toInt();
+    final theme = Theme.of(context);
+    final primary = theme.colorScheme.primary;
+
+    void setSold(int n) {
+      ref.read(soldLoadsProvider.notifier).setSold(oreTypeId, n.clamp(0, total).toInt());
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Verkauft: $sold / $total', style: theme.textTheme.bodySmall),
+          const SizedBox(height: 4),
+          if (total <= _pipCap)
+            Wrap(
+              spacing: 4,
+              runSpacing: 4,
+              children: [
+                for (var i = 0; i < total; i++)
+                  _Pip(
+                    filled: i < sold,
+                    color: primary,
+                    // Tap fills up to here, or clears from here if already filled.
+                    onTap: () => setSold(i < sold ? i : i + 1),
+                  ),
+              ],
+            )
+          else
+            Row(
+              children: [
+                _StepButton(label: '−', onTap: () => setSold(sold - 1)),
+                const SizedBox(width: 8),
+                _StepButton(label: '+', onTap: () => setSold(sold + 1)),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(3),
+                    child: LinearProgressIndicator(
+                      value: total > 0 ? sold / total : 0,
+                      minHeight: 6,
+                      color: primary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Pip extends StatelessWidget {
+  const _Pip({required this.filled, required this.color, required this.onTap});
+
+  final bool filled;
+  final Color color;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(4),
+      child: Container(
+        width: 22,
+        height: 22,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: filled ? color : color.withAlpha(80)),
+          color: filled ? color.withAlpha(40) : null,
+        ),
+        child: filled ? Icon(Icons.check, size: 14, color: color) : null,
+      ),
+    );
+  }
+}
+
+class _StepButton extends StatelessWidget {
+  const _StepButton({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(4),
+      child: Container(
+        width: 28,
+        height: 28,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: color.withAlpha(120)),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(color: color, fontSize: 16, fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/src/components/trading/OreRankingTable.tsx
+++ b/frontend/src/components/trading/OreRankingTable.tsx
@@ -7,6 +7,7 @@ import { cn, formatISK } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { openMarketDetails, setWaypoint } from "@/lib/api-client";
+import { SoldLoadsTally } from "./SoldLoadsTally";
 
 interface OreRankingTableProps {
   rows: OreRankRow[];
@@ -30,6 +31,17 @@ function formatStation(name?: string, system?: string): string {
  * where to sell (raw ore, or a per-mineral breakdown for the refine path).
  */
 export function OreRankingTable({ rows }: OreRankingTableProps) {
+  // Sold-loads tally per ore (ore_type_id → sold count). Reset on every new
+  // ranking so a recalculation starts the tally empty — done by adjusting state
+  // during render when `rows` changes identity (React's recommended pattern,
+  // avoids an effect).
+  const [sold, setSold] = useState<Record<number, number>>({});
+  const [seenRows, setSeenRows] = useState(rows);
+  if (rows !== seenRows) {
+    setSeenRows(rows);
+    setSold({});
+  }
+
   if (rows.length === 0) {
     return (
       <Card>
@@ -69,7 +81,12 @@ export function OreRankingTable({ rows }: OreRankingTableProps) {
             </thead>
             <tbody>
               {rows.map((row) => (
-                <OreRankRow key={row.ore_type_id} row={row} />
+                <OreRankRow
+                  key={row.ore_type_id}
+                  row={row}
+                  sold={sold[row.ore_type_id] ?? 0}
+                  onSoldChange={(n) => setSold((s) => ({ ...s, [row.ore_type_id]: n }))}
+                />
               ))}
             </tbody>
           </table>
@@ -79,7 +96,15 @@ export function OreRankingTable({ rows }: OreRankingTableProps) {
   );
 }
 
-function OreRankRow({ row }: { row: OreRankRow }) {
+function OreRankRow({
+  row,
+  sold,
+  onSoldChange,
+}: {
+  row: OreRankRow;
+  sold: number;
+  onSoldChange: (n: number) => void;
+}) {
   const [open, setOpen] = useState(false);
   const { toast } = useToast();
   const linkCls = "text-left hover:underline underline-offset-2 hover:text-primary transition-colors";
@@ -190,6 +215,13 @@ function OreRankRow({ row }: { row: OreRankRow }) {
                     </div>
                   )
                 )}
+                {row.market_loads != null && row.market_loads >= 1 && (
+                  <SoldLoadsTally
+                    total={Math.floor(row.market_loads)}
+                    sold={sold}
+                    onChange={onSoldChange}
+                  />
+                )}
                 <div className="text-sm">
                   <span className="text-muted-foreground">Aufbereiten bei: </span>
                   {row.best_station_id ? (
@@ -274,6 +306,13 @@ function OreRankRow({ row }: { row: OreRankRow }) {
                       ⚠ Bestpreis nur ~{row.market_loads.toFixed(2)} Ladungen — ISK/h optimistisch
                     </div>
                   )
+                )}
+                {row.market_loads != null && row.market_loads >= 1 && (
+                  <SoldLoadsTally
+                    total={Math.floor(row.market_loads)}
+                    sold={sold}
+                    onChange={onSoldChange}
+                  />
                 )}
                 <span className="text-muted-foreground">Roh verkaufen bei: </span>
                 {row.raw_sell?.location_id ? (

--- a/frontend/src/components/trading/SoldLoadsTally.tsx
+++ b/frontend/src/components/trading/SoldLoadsTally.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+// Above this many full loads, individual pips become unwieldy → counter + bar.
+const PIP_CAP = 24;
+
+interface SoldLoadsTallyProps {
+  /** Number of full ore-hold loads the best buy order absorbs (floored, ≥ 1). */
+  total: number;
+  /** How many loads the user has marked sold (0…total). */
+  sold: number;
+  onChange: (sold: number) => void;
+}
+
+/**
+ * A per-ore tally for marking off loads already sold — lets the miner keep
+ * track while selling. State is owned by the caller and reset on recalculation.
+ */
+export function SoldLoadsTally({ total, sold, onChange }: SoldLoadsTallyProps) {
+  if (total < 1) return null;
+  const clamped = Math.max(0, Math.min(sold, total));
+
+  return (
+    <div className="mt-1 space-y-1" data-testid="sold-loads-tally">
+      <div className="text-xs text-muted-foreground">
+        Verkauft:{" "}
+        <span className="font-medium text-foreground">{clamped}</span> / {total}
+      </div>
+      {total <= PIP_CAP ? (
+        <div className="flex flex-wrap gap-1" role="group" aria-label="Verkaufte Ladungen abhaken">
+          {Array.from({ length: total }, (_, i) => {
+            const filled = i < clamped;
+            return (
+              <button
+                key={i}
+                type="button"
+                aria-pressed={filled}
+                aria-label={`Ladung ${i + 1}${filled ? " — verkauft" : ""}`}
+                // Tap fills up to here, or clears from here if already filled.
+                onClick={() => onChange(i < clamped ? i : i + 1)}
+                className={cn(
+                  "h-5 w-5 rounded border text-[11px] leading-none transition-colors",
+                  filled
+                    ? "border-primary bg-primary/15 text-primary"
+                    : "border-muted-foreground/30 text-transparent hover:border-muted-foreground/60",
+                )}
+              >
+                ✓
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            aria-label="Eine Ladung weniger"
+            onClick={() => onChange(Math.max(0, clamped - 1))}
+            className="h-6 w-6 rounded border border-muted-foreground/30 text-sm leading-none hover:border-muted-foreground/60"
+          >
+            −
+          </button>
+          <button
+            type="button"
+            aria-label="Eine Ladung mehr"
+            onClick={() => onChange(Math.min(total, clamped + 1))}
+            className="h-6 w-6 rounded border border-muted-foreground/30 text-sm leading-none hover:border-muted-foreground/60"
+          >
+            +
+          </button>
+          <div className="h-1.5 flex-1 overflow-hidden rounded bg-muted">
+            <div className="h-full bg-primary" style={{ width: `${(clamped / total) * 100}%` }} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/tests/components/SoldLoadsTally.test.tsx
+++ b/frontend/tests/components/SoldLoadsTally.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SoldLoadsTally } from "@/components/trading/SoldLoadsTally";
+
+describe("SoldLoadsTally", () => {
+  it("renders one pip per full load and the sold/total counter", () => {
+    render(<SoldLoadsTally total={5} sold={2} onChange={() => {}} />);
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText(/\/ 5/)).toBeInTheDocument();
+    // 5 pip buttons (group role).
+    const group = screen.getByRole("group", { name: /verkaufte ladungen/i });
+    expect(group.querySelectorAll("button")).toHaveLength(5);
+  });
+
+  it("tapping an unfilled pip fills up to it (sold = index + 1)", () => {
+    const onChange = vi.fn();
+    render(<SoldLoadsTally total={5} sold={2} onChange={onChange} />);
+    // pip index 3 (4th) is unfilled (sold=2) → fills up to 4.
+    fireEvent.click(screen.getByRole("button", { name: "Ladung 4" }));
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it("tapping a filled pip clears from it (sold = index)", () => {
+    const onChange = vi.fn();
+    render(<SoldLoadsTally total={5} sold={3} onChange={onChange} />);
+    // pip index 1 (2nd) is filled (sold=3) → clears down to 1.
+    fireEvent.click(screen.getByRole("button", { name: /Ladung 2/ }));
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it("switches to a +/- counter above the pip cap (24)", () => {
+    const onChange = vi.fn();
+    render(<SoldLoadsTally total={100} sold={42} onChange={onChange} />);
+    expect(screen.queryByRole("group", { name: /verkaufte ladungen/i })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /eine ladung mehr/i }));
+    expect(onChange).toHaveBeenCalledWith(43);
+    fireEvent.click(screen.getByRole("button", { name: /eine ladung weniger/i }));
+    expect(onChange).toHaveBeenCalledWith(41);
+  });
+
+  it("renders nothing when there are no full loads", () => {
+    const { container } = render(<SoldLoadsTally total={0} sold={0} onChange={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## Was
Im aufgeklappten Erz-Detail (unter „Markt: ~X volle Ladungen") kann man die **bereits verkauften Ladungen abhaken** und behält den Überblick. Reset bei jeder Neuberechnung.

- **Pips + Zähler:** antippbare Kästchen (eine pro voller Ladung, N = ⌊market_loads⌋) + „Verkauft: X / N". Tippen füllt bis dahin / leert ab dort.
- **> 24 Ladungen:** automatisch Zähler `[−] X / N [+]` + Fortschrittsbalken (statt unbedienbarer Pip-Reihe).
- **In-Memory**, kein Backend; Reset on recalc.

## Umsetzung
- **Web:** `SoldLoadsTally`-Komponente; State in `OreRankingTable` (Reset über „adjust state on prop change during render"-Pattern, kein Effekt).
- **Flutter:** `MiningLoadsTally` + `soldLoadsProvider` (Riverpod-`Notifier`), Reset in `OreRankingNotifier.run`.

## Verifikation
- Web: eslint `--max-warnings=0` · tsc · `next build` · **102 vitest** (inkl. 5 neue `SoldLoadsTally`-Tests: Pip-Render, Füll-/Leer-Logik, Counter-Modus > 24, Leer bei 0 Ladungen)
- Flutter: `dart analyze` → **No issues found!**

Design vorab gebrainstormt + abgenickt (Pips+Zähler, Web+Flutter, in-memory). On-device-Verify nach der Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)