### PR TITLE
build(app): add android-install target (prod release build + verified adb install)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Tooling: `make android-install` (Flutter-App, `app/Makefile`).** Baut die Release-APK mit den Prod-`--dart-define`s (`API_BASE_URL=https://eveonline.sternrassler.de`, `EVE_CLIENT_ID` aus `deployments/.env` → `EVE_MOBILE_CLIENT_ID`, fail-loud wenn Datei/Variable fehlt), installiert sie per `adb install -r` aufs angeschlossene Gerät und verifiziert den Install via `dumpsys` (INTERNET-Permission + `lastUpdateTime`). Macht die beiden bekannten Fehlerklassen mechanisch unmöglich: „APK ohne dart-defines gebaut → leere `client_id` → SSO-Login kaputt" und „APK gebaut, aber nie aufs Gerät deployed".
+
 ## [0.30.0] - 2026-06-04
 
 ### Added

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,6 +1,6 @@
 # Makefile — eve-o-provit Flutter app
 # Run `make help` to list all targets.
-.PHONY: help test e2e-test analyze build-debug
+.PHONY: help test e2e-test analyze build-debug android-install
 
 # ── Help ───────────────────────────────────────────────────────────────────────
 help: ## Show this help
@@ -22,10 +22,40 @@ analyze: ## Run flutter analyze (must be clean for CI)
 build-debug: ## Build a debug APK (sanity-check compilation)
 	flutter build apk --debug
 
+# ── Release install (real device) ──────────────────────────────────────────────
+#
+# Builds the release APK with the production dart-defines and installs it on the
+# connected device. The mobile client ID is read from ../deployments/.env
+# (EVE_MOBILE_CLIENT_ID) so a release APK can never ship with an empty client_id
+# (which silently breaks the SSO login). Afterwards the install is verified via
+# dumpsys (INTERNET permission present + lastUpdateTime).
+#
+# Optional: set ANDROID_DEVICE=<serial> when more than one device is attached.
+PROD_API_BASE_URL ?= https://eveonline.sternrassler.de
+DEPLOY_ENV         := ../deployments/.env
+RELEASE_APK        := build/app/outputs/flutter-apk/app-release.apk
+ANDROID_PACKAGE    := de.sternrassler.eve_o_provit
+ANDROID_DEVICE_ARG := $(if $(ANDROID_DEVICE),-s $(ANDROID_DEVICE),)
+
+android-install: ## Build release APK with prod dart-defines and install it via adb (verified)
+	@set -e; \
+	test -f "$(DEPLOY_ENV)" || { echo "ERROR: $(DEPLOY_ENV) not found (provides EVE_MOBILE_CLIENT_ID)" >&2; exit 1; }; \
+	CLIENT_ID="$$(grep -E '^EVE_MOBILE_CLIENT_ID=' "$(DEPLOY_ENV)" | head -n1 | cut -d= -f2-)"; \
+	test -n "$$CLIENT_ID" || { echo "ERROR: EVE_MOBILE_CLIENT_ID missing/empty in $(DEPLOY_ENV)" >&2; exit 1; }; \
+	echo "Building release APK (API_BASE_URL=$(PROD_API_BASE_URL), EVE_CLIENT_ID from deployments/.env) ..."; \
+	flutter build apk --release \
+		--dart-define=API_BASE_URL=$(PROD_API_BASE_URL) \
+		--dart-define=EVE_CLIENT_ID="$$CLIENT_ID"; \
+	adb $(ANDROID_DEVICE_ARG) install -r "$(RELEASE_APK)"; \
+	echo "Verifying installed package ..."; \
+	adb $(ANDROID_DEVICE_ARG) shell dumpsys package $(ANDROID_PACKAGE) | grep -E 'android.permission.INTERNET|lastUpdateTime='; \
+	echo "OK: $(ANDROID_PACKAGE) installed (INTERNET permission verified)."
+
 # ── Real-backend on-device validation (manual) ─────────────────────────────────
 #
-# The automated E2E tests mock all backend/auth layers. To validate the real SSO
-# login flow and live route calculation on a physical device or emulator, run:
+# The automated E2E tests mock all backend/auth layers. `make android-install`
+# (above) is the canonical way to put a production release build on a device.
+# To iterate against a non-production backend, run:
 #
 #   flutter run \
 #     --dart-define=API_BASE_URL=https://your-backend.example.com \


### PR DESCRIPTION
## Was

Neues Make-Target `android-install` in `app/Makefile` — der kanonische Weg, eine Prod-Release-APK aufs Gerät zu bringen:

1. `flutter build apk --release` mit den Prod-`--dart-define`s: `API_BASE_URL=https://eveonline.sternrassler.de` fest, `EVE_CLIENT_ID` wird **fail-loud** aus `deployments/.env` (`EVE_MOBILE_CLIENT_ID`) gelesen — fehlt Datei oder Variable, bricht das Target ab statt eine kaputte APK zu bauen.
2. `adb install -r` aufs angeschlossene Gerät (optional `ANDROID_DEVICE=<serial>`).
3. Verifikation per `dumpsys`: INTERNET-Permission vorhanden + `lastUpdateTime`.

## Warum

Macht zwei real aufgetretene Fehlerklassen mechanisch unmöglich:
- APK ohne `--dart-define` gebaut → leere `client_id` → SSO-Login kaputt (2026-05-29)
- APK gebaut + als Datei verschickt, aber nie installiert → „deployed" war es nicht (2026-06-02)

Vorbild: `android-install`-Targets in kochen/foodlens, hier ergänzt um Env-Sourcing + Install-Verifikation.

## Validierung

- `make help` listet das Target, `make -n android-install` Dry-Run geprüft
- Realer Lauf: Build-Teil grün (Release-APK 53,6 MB mit Prod-Defines, 39 s); Install-Teil bricht bei nicht autorisiertem Gerät korrekt fail-loud ab. On-Device-Verify folgt nach Geräte-Autorisierung (wird vor Merge nachgereicht).

🤖 Generated with [Claude Code](https://claude.com/claude-code)