### PR TITLE
feat(metrics): app-specific Prometheus metrics (HTTP, ESI) under eveoprovit_ namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **App-spezifische Prometheus-Metriken (Backend).** Drei neue Messschichten unter dem einheitlichen `eveoprovit_`-Namespace: (1) **HTTP** — `eveoprovit_http_requests_total{method,route,status}` + Latenz-Histogramm `eveoprovit_http_request_duration_seconds{method,route}` via Fiber-Middleware (Route-Pattern statt Roh-Pfad gegen Label-Explosion, unmatched → `(unmatched)`, `/metrics`/`/swagger`/Health ausgenommen; Buckets bis 60 s wegen langer Routen-Berechnungen). (2) **ESI** — `eveoprovit_esi_requests_total{status}` + Dauer-Histogramm über einen instrumentierten `http.RoundTripper` (`SetHTTPClient` am eve-esi-client): zählt jeden Transport-Versuch inkl. Retries — die ehrliche Messgröße fürs ESI-Error-Limit (420er sichtbar), `transport_error` für Verbindungsfehler. (3) Bestehende Trading-Metriken (Calc-Duration, Cache-Hits/Misses) bleiben erhalten.
 - **Tooling: `make android-install` (Flutter-App, `app/Makefile`).** Baut die Release-APK mit den Prod-`--dart-define`s (`API_BASE_URL=https://eveonline.sternrassler.de`, `EVE_CLIENT_ID` aus `deployments/.env` → `EVE_MOBILE_CLIENT_ID`, fail-loud wenn Datei/Variable fehlt), installiert sie per `adb install -r` aufs angeschlossene Gerät und verifiziert den Install via `dumpsys` (INTERNET-Permission + `lastUpdateTime`). Macht die beiden bekannten Fehlerklassen mechanisch unmöglich: „APK ohne dart-defines gebaut → leere `client_id` → SSO-Login kaputt" und „APK gebaut, aber nie aufs Gerät deployed".
+
+### Changed
+
+- **Prometheus-Namespace vereinheitlicht:** `trading_*`-Metriken heißen jetzt `eveoprovit_trading_*` (Konvention wie depots `depot_`-Prefix). Kein Konsument betroffen — die Metriken wurden bis heute von keinem Prometheus gescraped.
+
+### Removed
+
+- **Tote Metriken entfernt:** `trading_cache_hit_ratio` und `trading_worker_pool_queue_size` wurden nirgends gesetzt und exportierten irreführende Konstanten (0).
 
 ## [0.30.0] - 2026-06-04
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -56,6 +56,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Sternrassler/eve-o-provit/backend/internal/metrics"
 	_ "github.com/Sternrassler/eve-o-provit/backend/internal/models" // For OpenAPI
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/evesso"
 	"github.com/gofiber/fiber/v2"
@@ -106,6 +107,7 @@ func setupApp(c *AppContainer) *fiber.App {
 		AllowMethods:     "GET, POST, OPTIONS",
 		AllowCredentials: true,
 	}))
+	app.Use(metrics.HTTPMiddleware())
 
 	// Prometheus metrics (internal — not rate limited)
 	app.Get("/metrics", adaptor.HTTPHandler(promhttp.Handler()))

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.3 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.6 // indirect

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -1,4 +1,8 @@
-// Package metrics - Prometheus metrics for trading operations
+// Package metrics — Prometheus metrics for the eve-o-provit backend.
+//
+// All metrics share the "eveoprovit_" namespace so they stay unambiguous in
+// the portfolio-wide Prometheus (one scrape job per app, same convention as
+// depot's "depot_" prefix).
 package metrics
 
 import (
@@ -7,34 +11,55 @@ import (
 )
 
 var (
+	// HTTPRequestsTotal counts handled HTTP requests by method, route pattern
+	// and response status. Route patterns (not raw paths) keep label
+	// cardinality bounded by the number of registered routes.
+	HTTPRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "eveoprovit_http_requests_total",
+		Help: "Total HTTP requests by method, route pattern and status code",
+	}, []string{"method", "route", "status"})
+
+	// HTTPRequestDuration tracks request latency by method and route pattern.
+	// Buckets reach 60s because trading route calculations may legitimately
+	// run for >30s (ROUTE_CALCULATION_TIMEOUT).
+	HTTPRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "eveoprovit_http_request_duration_seconds",
+		Help:    "HTTP request duration by method and route pattern",
+		Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+	}, []string{"method", "route"})
+
+	// ESIRequestsTotal counts outbound ESI requests by HTTP status — every
+	// transport attempt including internal retries, which is the truthful
+	// measure for the ESI error limit (watch 420s). "transport_error" marks
+	// requests that never produced a response.
+	ESIRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "eveoprovit_esi_requests_total",
+		Help: "Outbound ESI requests by HTTP status (transport_error if no response)",
+	}, []string{"status"})
+
+	// ESIRequestDuration tracks outbound ESI request latency.
+	ESIRequestDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "eveoprovit_esi_request_duration_seconds",
+		Help:    "Outbound ESI request duration",
+		Buckets: prometheus.DefBuckets,
+	})
+
 	// TradingCalculationDuration tracks route calculation duration
 	TradingCalculationDuration = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "trading_calculation_duration_seconds",
