### PR TITLE
fix(mining): Skills-/Standings-Degradation sichtbar statt stillem Fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mining: stille Skills-/Standings-Degradation jetzt sichtbar (no-silent-fallbacks).** Konnte das Erz-Ranking die Mining-/Reprocessing-Skills oder Standings nicht von ESI laden (z. B. abgelaufener Token), rechnete es **still** mit Null-Skills bzw. neutralen Standings weiter — der Owner sah massiv falsche ISK/h-/Yield-Werte ohne Hinweis (real: 3× Standings-401 am 2026-06-07). Die `OreRankingResponse` trägt jetzt `skills_degraded`/`standings_degraded` + eine erklärende `degraded_reason`; Web und Flutter zeigen einen Warn-Banner über der Tabelle (auch bei vorhandenen Zeilen). Das Ranking wird weiter geliefert, aber nicht mehr als verlässlich dargestellt. Spiegelt das `is_estimate`/`not_routable_reason`-Muster derselben Feature-Fläche.
+
+
 ## [0.33.0] - 2026-06-07
 
 ### Changed

--- a/app/lib/api/mining_models.dart
+++ b/app/lib/api/mining_models.dart
@@ -283,6 +283,9 @@ class OreRankingResponse {
     this.notAvailableReason,
     this.originSystemName,
     this.originStationName,
+    this.skillsDegraded = false,
+    this.standingsDegraded = false,
+    this.degradedReason,
   });
 
   /// Backend: `region_id`
@@ -310,6 +313,18 @@ class OreRankingResponse {
   /// Backend: `rows` — pre-sorted by best ISK/h desc.
   final List<OreRankRow> rows;
 
+  /// Backend: `skills_degraded` — true when mining/reprocessing skills could
+  /// not be loaded from ESI (ranking computed with null skills).
+  final bool skillsDegraded;
+
+  /// Backend: `standings_degraded` — true when standings could not be loaded
+  /// (ranking computed with neutral standings).
+  final bool standingsDegraded;
+
+  /// Backend: `degraded_reason` — human-readable explanation, set whenever
+  /// [skillsDegraded] or [standingsDegraded] is true.
+  final String? degradedReason;
+
   /// True when the ranked rows list is empty.
   bool get isEmpty => rows.isEmpty;
 
@@ -323,6 +338,9 @@ class OreRankingResponse {
       noMiningSetup: json['no_mining_setup'] as bool? ?? false,
       originSystemName: json['origin_system_name'] as String?,
       originStationName: json['origin_station_name'] as String?,
+      skillsDegraded: json['skills_degraded'] as bool? ?? false,
+      standingsDegraded: json['standings_degraded'] as bool? ?? false,
+      degradedReason: json['degraded_reason'] as String?,
       rows: rawRows
           .whereType<Map<String, dynamic>>()
           .map(OreRankRow.fromJson)

--- a/app/lib/features/mining/mining_screen.dart
+++ b/app/lib/features/mining/mining_screen.dart
@@ -180,9 +180,12 @@ class _ResultPane extends ConsumerWidget {
         if (result.isEmpty) {
           return const _EmptyResult();
         }
+        final degradedReason = result.degradedReason;
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (degradedReason != null && degradedReason.isNotEmpty)
+              _DegradedBanner(reason: degradedReason),
             Expanded(child: OreRankingTable(result: result)),
             const Padding(
               padding: EdgeInsets.only(top: 8),
@@ -335,6 +338,55 @@ class _NotAvailable extends StatelessWidget {
                     color:
                         Theme.of(context).colorScheme.onSurface.withAlpha(140),
                   ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Visible warning shown above the result list when the backend computed the
+/// ranking with degraded inputs (skills and/or standings could not be loaded).
+/// Unlike [_NotAvailable], this renders even when [rows] are present, so the
+/// numbers below are never mistaken for reliable values.
+class _DegradedBanner extends StatelessWidget {
+  const _DegradedBanner({required this.reason});
+
+  final String reason;
+
+  // Amber/orange — consistent with the ≈ estimate marker used elsewhere.
+  static const Color _warnColor = Color(0xFFFFB300);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      key: const Key('mining-degraded-banner'),
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: _warnColor.withAlpha(30),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: _warnColor.withAlpha(150)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Icon(
+              Icons.warning_amber_rounded,
+              size: 20,
+              color: _warnColor,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                reason,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                      fontWeight: FontWeight.w500,
+                    ),
+              ),
             ),
           ],
         ),

--- a/app/test/mining_models_test.dart
+++ b/app/test/mining_models_test.dart
@@ -334,5 +334,30 @@ void main() {
       expect(resp.isEmpty, isTrue);
       expect(resp.rows, isEmpty);
     });
+
+    test('degraded flags default to false / null when absent', () {
+      final resp = OreRankingResponse.fromJson(sample);
+      expect(resp.skillsDegraded, isFalse);
+      expect(resp.standingsDegraded, isFalse);
+      expect(resp.degradedReason, isNull);
+    });
+
+    test('degraded fields are parsed when present', () {
+      final resp = OreRankingResponse.fromJson(const {
+        'region_id': 10000002,
+        'no_mining_setup': false,
+        'skills_degraded': true,
+        'standings_degraded': true,
+        'degraded_reason':
+            'Skills und Standings konnten nicht von ESI geladen werden.',
+        'rows': [],
+      });
+      expect(resp.skillsDegraded, isTrue);
+      expect(resp.standingsDegraded, isTrue);
+      expect(
+        resp.degradedReason,
+        'Skills und Standings konnten nicht von ESI geladen werden.',
+      );
+    });
   });
 }

