### PR TITLE
chore(deps): eve-esi-client v0.6.0 — X-Ratelimit-Gruppen-Rate-Limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **eve-esi-client v0.5.1 → v0.6.0: Adoption des neuen ESI-Gruppen-Rate-Limitings (`X-Ratelimit-*`).** Die Lib trackt jetzt CCPs Token-Buckets pro Route-Gruppe (z. B. `market-order: 12000/15m`), drosselt proaktiv bei knappem Budget und respektiert `Retry-After` nach 429 (Retry statt Sofort-Fehler). Das Legacy-Error-Limit-Tracking bleibt für nicht migrierte Routen aktiv. Details → eve-esi-client-CHANGELOG v0.6.0.
+
 ## [0.31.1] - 2026-06-07
 
 ### Fixed

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.4
 
 require (
-	github.com/Sternrassler/eve-esi-client v0.5.1
+	github.com/Sternrassler/eve-esi-client v0.6.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/gofiber/fiber/v2 v2.52.12
 	github.com/jackc/pgx/v5 v5.7.6

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -11,8 +11,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/Sternrassler/eve-esi-client v0.5.1 h1:V1Qp/oUGGOgOFUP7Q+XhLeorTVnc/nPc5D8qKNsp7NQ=
-github.com/Sternrassler/eve-esi-client v0.5.1/go.mod h1:+FdYmvFXlzZjuE9wXRY/cRGesq9ruDpQZk7W5MlL4TE=
+github.com/Sternrassler/eve-esi-client v0.6.0 h1:q6A2MVvDlPEZBysJShv+Tq5T2t7CvPxPcfCADceccu8=
+github.com/Sternrassler/eve-esi-client v0.6.0/go.mod h1:+FdYmvFXlzZjuE9wXRY/cRGesq9ruDpQZk7W5MlL4TE=
 github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=


### PR DESCRIPTION
Bump auf eve-esi-client v0.6.0 ([Sternrassler/eve-esi-client#30](https://github.com/Sternrassler/eve-esi-client/pull/30)): Adoption des neuen CCP-Schemas — Token-Buckets pro Route-Gruppe (X-Ratelimit-*), proaktive Drossel bei knappem Budget, Retry-After-Respekt nach 429; Legacy-Error-Limit bleibt für nicht migrierte Routen aktiv. Kein API-Change im Backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)