+		Name:    "eveoprovit_trading_calculation_duration_seconds",
 		Help:    "Duration of trading route calculation",
 		Buckets: prometheus.ExponentialBuckets(0.1, 2, 10), // 0.1s to 51.2s
 	})
 
-	// TradingCacheHitRatio tracks cache hit ratio
-	TradingCacheHitRatio = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "trading_cache_hit_ratio",
-		Help: "Cache hit ratio for market orders",
-	})
-
-	// TradingCacheHitsTotal counts cache hits
+	// TradingCacheHitsTotal counts market-order cache hits
 	TradingCacheHitsTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "trading_cache_hits_total",
-		Help: "Total trading cache hits",
+		Name: "eveoprovit_trading_cache_hits_total",
+		Help: "Total trading market-order cache hits",
 	})
 
-	// TradingCacheMissesTotal counts cache misses
+	// TradingCacheMissesTotal counts market-order cache misses
 	TradingCacheMissesTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "trading_cache_misses_total",
-		Help: "Total trading cache misses",
+		Name: "eveoprovit_trading_cache_misses_total",
+		Help: "Total trading market-order cache misses",
 	})
-
-	// TradingWorkerPoolQueueSize tracks worker pool queue size
-	TradingWorkerPoolQueueSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "trading_worker_pool_queue_size",
-		Help: "Current trading worker pool queue size",
-	}, []string{"pool_type"})
 )

--- a/backend/internal/metrics/middleware.go
+++ b/backend/internal/metrics/middleware.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// HTTPMiddleware records request count and latency for every handled route.
+// Excluded to avoid self-instrumentation and health-ping noise (same approach
+// as depot): /metrics, /swagger/* and the health endpoint.
+func HTTPMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		path := c.Path()
+		if path == "/metrics" || path == "/api/v1/health" || strings.HasPrefix(path, "/swagger") {
+			return c.Next()
+		}
+
+		start := time.Now()
+		err := c.Next()
+
+		status := c.Response().StatusCode()
+		if err != nil {
+			// The global error handler runs after this middleware — mirror its
+			// status mapping so the label matches the wire response.
+			status = fiber.StatusInternalServerError
+			var fiberErr *fiber.Error
+			if errors.As(err, &fiberErr) {
+				status = fiberErr.Code
+			}
+		}
+
+		// Fiber reports "/" as route for unmatched paths — collapse those to a
+		// single label value so path scanners cannot inflate cardinality.
+		route := c.Route().Path
+		if route == "/" && path != "/" {
+			route = "(unmatched)"
+		}
+
+		HTTPRequestsTotal.WithLabelValues(c.Method(), route, strconv.Itoa(status)).Inc()
+		HTTPRequestDuration.WithLabelValues(c.Method(), route).Observe(time.Since(start).Seconds())
+		return err
+	}
+}

