### PR TITLE
chore(deps): eve-esi-client v0.7.0 — Fresh-Serve für ESI-Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **eve-esi-client v0.6.0 → v0.7.0: Fresh-Serve.** Frische ESI-Cache-Einträge (innerhalb des `Expires`-Fensters) werden jetzt ohne Netzwerk-Roundtrip direkt aus Redis serviert statt pro Lookup per Conditional Request (304) revalidiert zu werden; Caching strikt GET-only. Effekt: Wiederholungs-Berechnungen (Hauling/Mining/ROI) im 5-Minuten-Markt-Fenster laufen in Sekundenbruchteilen statt ~30 s, ESI-Last und Rate-Limit-Token-Verbrauch sinken deutlich. Details → eve-esi-client-CHANGELOG v0.7.0.
+
+
 ## [0.32.0] - 2026-06-07
 
 ### Changed

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.4
 
 require (
-	github.com/Sternrassler/eve-esi-client v0.6.0
+	github.com/Sternrassler/eve-esi-client v0.7.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/gofiber/fiber/v2 v2.52.12
 	github.com/jackc/pgx/v5 v5.7.6

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -11,8 +11,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/Sternrassler/eve-esi-client v0.6.0 h1:q6A2MVvDlPEZBysJShv+Tq5T2t7CvPxPcfCADceccu8=
-github.com/Sternrassler/eve-esi-client v0.6.0/go.mod h1:+FdYmvFXlzZjuE9wXRY/cRGesq9ruDpQZk7W5MlL4TE=
+github.com/Sternrassler/eve-esi-client v0.7.0 h1:GBd+2TrZQhJIjZneL5ed6sZZbdPqPYrrT1Tyl0RkaLk=
+github.com/Sternrassler/eve-esi-client v0.7.0/go.mod h1:+FdYmvFXlzZjuE9wXRY/cRGesq9ruDpQZk7W5MlL4TE=
 github.com/agiledragon/gomonkey/v2 v2.3.1/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
 github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=


### PR DESCRIPTION
Bump auf eve-esi-client v0.7.0 ([Sternrassler/eve-esi-client#31](https://github.com/Sternrassler/eve-esi-client/pull/31)): frische Cache-Einträge werden ohne Netzwerk-Roundtrip serviert (vorher 304-Revalidierung pro Lookup), Caching strikt GET-only. Erwartung: Warm-Berechnungen im 5-min-Markt-Fenster in Sekundenbruchteilen statt ~30 s. Kein API-Change im Backend; volle Testsuite grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)