--- a/app/test/mining_screen_layout_test.dart
+++ b/app/test/mining_screen_layout_test.dart
@@ -126,6 +126,30 @@ OreRankingResponse _detailResponse() => const OreRankingResponse(
       ],
     );
 
+OreRankingResponse _degradedResponse() => const OreRankingResponse(
+      regionId: 10000002,
+      noMiningSetup: false,
+      skillsDegraded: true,
+      standingsDegraded: false,
+      degradedReason:
+          'Mining-Skills konnten nicht geladen werden — mit Null-Skills gerechnet.',
+      rows: [
+        OreRankRow(
+          oreTypeId: 1230,
+          oreName: 'Veldspar',
+          miningM3PerHour: 3600,
+          rawIskPerHour: 4200000,
+          refineIskPerHour: 5100000,
+          rawNetPerM3: 1166.67,
+          refineNetPerM3: 1416.67,
+          best: 'refine',
+          deltaIskPerHour: 900000,
+          bestStationId: 60003760,
+          bestStationTax: 0.05,
+        ),
+      ],
+    );
+
 OreRankingResponse _noSetupResponse() => const OreRankingResponse(
       regionId: 10000002,
       noMiningSetup: true,
@@ -159,6 +183,11 @@ class _StubNotifier extends OreRankingNotifier {
 class _DetailNotifier extends OreRankingNotifier {
   @override
   Future<OreRankingResponse?> build() async => _detailResponse();
+}
+
+class _DegradedNotifier extends OreRankingNotifier {
+  @override
+  Future<OreRankingResponse?> build() async => _degradedResponse();
 }
 
 class _NoSetupNotifier extends OreRankingNotifier {
@@ -263,6 +292,30 @@ void main() {
       findsOneWidget,
     );
     expect(find.byKey(const Key('mining-ore-table')), findsNothing);
+  });
+
+  testWidgets(
+      'Degraded result shows the warn banner above the ore table (rows present)',
+      (tester) async {
+    await _pumpScreen(tester, 1280, notifier: _DegradedNotifier.new);
+
+    // Banner is visible alongside the populated table.
+    expect(find.byKey(const Key('mining-degraded-banner')), findsOneWidget);
+    expect(
+      find.text(
+        'Mining-Skills konnten nicht geladen werden — mit Null-Skills gerechnet.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('mining-ore-table')), findsOneWidget);
+    expect(find.text('Veldspar'), findsOneWidget);
+  });
+
+  testWidgets('Non-degraded result does not show the warn banner',
+      (tester) async {
+    await _pumpScreen(tester, 1280);
+
+    expect(find.byKey(const Key('mining-degraded-banner')), findsNothing);
   });
 
   testWidgets('CurrentShipCard is shown at the top of the input form',

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1961,6 +1961,10 @@ const docTemplate = `{
         "models.OreRankingResponse": {
             "type": "object",
             "properties": {
+                "degraded_reason": {
+                    "description": "human-readable explanation when either flag is set",
+                    "type": "string"
+                },
                 "no_mining_setup": {
                     "type": "boolean"
                 },
@@ -1992,6 +1996,13 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/models.OreRankRow"
                     }
+                },
+                "skills_degraded": {
+                    "description": "Degradation flags: true when the named ESI input could not be fetched\n(e.g. expired token) and a neutral fallback was used. The ranking is still\nreturned but the numbers are less accurate — the UI must surface this\ninstead of presenting degraded results as authoritative.",
+                    "type": "boolean"
+                },
+                "standings_degraded": {
+                    "type": "boolean"
                 },
                 "system_security": {
                     "description": "current system, displayed sec",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1955,6 +1955,10 @@
         "models.OreRankingResponse": {
             "type": "object",
             "properties": {
+                "degraded_reason": {
+                    "description": "human-readable explanation when either flag is set",
+                    "type": "string"
+                },
                 "no_mining_setup": {
                     "type": "boolean"
                 },
@@ -1986,6 +1990,13 @@
                     "items": {
                         "$ref": "#/definitions/models.OreRankRow"
                     }
+                },
+                "skills_degraded": {
+                    "description": "Degradation flags: true when the named ESI input could not be fetched\n(e.g. expired token) and a neutral fallback was used. The ranking is still\nreturned but the numbers are less accurate — the UI must surface this\ninstead of presenting degraded results as authoritative.",
+                    "type": "boolean"
+                },
+                "standings_degraded": {
+                    "type": "boolean"
                 },
                 "system_security": {
                     "description": "current system, displayed sec",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -599,6 +599,9 @@ definitions:
     type: object
   models.OreRankingResponse:
     properties:
+      degraded_reason:
+        description: human-readable explanation when either flag is set
+        type: string
       no_mining_setup:
         type: boolean
       not_available_reason:
@@ -622,6 +625,15 @@ definitions:
         items:
           $ref: '#/definitions/models.OreRankRow'
         type: array
+      skills_degraded:
+        description: |-
+          Degradation flags: true when the named ESI input could not be fetched
+          (e.g. expired token) and a neutral fallback was used. The ranking is still
+          returned but the numbers are less accurate — the UI must surface this
+          instead of presenting degraded results as authoritative.
+        type: boolean
+      standings_degraded:
+        type: boolean
       system_security:
         description: current system, displayed sec
         type: number

--- a/backend/internal/models/mining.go
+++ b/backend/internal/models/mining.go
@@ -66,13 +66,20 @@ type OreRankRow struct {
 // NoMiningSetup is true when the active ship has no mining modules (per-m³ values are
 // still populated; isk/h is 0). Rows is always non-nil (never JSON null).
 type OreRankingResponse struct {
-	RegionID           int          `json:"region_id"`
-	OriginSystemID     int64        `json:"origin_system_id,omitempty"`    // character's current system (ranking origin)
-	OriginSystemName   string       `json:"origin_system_name,omitempty"`  // resolved name of the current system
-	OriginStationName  string       `json:"origin_station_name,omitempty"` // docked station name, if any
-	SystemSecurity     float64      `json:"system_security,omitempty"`     // current system, displayed sec
-	Quarter            string       `json:"quarter,omitempty"`             // amarr|caldari|gallente|minmatar|""
-	NoMiningSetup      bool         `json:"no_mining_setup"`
-	NotAvailableReason string       `json:"not_available_reason,omitempty"` // set when no ores apply here
-	Rows               []OreRankRow `json:"rows"`
+	RegionID           int     `json:"region_id"`
+	OriginSystemID     int64   `json:"origin_system_id,omitempty"`    // character's current system (ranking origin)
+	OriginSystemName   string  `json:"origin_system_name,omitempty"`  // resolved name of the current system
+	OriginStationName  string  `json:"origin_station_name,omitempty"` // docked station name, if any
+	SystemSecurity     float64 `json:"system_security,omitempty"`     // current system, displayed sec
+	Quarter            string  `json:"quarter,omitempty"`             // amarr|caldari|gallente|minmatar|""
+	NoMiningSetup      bool    `json:"no_mining_setup"`
+	NotAvailableReason string  `json:"not_available_reason,omitempty"` // set when no ores apply here
+	// Degradation flags: true when the named ESI input could not be fetched
+	// (e.g. expired token) and a neutral fallback was used. The ranking is still
+	// returned but the numbers are less accurate — the UI must surface this
+	// instead of presenting degraded results as authoritative.
+	SkillsDegraded    bool         `json:"skills_degraded"`
+	StandingsDegraded bool         `json:"standings_degraded"`
+	DegradedReason    string       `json:"degraded_reason,omitempty"` // human-readable explanation when either flag is set
+	Rows              []OreRankRow `json:"rows"`
 }

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -155,11 +155,14 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	// 3. Skills + standings + sales tax + mining rate.
 	skills, err := s.skills.GetMiningReprocessingSkills(ctx, s.sdeDB, characterID, accessToken)
 	if err != nil {
-		// Degrade to zero skills (still rank ores) but log loudly.
+		// Degrade to zero skills (still rank ores) but log loudly AND flag it on
+		// the response — a silent zero-skills fallback would present wildly wrong
+		// yields as authoritative (no-silent-fallbacks).
 		if s.logger != nil {
 			s.logger.Warn("ore ranking: mining skills unavailable, using zero skills", "error", err)
 		}
 		skills = &MiningReprocessingSkills{OreProcessing: map[int64]int{}}
+		resp.SkillsDegraded = true
 	}
 	standings, err := s.skills.GetCharacterStandings(ctx, characterID, accessToken)
 	if err != nil {
@@ -167,7 +170,9 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 			s.logger.Warn("ore ranking: standings unavailable, using neutral", "error", err)
 		}
 		standings = map[int64]float64{}
+		resp.StandingsDegraded = true
 	}
+	resp.DegradedReason = miningDegradedReason(resp.SkillsDegraded, resp.StandingsDegraded)
 	salesTaxRate := SalesTaxRate(skills.Accounting)
 
 	moduleIDs, err := s.fitting.ActiveShipFittedModuleTypeIDs(ctx, characterID, accessToken)
@@ -718,4 +723,20 @@ func (s *MiningService) travelSecs(from, to int64, params *navigation.Navigation
 	}
 	memo[key] = r
 	return r.TotalSeconds, r.Jumps, true
+}
+
+// miningDegradedReason builds a human-readable explanation when mining skills
+// and/or standings could not be fetched and neutral fallbacks were used. Empty
+// string when nothing is degraded.
+func miningDegradedReason(skillsDegraded, standingsDegraded bool) string {
+	switch {
+	case skillsDegraded && standingsDegraded:
+		return "Skills und Standings konnten nicht von ESI geladen werden (Login/Token prüfen) — gerechnet mit Null-Skills und neutralen Standings. ISK/h und Reprocessing-Werte sind nur grobe Untergrenzen."
+	case skillsDegraded:
+		return "Mining-/Reprocessing-Skills konnten nicht von ESI geladen werden (Login/Token prüfen) — gerechnet mit Null-Skills. ISK/h und Mengen sind eine grobe Untergrenze."
+	case standingsDegraded:
+		return "Standings konnten nicht von ESI geladen werden (Login/Token prüfen) — gerechnet mit neutralen Standings. Die Reprocessing-Steuer kann in Wirklichkeit niedriger sein."
+	default:
+		return ""
+	}
 }

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/Sternrassler/eve-o-provit/backend/internal/database"
@@ -13,6 +14,9 @@ import (
 	"github.com/Sternrassler/eve-o-provit/backend/pkg/logger"
 	_ "github.com/mattn/go-sqlite3"
 )
+
+// errESI is a sentinel for simulating an ESI fetch failure (e.g. expired token).
+var errESI = fmt.Errorf("esi unavailable (401)")
 
 // --- Fakes ---------------------------------------------------------------
 
@@ -105,16 +109,25 @@ func (f *fakeMiningModules) GetShipFitting(_ context.Context, _, _ int, _ string
 }
 
 // fakeMiningSkillsProvider implements MiningSkillsProvider with fixed skills + standings.
+// skillsErr/standingsErr exercise the degradation (fail-loud) path.
 type fakeMiningSkillsProvider struct {
-	skills    *MiningReprocessingSkills
-	standings map[int64]float64
+	skills       *MiningReprocessingSkills
+	standings    map[int64]float64
+	skillsErr    error
+	standingsErr error
 }
 
 func (f *fakeMiningSkillsProvider) GetMiningReprocessingSkills(_ context.Context, _ *sql.DB, _ int, _ string) (*MiningReprocessingSkills, error) {
+	if f.skillsErr != nil {
+		return nil, f.skillsErr
+	}
 	return f.skills, nil
 }
 
 func (f *fakeMiningSkillsProvider) GetCharacterStandings(_ context.Context, _ int, _ string) (map[int64]float64, error) {
+	if f.standingsErr != nil {
+		return nil, f.standingsErr
+	}
 	return f.standings, nil
 }
 
@@ -673,3 +686,94 @@ func TestMiningService_OreRanking_MarketLoadsCap(t *testing.T) {
 }
 
 func approxEq(a, b float64) bool { return math.Abs(a-b) < 1e-6 }
+
+// TestMiningService_OreRanking_DegradedFlags verifies the response flags + reason
+// when skills/standings can't be fetched from ESI (e.g. expired token). The ranking
+// is still produced, but the degradation must be surfaced (no silent fallback).
+func TestMiningService_OreRanking_DegradedFlags(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	market := &fakeMiningMarket{buyPriceByType: map[int]float64{
+		veldsparTypeID:  15.0,
+		tritaniumTypeID: 5.0,
+	}}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	stations := &fakeStations{stations: []database.ReprocessStation{
+		{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05},
+	}}
+	loc := fakeMiningLocation{shipTypeID: 22544}
+
+	cases := []struct {
+		name           string
+		skillsErr      error
+		standingsErr   error
+		wantSkills     bool
+		wantStandings  bool
+		reasonContains string
+	}{
+		{"both", errESI, errESI, true, true, "Skills und Standings"},
+		{"skills only", errESI, nil, true, false, "Skills konnten nicht"},
+		{"standings only", nil, errESI, false, true, "Standings konnten nicht"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			skills := &fakeMiningSkillsProvider{
+				skills: &MiningReprocessingSkills{
+					OreProcessing: map[int64]int{},
+					SkillLevels:   map[int64]int{17940: 5, 22551: 5},
+				},
+				standings:    map[int64]float64{},
+				skillsErr:    tc.skillsErr,
+				standingsErr: tc.standingsErr,
+			}
+			svc := NewMiningService(sdeDB, stations, market, skills, fitting, loc, nil, fakeMiningNames{}, logger.NewNoop())
+
+			resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{RegionID: 10000002})
+			if err != nil {
+				t.Fatalf("OreRanking error: %v", err)
+			}
+			if resp.SkillsDegraded != tc.wantSkills {
+				t.Errorf("SkillsDegraded = %v, want %v", resp.SkillsDegraded, tc.wantSkills)
+			}
+			if resp.StandingsDegraded != tc.wantStandings {
+				t.Errorf("StandingsDegraded = %v, want %v", resp.StandingsDegraded, tc.wantStandings)
+			}
+			if resp.DegradedReason == "" {
+				t.Fatal("DegradedReason must be set when degraded")
+			}
+			if !strings.Contains(resp.DegradedReason, tc.reasonContains) {
+				t.Errorf("DegradedReason = %q, want substring %q", resp.DegradedReason, tc.reasonContains)
+			}
+			// Ranking still produced despite degradation.
+			if len(resp.Rows) == 0 {
+				t.Error("expected ranking rows even when degraded")
+			}
+		})
+	}
+}
+
+// TestMiningService_OreRanking_NotDegradedByDefault guards against false positives:
+// a healthy fetch must leave the flags clear and the reason empty.
+func TestMiningService_OreRanking_NotDegradedByDefault(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	market := &fakeMiningMarket{buyPriceByType: map[int]float64{veldsparTypeID: 15.0, tritaniumTypeID: 5.0}}
+	skills := &fakeMiningSkillsProvider{
+		skills:    &MiningReprocessingSkills{OreProcessing: map[int64]int{}, SkillLevels: map[int64]int{17940: 5, 22551: 5}},
+		standings: map[int64]float64{},
+	}
+	fitting := &fakeMiningModules{ids: []int64{stripMinerITypeID}}
+	stations := &fakeStations{stations: []database.ReprocessStation{{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05}}}
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, fakeMiningLocation{shipTypeID: 22544}, nil, fakeMiningNames{}, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{RegionID: 10000002})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+	if resp.SkillsDegraded || resp.StandingsDegraded || resp.DegradedReason != "" {
+		t.Errorf("healthy fetch must not be degraded: skills=%v standings=%v reason=%q",
+			resp.SkillsDegraded, resp.StandingsDegraded, resp.DegradedReason)
+	}
+}

--- a/frontend/src/app/mining/page.tsx
+++ b/frontend/src/app/mining/page.tsx
@@ -149,6 +149,16 @@ function MiningPageContent() {
                   </AlertDescription>
                 </Alert>
               )}
+              {miningMutation.data.degraded_reason && (
+                <div
+                  role="alert"
+                  data-testid="mining-degraded-banner"
+                  className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200"
+                >
+                  <p className="font-medium">Eingeschränkte Datenlage</p>
+                  <p className="mt-1">{miningMutation.data.degraded_reason}</p>
+                </div>
+              )}
               {miningMutation.data.not_available_reason && miningMutation.data.rows.length === 0 && (
                 <Alert>
                   <AlertTitle>Keine Daten verfügbar</AlertTitle>

--- a/frontend/src/types/trading.ts
+++ b/frontend/src/types/trading.ts
@@ -375,6 +375,13 @@ export interface OreRankingResponse {
   system_security?: number;
   quarter?: string;
   not_available_reason?: string;
+  /** true when mining/reprocessing skills could not be loaded from ESI and
+   *  null skills were assumed — results are a lower bound. */
+  skills_degraded?: boolean;
+  /** true when standings could not be loaded and neutral standings were assumed. */
+  standings_degraded?: boolean;
+  /** Human-readable explanation, set whenever a degraded flag is true. */
+  degraded_reason?: string;
   no_mining_setup: boolean;
   rows: OreRankRow[];
 }

--- a/frontend/tests/lib/api-client-mining.test.ts
+++ b/frontend/tests/lib/api-client-mining.test.ts
@@ -52,6 +52,42 @@ describe("fetchOreRanking", () => {
     expect(result.rows[1].ore_name).toBe("Scordite");
   });
 
+  it("passes degraded flags and reason through so the UI can warn", async () => {
+    mockJson({
+      region_id: 10000002,
+      quarter: "caldari",
+      system_security: 0.9,
+      no_mining_setup: false,
+      skills_degraded: true,
+      standings_degraded: false,
+      degraded_reason: "Skills konnten nicht von ESI geladen werden — mit Null-Skills gerechnet.",
+      rows: [makeRow()],
+    });
+
+    const result = await fetchOreRanking({ region_id: 0, allow_low_sec: false });
+
+    expect(result.skills_degraded).toBe(true);
+    expect(result.standings_degraded).toBe(false);
+    expect(result.degraded_reason).toMatch(/Null-Skills/);
+    expect(result.rows).toHaveLength(1);
+  });
+
+  it("leaves degraded fields undefined when the backend omits them", async () => {
+    mockJson({
+      region_id: 10000002,
+      quarter: "caldari",
+      system_security: 0.9,
+      no_mining_setup: false,
+      rows: [makeRow()],
+    });
+
+    const result = await fetchOreRanking({ region_id: 0, allow_low_sec: false });
+
+    expect(result.degraded_reason).toBeUndefined();
+    expect(result.skills_degraded).toBeUndefined();
+    expect(result.standings_degraded).toBeUndefined();
+  });
+
   it("throws when the response is not ok", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ error: "unauthorized" }), {


### PR DESCRIPTION
**/brain-review-Vorschlag (no-silent-fallbacks):** Das Erz-Ranking rechnete bei ESI-Fehlern (abgelaufener Token) still mit Null-Skills bzw. neutralen Standings weiter — nur Server-Log, Response unmarkiert. Folge: am 2026-06-07 sah der Owner nach 3× Standings-401 ein Ranking mit massiv falschen ISK/h-/Yield-Werten ohne Hinweis.

## Änderung
- **Backend:** `OreRankingResponse` trägt `skills_degraded` / `standings_degraded` (bool) + `degraded_reason` (erklärender Text, gesetzt sobald ein Flag true ist). Das Ranking wird weiter geliefert (Degradation ≠ fatal), aber markiert.
- **Web + Flutter:** Warn-Banner (amber) über der Ergebnis-Tabelle, sobald `degraded_reason` gesetzt ist — auch bei vorhandenen Zeilen (anders als `not_available_reason`, das nur bei leerer Liste greift).
- Spiegelt das bestehende `is_estimate`/`not_routable_reason`-Muster derselben Feature-Fläche.

## Tests
- Backend (TDD): Degraded-Flags je Quelle (both/skills/standings) + Not-Degraded-Guard.
- Web: api-client-Passthrough der 3 Felder (gesetzt + abwesend); vitest 104/104.
- Flutter: fromJson-Parsing + Widget-Tests (Banner erscheint bei degradedReason, fehlt sonst); flutter test 238 grün, analyze clean.

Ausführung: Backend selbst TDD, Web+Flutter als parallele Subagenten gegen den gelockten Vertrag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)