--- a/backend/internal/metrics/middleware_test.go
+++ b/backend/internal/metrics/middleware_test.go
@@ -1,0 +1,92 @@
+package metrics
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func newTestApp() *fiber.App {
+	app := fiber.New()
+	app.Use(HTTPMiddleware())
+	app.Get("/api/v1/types/:id", func(c *fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+	app.Get("/api/v1/boom", func(c *fiber.Ctx) error {
+		return fiber.NewError(fiber.StatusBadGateway, "boom")
+	})
+	app.Get("/api/v1/health", func(c *fiber.Ctx) error {
+		return c.SendString("healthy")
+	})
+	return app
+}
+
+func TestHTTPMiddleware_CountsByRoutePattern(t *testing.T) {
+	app := newTestApp()
+
+	before := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("GET", "/api/v1/types/:id", "200"))
+	for _, target := range []string{"/api/v1/types/34", "/api/v1/types/35"} {
+		resp, err := app.Test(httptest.NewRequest("GET", target, nil))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+	}
+
+	got := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("GET", "/api/v1/types/:id", "200")) - before
+	if got != 2 {
+		t.Errorf("expected 2 requests counted on route pattern, got %v", got)
+	}
+}
+
+func TestHTTPMiddleware_ErrorStatusFromFiberError(t *testing.T) {
+	app := newTestApp()
+
+	before := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("GET", "/api/v1/boom", "502"))
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/boom", nil))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if resp.StatusCode != 502 {
+		t.Fatalf("expected 502, got %d", resp.StatusCode)
+	}
+
+	got := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("GET", "/api/v1/boom", "502")) - before
+	if got != 1 {
+		t.Errorf("expected error response counted with status 502, got %v", got)
+	}
+}
+
+func TestHTTPMiddleware_CollapsesUnmatchedRoutes(t *testing.T) {
+	app := newTestApp()
+
+	before := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("GET", "(unmatched)", "404"))
+	for _, target := range []string{"/scanner-probe-1", "/scanner-probe-2/etc"} {
+		if _, err := app.Test(httptest.NewRequest("GET", target, nil)); err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+	}
+
+	got := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("GET", "(unmatched)", "404")) - before
+	if got != 2 {
+		t.Errorf("expected 2 unmatched requests collapsed into one label, got %v", got)
+	}
+}
+
+func TestHTTPMiddleware_ExcludesHealthAndMetrics(t *testing.T) {
+	app := newTestApp()
+
+	before := testutil.CollectAndCount(HTTPRequestsTotal)
+	if _, err := app.Test(httptest.NewRequest("GET", "/api/v1/health", nil)); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	after := testutil.CollectAndCount(HTTPRequestsTotal)
+
+	if after != before {
+		t.Errorf("health endpoint must not be instrumented (series before=%d after=%d)", before, after)
+	}
+}

--- a/backend/internal/metrics/transport.go
+++ b/backend/internal/metrics/transport.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// ESITransport instruments an http.RoundTripper with the ESI request metrics.
+// It counts every transport attempt (including library-internal retries) by
+// HTTP status, which is the truthful measure for the ESI error limit.
+type ESITransport struct {
+	base http.RoundTripper
+}
+
+// NewESITransport wraps base with ESI metrics instrumentation.
+// A nil base falls back to http.DefaultTransport.
+func NewESITransport(base http.RoundTripper) *ESITransport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &ESITransport{base: base}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *ESITransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := t.base.RoundTrip(req)
+
+	status := "transport_error"
+	if err == nil {
+		status = strconv.Itoa(resp.StatusCode)
+	}
+	ESIRequestsTotal.WithLabelValues(status).Inc()
+	ESIRequestDuration.Observe(time.Since(start).Seconds())
+	return resp, err
+}

