### PR TITLE
ci: Docker-Hub-Base-Image-Pulls härten (alpine pinnen + optionaler DH-Login)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,9 +30,23 @@ env:
 jobs:
   build-push:
     runs-on: ubuntu-latest
+    # Presence flag for the optional Docker Hub login below (secrets aren't
+    # allowed in step `if:` directly, so surface it as a job env boolean).
+    env:
+      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+      # Authenticate to Docker Hub to lift the anonymous pull rate limit on
+      # shared GH runners (the base-image pull that timed out the v0.34.0 deploy:
+      # registry-1.docker.io context deadline exceeded). No-op until the
+      # DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets are set.
+      - name: Log in to Docker Hub (optional, raises base-image pull limit)
+        if: ${{ env.HAS_DOCKERHUB == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -62,9 +76,17 @@ jobs:
 
   build-push-frontend:
     runs-on: ubuntu-latest
+    env:
+      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub (optional, raises base-image pull limit)
+        if: ${{ env.HAS_DOCKERHUB == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI/Build härtet die Docker-Hub-Abhängigkeit.** Base-Image `alpine:latest` → `alpine:3.21` gepinnt (reproduzierbare Builds); `deploy.yml` loggt sich optional bei Docker Hub ein (hebt das Anonymous-Pull-Rate-Limit auf Shared-GH-Runnern, das den v0.34.0-Deploy mit `registry-1.docker.io context deadline exceeded` riss) — no-op bis `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`-Secrets gesetzt sind.
+
+
 ## [0.34.0] - 2026-06-08
 
 ### Fixed

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,8 +20,8 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo \
 	-ldflags "-X github.com/Sternrassler/eve-o-provit/backend/internal/version.Version=${APP_VERSION}" \
 	-o api ./cmd/api
 
-# Runtime stage
-FROM alpine:latest
+# Runtime stage — pinned (not :latest) for reproducible builds.
+FROM alpine:3.21
 
 RUN apk --no-cache add ca-certificates sqlite-libs wget
 


### PR DESCRIPTION
**/brain-review-Vorschlag 2:** Der v0.34.0-Deploy scheiterte an einem transienten Docker-Hub-Timeout beim Base-Image-Pull (`registry-1.docker.io context deadline exceeded`) und musste manuell per `gh run rerun --failed` wiederholt werden.

- **`alpine:latest` → `alpine:3.21`** gepinnt (reproduzierbare Builds; widersprach dem Reproduzierbarkeits-Prinzip).
- **Optionaler Docker-Hub-Login** in beide Build-Jobs (`build-push` + `build-push-frontend`): hebt das Anonymous-Pull-Rate-Limit auf Shared-GH-Runnern (der eigentliche Throttle-Fix). Secret-guarded via Job-Env `HAS_DOCKERHUB` → **no-op, bis `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` gesetzt sind** (kein Risiko für den bestehenden Deploy-Flow).
- Spiegelbild ins hetzner `release.yml`-Template (separater PR) → alle App-Repos.

## Handoff (zum Voll-Aktivieren)

Repo-Secrets `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (Docker-Hub-Account + Read-only-PAT) setzen — dann greift der authentifizierte Pull. Der alpine-Pin wirkt sofort; ohne Secret bleibt nur der seltene Throttle (per rerun abgefangen).

Validierung: beide Workflow-YAMLs parsen sauber, kein `alpine:latest` mehr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)