### PR TITLE
fix(mining): Fitting-Abruf-Fehler nicht als kein-Mining-Setup fehldeuten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mining: transienter Fitting-Abruf-Fehler wird nicht mehr als „kein Mining-Setup" fehlinterpretiert.** Schlug der ESI-Abruf des aktuellen Schiffs/der Module fehl, wurde still mit `moduleIDs=nil` weitergerechnet → `m3h=0` → `no_mining_setup=true`, also „du hast kein Mining-Schiff" statt „ESI-Hiccup". Jetzt: neues `fitting_degraded`-Flag, `no_mining_setup` wird nur noch bei **erfolgreichem** Abruf mit 0 m³/h gesetzt, und der Grund landet in `degraded_reason` (Banner zeigt ihn automatisch). Letzte verbliebene Silent-Fallback-Stelle im Mining-Pfad, Prinzip [[no-silent-fallbacks]]. `degraded_reason` ist jetzt kompositorisch (Skills/Standings/Fitting in einer Meldung).
+
+
 ### Changed
 
 - **CI/Build härtet die Docker-Hub-Abhängigkeit.** Base-Image `alpine:latest` → `alpine:3.21` gepinnt (reproduzierbare Builds); `deploy.yml` loggt sich optional bei Docker Hub ein (hebt das Anonymous-Pull-Rate-Limit auf Shared-GH-Runnern, das den v0.34.0-Deploy mit `registry-1.docker.io context deadline exceeded` riss) — no-op bis `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`-Secrets gesetzt sind.

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1962,8 +1962,12 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "degraded_reason": {
-                    "description": "human-readable explanation when either flag is set",
+                    "description": "human-readable explanation when any flag is set",
                     "type": "string"
+                },
+                "fitting_degraded": {
+                    "description": "active-ship/modules fetch failed → m3h unreliable, NoMiningSetup not asserted",
+                    "type": "boolean"
                 },
                 "no_mining_setup": {
                     "type": "boolean"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1956,8 +1956,12 @@
             "type": "object",
             "properties": {
                 "degraded_reason": {
-                    "description": "human-readable explanation when either flag is set",
+                    "description": "human-readable explanation when any flag is set",
                     "type": "string"
+                },
+                "fitting_degraded": {
+                    "description": "active-ship/modules fetch failed → m3h unreliable, NoMiningSetup not asserted",
+                    "type": "boolean"
                 },
                 "no_mining_setup": {
                     "type": "boolean"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -600,8 +600,12 @@ definitions:
   models.OreRankingResponse:
     properties:
       degraded_reason:
-        description: human-readable explanation when either flag is set
+        description: human-readable explanation when any flag is set
         type: string
+      fitting_degraded:
+        description: active-ship/modules fetch failed → m3h unreliable, NoMiningSetup
+          not asserted
+        type: boolean
       no_mining_setup:
         type: boolean
       not_available_reason:

--- a/backend/internal/models/mining.go
+++ b/backend/internal/models/mining.go
@@ -80,6 +80,7 @@ type OreRankingResponse struct {
 	// instead of presenting degraded results as authoritative.
 	SkillsDegraded    bool         `json:"skills_degraded"`
 	StandingsDegraded bool         `json:"standings_degraded"`
-	DegradedReason    string       `json:"degraded_reason,omitempty"` // human-readable explanation when either flag is set
+	FittingDegraded   bool         `json:"fitting_degraded"`          // active-ship/modules fetch failed → m3h unreliable, NoMiningSetup not asserted
+	DegradedReason    string       `json:"degraded_reason,omitempty"` // human-readable explanation when any flag is set
 	Rows              []OreRankRow `json:"rows"`
 }

--- a/backend/internal/services/mining_service.go
+++ b/backend/internal/services/mining_service.go
@@ -172,15 +172,17 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 		standings = map[int64]float64{}
 		resp.StandingsDegraded = true
 	}
-	resp.DegradedReason = miningDegradedReason(resp.SkillsDegraded, resp.StandingsDegraded)
 	salesTaxRate := SalesTaxRate(skills.Accounting)
 
 	moduleIDs, err := s.fitting.ActiveShipFittedModuleTypeIDs(ctx, characterID, accessToken)
+	fittingFetchFailed := false
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warn("ore ranking: active-ship modules unavailable", "error", err)
 		}
 		moduleIDs = nil
+		fittingFetchFailed = true
+		resp.FittingDegraded = true
 	}
 	m3h, err := mining.MiningRateM3PerHour(s.sdeDB, moduleIDs, mining.MiningSkills{
 		Mining:       skills.Mining,
@@ -189,9 +191,13 @@ func (s *MiningService) OreRanking(ctx context.Context, characterID int, accessT
 	if err != nil {
 		return nil, err
 	}
-	if m3h == 0 {
+	// m3h == 0 nur dann als "kein Mining-Setup" werten, wenn der Fitting-Abruf
+	// auch wirklich gelang — sonst ist die 0 ein Artefakt des ESI-Fehlers
+	// (transienter Hiccup darf nicht als "du hast kein Mining-Schiff" erscheinen).
+	if m3h == 0 && !fittingFetchFailed {
 		resp.NoMiningSetup = true
 	}
+	resp.DegradedReason = miningDegradedReason(resp.SkillsDegraded, resp.StandingsDegraded, resp.FittingDegraded)
 
 	// Hull ore-mining-yield bonus (role + per-skill-level), applied to every ore.
 	// hullResolved starts false: if the active ship can't be resolved it stays false,
@@ -728,15 +734,19 @@ func (s *MiningService) travelSecs(from, to int64, params *navigation.Navigation
 // miningDegradedReason builds a human-readable explanation when mining skills
 // and/or standings could not be fetched and neutral fallbacks were used. Empty
 // string when nothing is degraded.
-func miningDegradedReason(skillsDegraded, standingsDegraded bool) string {
-	switch {
-	case skillsDegraded && standingsDegraded:
-		return "Skills und Standings konnten nicht von ESI geladen werden (Login/Token prüfen) — gerechnet mit Null-Skills und neutralen Standings. ISK/h und Reprocessing-Werte sind nur grobe Untergrenzen."
-	case skillsDegraded:
-		return "Mining-/Reprocessing-Skills konnten nicht von ESI geladen werden (Login/Token prüfen) — gerechnet mit Null-Skills. ISK/h und Mengen sind eine grobe Untergrenze."
-	case standingsDegraded:
-		return "Standings konnten nicht von ESI geladen werden (Login/Token prüfen) — gerechnet mit neutralen Standings. Die Reprocessing-Steuer kann in Wirklichkeit niedriger sein."
-	default:
+func miningDegradedReason(skillsDegraded, standingsDegraded, fittingDegraded bool) string {
+	var parts []string
+	if skillsDegraded {
+		parts = append(parts, "Mining-/Reprocessing-Skills (gerechnet mit Null-Skills; ISK/h und Mengen nur grobe Untergrenze)")
+	}
+	if standingsDegraded {
+		parts = append(parts, "Standings (gerechnet mit neutralen Standings; Reprocessing-Steuer ggf. zu hoch angesetzt)")
+	}
+	if fittingDegraded {
+		parts = append(parts, "aktuelles Schiff/Module (ISK/h evtl. 0; ein etwaiges \"kein Mining-Setup\" ist hier ungewiss, nicht bestätigt)")
+	}
+	if len(parts) == 0 {
 		return ""
 	}
+	return "Konnte nicht von ESI laden (Login/Token prüfen): " + strings.Join(parts, "; ") + "."
 }

--- a/backend/internal/services/mining_service_test.go
+++ b/backend/internal/services/mining_service_test.go
@@ -98,9 +98,15 @@ func (f *fakeStations) GetRegionReprocessStations(_ context.Context, _ int) ([]d
 	return f.stations, nil
 }
 
-type fakeMiningModules struct{ ids []int64 }
+type fakeMiningModules struct {
+	ids        []int64
+	modulesErr error // when set, ActiveShipFittedModuleTypeIDs fails (exercise fitting-degraded path)
+}
 
 func (f *fakeMiningModules) ActiveShipFittedModuleTypeIDs(_ context.Context, _ int, _ string) ([]int64, error) {
+	if f.modulesErr != nil {
+		return nil, f.modulesErr
+	}
 	return f.ids, nil
 }
 
@@ -712,9 +718,9 @@ func TestMiningService_OreRanking_DegradedFlags(t *testing.T) {
 		wantStandings  bool
 		reasonContains string
 	}{
-		{"both", errESI, errESI, true, true, "Skills und Standings"},
-		{"skills only", errESI, nil, true, false, "Skills konnten nicht"},
-		{"standings only", nil, errESI, false, true, "Standings konnten nicht"},
+		{"both", errESI, errESI, true, true, "Mining-/Reprocessing-Skills"},
+		{"skills only", errESI, nil, true, false, "Mining-/Reprocessing-Skills"},
+		{"standings only", nil, errESI, false, true, "Standings"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -775,5 +781,40 @@ func TestMiningService_OreRanking_NotDegradedByDefault(t *testing.T) {
 	if resp.SkillsDegraded || resp.StandingsDegraded || resp.DegradedReason != "" {
 		t.Errorf("healthy fetch must not be degraded: skills=%v standings=%v reason=%q",
 			resp.SkillsDegraded, resp.StandingsDegraded, resp.DegradedReason)
+	}
+}
+
+// TestMiningService_OreRanking_FittingFetchDegraded: schlägt der Fitting-Abruf
+// fehl (transienter ESI-Fehler), darf das NICHT als "kein Mining-Setup"
+// erscheinen — stattdessen FittingDegraded + Reason, NoMiningSetup bleibt false.
+func TestMiningService_OreRanking_FittingFetchDegraded(t *testing.T) {
+	sdeDB := testutil.OpenTestDB(t)
+	defer func() { _ = sdeDB.Close() }()
+
+	market := &fakeMiningMarket{buyPriceByType: map[int]float64{veldsparTypeID: 15.0, tritaniumTypeID: 5.0}}
+	skills := &fakeMiningSkillsProvider{
+		skills:    &MiningReprocessingSkills{OreProcessing: map[int64]int{}, SkillLevels: map[int64]int{17940: 5, 22551: 5}},
+		standings: map[int64]float64{},
+	}
+	// Fitting-Abruf scheitert → moduleIDs nil → m3h 0, aber NICHT als no-setup werten.
+	fitting := &fakeMiningModules{modulesErr: errESI}
+	stations := &fakeStations{stations: []database.ReprocessStation{{StationID: 60000001, OwnerCorpID: 1000035, BaseRate: 0.50, BaseTake: 0.05}}}
+	svc := NewMiningService(sdeDB, stations, market, skills, fitting, fakeMiningLocation{shipTypeID: 22544}, nil, fakeMiningNames{}, logger.NewNoop())
+
+	resp, err := svc.OreRanking(context.Background(), 42, "token", models.OreRankingRequest{RegionID: 10000002})
+	if err != nil {
+		t.Fatalf("OreRanking error: %v", err)
+	}
+	if !resp.FittingDegraded {
+		t.Error("FittingDegraded must be true when the active-ship/modules fetch fails")
+	}
+	if resp.NoMiningSetup {
+		t.Error("NoMiningSetup must NOT be asserted on a fitting-fetch error (ESI hiccup != no mining ship)")
+	}
+	if !strings.Contains(resp.DegradedReason, "Schiff/Module") {
+		t.Errorf("DegradedReason must mention the ship/modules degradation, got %q", resp.DegradedReason)
+	}
+	if len(resp.Rows) == 0 {
+		t.Error("ranking rows must still be produced (per-m³ values are independent of m3h)")
 	}
 }


### PR DESCRIPTION
**/brain-review-Vorschlag 4 (letzter):** Schlug der ESI-Abruf des aktuellen Schiffs/der Module fehl, wurde still mit `moduleIDs=nil` weitergerechnet → `m3h=0` → `no_mining_setup=true` — ein transienter ESI-Hiccup sah aus wie „du hast kein Mining-Schiff". Dieselbe Silent-Fallback-Klasse wie der heutige Skills/Standings-Fix, an der Schwester-Stelle übersehen.

- Neues `fitting_degraded`-Flag; `no_mining_setup` wird nur noch bei **erfolgreichem** Fitting-Abruf mit 0 m³/h gesetzt.
- Grund landet im (jetzt kompositorischen) `degraded_reason` — der bestehende Web/Flutter-Banner rendert ihn automatisch, **keine Frontend-Änderung nötig** (Banner hängt am `degraded_reason`-Text).

## Tests
- Backend: neuer Fall (Fitting-Fehler → `fitting_degraded`, `no_mining_setup`=false, Reason nennt Schiff/Module, Ranking-Zeilen bleiben); bestehende Degraded-Tests auf den kompositorischen Reason angepasst. `go test ./...` grün, golangci-lint 0 Issues, swagger regeneriert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
