### PR TITLE
fix: /metrics-Label-Korruption + eve-esi-client v0.5.1 (Hauling-Dauerdrossel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/metrics` lieferte 500 (Label-Korruption durch Fiber-Zero-Copy).** Die HTTP-Metrics-Middleware speicherte `c.Method()`/`c.Route().Path` ungekopiert als Prometheus-Label; fasthttp recycelt die Request-Puffer, der nächste Request mutierte das gespeicherte Label (Prod: `method="POS"`) → `Gather()` schlug mit Duplikat-Fehlern fehl → `/metrics` 500 und Prometheus-Scrape tot. Fix: `strings.Clone` vor dem Speichern; Regressionstest simuliert die Puffer-Wiederverwendung (50× alternierende Requests + Gather).
+- **ESI-Dauerdrossel durch vergifteten Rate-Limit-State (Hauling-Timeout).** eve-esi-client auf **v0.5.1** gehoben: ein stale `errors_remaining`-Wert in Redis (TTL -1, durch die abgeschafften `X-ESI-Error-Limit-*`-Header nie wieder angehoben) drosselte jeden ESI-Aufruf inkl. Cache-Hits mit 1 s Sleep — Hauling brauchte 73 s, der Client lief in den Timeout. Die Lib behandelt abgelaufene Reset-Fenster jetzt als healthy und versieht den State mit TTLs (Details im eve-esi-client-CHANGELOG).
+
 ## [0.31.0] - 2026-06-07
 
 ### Added

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.4
 
 require (
-	github.com/Sternrassler/eve-esi-client v0.5.0
+	github.com/Sternrassler/eve-esi-client v0.5.1
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/gofiber/fiber/v2 v2.52.12
 	github.com/jackc/pgx/v5 v5.7.6

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -11,8 +11,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/Sternrassler/eve-esi-client v0.5.0 h1:bb9/LUVxAOTw8kSJ3hD+Y1fEVN1nDwU+s1x0s12epK8=
-github.com/Sternrassler/eve-esi-client v0.5.0/go.mod h1:+FdYmvFXlzZjuE9wXRY/cRGesq9ruDpQZk7W5MlL4TE=
+github.com/Sternrassler/eve-esi-client v0.5.1 h1:V1Qp/oUGGOgOFUP7Q+XhLeorTVnc/nPc5D8qKNsp7NQ=
+github.com/Sternrassler/eve-esi-client v0.5.1/go.mod h1:+FdYmvFXlzZjuE9wXRY/cRGesq9ruDpQZk7W5MlL4TE=
 github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=

--- a/backend/internal/metrics/middleware.go
+++ b/backend/internal/metrics/middleware.go
@@ -40,8 +40,15 @@ func HTTPMiddleware() fiber.Handler {
 			route = "(unmatched)"
 		}
 
-		HTTPRequestsTotal.WithLabelValues(c.Method(), route, strconv.Itoa(status)).Inc()
-		HTTPRequestDuration.WithLabelValues(c.Method(), route).Observe(time.Since(start).Seconds())
+		// fasthttp reuses request buffers across requests (zero-copy strings) —
+		// label values MUST be cloned before Prometheus stores them, otherwise
+		// the next request mutates the stored label (prod: method="POS") and
+		// Gather fails with duplicate-label errors (/metrics → 500).
+		method := strings.Clone(c.Method())
+		route = strings.Clone(route)
+
+		HTTPRequestsTotal.WithLabelValues(method, route, strconv.Itoa(status)).Inc()
+		HTTPRequestDuration.WithLabelValues(method, route).Observe(time.Since(start).Seconds())
 		return err
 	}
 }

--- a/backend/internal/metrics/middleware_test.go
+++ b/backend/internal/metrics/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
@@ -74,6 +75,38 @@ func TestHTTPMiddleware_CollapsesUnmatchedRoutes(t *testing.T) {
 	got := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("GET", "(unmatched)", "404")) - before
 	if got != 2 {
 		t.Errorf("expected 2 unmatched requests collapsed into one label, got %v", got)
+	}
+}
+
+// Fiber/fasthttp reuses request buffers across requests (zero-copy strings).
+// Storing c.Method()/c.Route().Path directly as Prometheus label values lets a
+// later request mutate the stored label (seen in prod: method="POS") — Gather
+// then fails with "was collected before with the same name and label values"
+// and /metrics serves 500. Regression test: many sequential requests with
+// alternating methods must leave the registry gatherable.
+func TestHTTPMiddleware_LabelsSurviveBufferReuse(t *testing.T) {
+	app := newTestApp()
+	app.Post("/api/v1/types/:id", func(c *fiber.Ctx) error {
+		return c.SendString("ok")
+	})
+
+	for range 50 {
+		for _, method := range []string{"POST", "GET"} {
+			resp, err := app.Test(httptest.NewRequest(method, "/api/v1/types/34", nil))
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			_ = resp.Body.Close()
+		}
+	}
+
+	if _, err := prometheus.DefaultGatherer.Gather(); err != nil {
+		t.Fatalf("registry not gatherable after buffer reuse (corrupted labels): %v", err)
+	}
+
+	got := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("POST", "/api/v1/types/:id", "200"))
+	if got < 50 {
+		t.Errorf("expected >=50 POST requests under intact label, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## Was

Zwei Prod-Fixes aus dem Hauling-Timeout-Incident (2026-06-07):

### 1. `/metrics` 500 — Fiber-Zero-Copy-Label-Korruption (Regression aus #183)
Die Middleware speicherte `c.Method()`/`c.Route().Path` ungekopiert als Prometheus-Label. fasthttp recycelt Request-Puffer → gespeichertes Label mutierte (Prod: `method="POS"`) → `Gather()` Duplikat-Fehler → `/metrics` 500, Prometheus-Scrape tot. **Fix:** `strings.Clone` beider Werte. **Regressionstest** treibt 50 alternierende Requests durch die Middleware und asserted, dass die Registry gatherbar bleibt (war vor dem Fix rot mit exakt dem Prod-Fehlerbild).

### 2. eve-esi-client v0.5.0 → v0.5.1 — ESI-Dauerdrossel
Stale `errors_remaining=5` in Redis (TTL -1; die `X-ESI-Error-Limit-*`-Header existieren ESI-seitig nicht mehr → Wert konnte nie steigen, nur fallen) drosselte jeden ESI-Aufruf inkl. Cache-Hits mit 1 s Sleep → Hauling 73 s → Client-Timeout. v0.5.1 (Sternrassler/eve-esi-client#29): abgelaufenes Reset-Fenster ⇒ healthy, TTLs auf allen State-Keys, Legacy-Keys bekommen TTL nachgerüstet — der vergiftete Prod-State heilt sich nach Deploy selbst.

## Validierung

- `go test ./...` grün (inkl. neuer Regressionstest), golangci-lint 0 Issues
- Nach Release v0.31.1 + Deploy: `/metrics` 200 mit sauberen Labels, Hauling-Tempo on-prod re-testen

🤖 Generated with [Claude Code](https://claude.com/claude-code)