--- a/backend/internal/metrics/transport_test.go
+++ b/backend/internal/metrics/transport_test.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestESITransport_CountsByStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(420) // ESI error-limited
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: NewESITransport(nil)}
+
+	before := testutil.ToFloat64(ESIRequestsTotal.WithLabelValues("420"))
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	got := testutil.ToFloat64(ESIRequestsTotal.WithLabelValues("420")) - before
+	if got != 1 {
+		t.Errorf("expected 1 request counted with status 420, got %v", got)
+	}
+}
+
+type failingTransport struct{}
+
+func (failingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("connection refused")
+}
+
+func TestESITransport_CountsTransportErrors(t *testing.T) {
+	client := &http.Client{Transport: NewESITransport(failingTransport{})}
+
+	before := testutil.ToFloat64(ESIRequestsTotal.WithLabelValues("transport_error"))
+	if _, err := client.Get("http://esi.invalid/"); err == nil {
+		t.Fatal("expected transport error")
+	}
+
+	got := testutil.ToFloat64(ESIRequestsTotal.WithLabelValues("transport_error")) - before
+	if got != 1 {
+		t.Errorf("expected 1 transport error counted, got %v", got)
+	}
+}

--- a/backend/pkg/esi/client.go
+++ b/backend/pkg/esi/client.go
@@ -7,10 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	esiclient "github.com/Sternrassler/eve-esi-client/pkg/client"
 	"github.com/redis/go-redis/v9"
+
+	"github.com/Sternrassler/eve-o-provit/backend/internal/metrics"
 )
 
 // Config holds ESI client configuration
@@ -40,6 +43,14 @@ func NewClient(redisClient *redis.Client, cfg Config) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ESI client: %w", err)
 	}
+
+	// Instrument the outbound HTTP transport with Prometheus metrics
+	// (eveoprovit_esi_*). The http.Client mirrors the eve-esi-client default
+	// (30s timeout) — the library only exposes a setter, not its default client.
+	esiClient.SetHTTPClient(&http.Client{
+		Timeout:   30 * time.Second,
+		Transport: metrics.NewESITransport(nil),
+	})
 
 	return &Client{esi: esiClient}, nil
 }


### PR DESCRIPTION
## Was

App-spezifische Prometheus-Metriken unter dem einheitlichen `eveoprovit_`-Namespace (Konvention wie depots `depot_`-Prefix), als Grundlage für das Grafana-App-Dashboard:

### 1. HTTP-Schicht (`internal/metrics/middleware.go`)
`eveoprovit_http_requests_total{method,route,status}` + Latenz-Histogramm `eveoprovit_http_request_duration_seconds{method,route}` als Fiber-Middleware.
- **Route-Pattern statt Roh-Pfad** (`/api/v1/types/:id`) → Label-Kardinalität durch registrierte Routen begrenzt
- Unmatched Pfade (Scanner) kollabieren zu `(unmatched)`
- `/metrics`, `/swagger/*`, Health ausgenommen (Self-Instrumentation-/Ping-Noise, wie bei depot)
- Fehler-Status aus `*fiber.Error` gespiegelt (Label = Wire-Response)
- Buckets bis 60 s — Routen-Berechnungen laufen legitim > 30 s

### 2. ESI-Schicht (`internal/metrics/transport.go`)
`eveoprovit_esi_requests_total{status}` + Dauer-Histogramm über einen instrumentierten `http.RoundTripper`, injiziert via `SetHTTPClient` am eve-esi-client (v0.5.0-API, kein Library-Patch).
- Zählt **jeden Transport-Versuch inkl. Retries** — die ehrliche Messgröße fürs ESI-Error-Limit (420er werden sichtbar)
- `transport_error` für Requests ohne Response

### 3. Aufräumen Bestand
- `trading_*` → `eveoprovit_trading_*` umbenannt (kein Konsument: bis heute hat kein Prometheus diese Metriken gescraped)
- Tote Gauges entfernt: `trading_cache_hit_ratio`, `trading_worker_pool_queue_size` (nirgends gesetzt, exportierten irreführende 0)

## Validierung

- 6 neue Tests (`internal/metrics`): Route-Pattern-Counting, Fiber-Error-Status, Unmatched-Kollaps, Health/Metrics-Exklusion, ESI-Status-Counting (420), Transport-Error
- `go test ./...` komplett grün, `golangci-lint` 0 Issues, `go build ./...` sauber
- Prod-Verify (Metriken live unter `/metrics`) folgt nach Release-Tag

## Folge-PRs (hetzner-Repo)

Scrape-Job `eve-o-provit` + Dashboard-Panels (req/s, Fehlerrate, p95-Latenz, ESI-Status, Cache-Hit-Ratio) im App-Dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
