### PR TITLE
fix(frontend): patch React2Shell RCE — Next.js 16.0.0→16.0.11 (CVE-2025-66478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Next.js 16.0.0 → 16.0.11 — schließt die RCE „React2Shell" (CVE-2025-55182 / CVE-2025-66478, CVSS 10.0).** Pre-Auth-RCE via RSC/Flight-Deserialisierung; am 2026-06-17 in Produktion ausgenutzt, um im Frontend-Container einen Cryptominer (`/tmp/XXcaLafo`, XMRig) zu starten, der den Host 17h auslastete (Incident-Doku im hetzner-Repo). 16.0.11 enthält den Fix aus 16.0.7 plus spätere Patches (gleiche Minor → minimales Breaking-Risiko). `npm run build` grün (14 Routen), 104/104 Unit-Tests grün. **Hinweis:** das Frontend wurde seit dem Incident bewusst gestoppt — dieser Release bringt es gepatcht zurück.
+
 ## [0.35.0] - 2026-06-08
 
 ### Fixed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.548.0",
-        "next": "16.0.0",
+        "next": "16.0.11",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "tailwind-merge": "^3.3.1"
@@ -40,7 +40,7 @@
         "@vitest/coverage-v8": "^4.0.7",
         "@vitest/ui": "^4.0.7",
         "eslint": "^9",
-        "eslint-config-next": "16.0.0",
+        "eslint-config-next": "16.0.11",
         "jsdom": "^27.1.0",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
@@ -1771,15 +1771,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.0.tgz",
-      "integrity": "sha512-s5j2iFGp38QsG1LWRQaE2iUY3h1jc014/melHFfLdrsMJPqxqDQwWNwyQTcNoUSGZlCVZuM7t7JDMmSyRilsnA==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.11.tgz",
+      "integrity": "sha512-hULMheQaOhFK1vAoFPigXca42LguwyLILtJKPRzpY1d+og6jk0YNAQVwLGNYYhWEMd2zj4gcIWSf1yC5PffqqA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.0.0.tgz",
-      "integrity": "sha512-IB7RzmmtrPOrpAgEBR1PIQPD0yea5lggh5cq54m51jHjjljU80Ia+czfxJYMlSDl1DPvpzb8S9TalCc0VMo9Hw==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.0.11.tgz",
+      "integrity": "sha512-aqyGPoeZwo2+iVRq+c9RSHuzWF+P5WHo3PZNt6I/baP1JeL7sJk8ut3pJyTd/WKquQ3B6CHMLX6YrmB5Iug5DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1787,9 +1787,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.0.tgz",
-      "integrity": "sha512-/CntqDCnk5w2qIwMiF0a9r6+9qunZzFmU0cBX4T82LOflE72zzH6gnOjCwUXYKOBlQi8OpP/rMj8cBIr18x4TA==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.11.tgz",
+      "integrity": "sha512-3G7Rx6m6tgLqkc3Ce3QY/Yrsx7nJF4ithdHfx70Jmzel8m2xpjnGRC+oB4UcCHvQwN0ZP5YsLJakwx/M0vWbSQ==",
       "cpu": [
         "arm64"
       ],
@@ -1803,9 +1803,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.0.tgz",
-      "integrity": "sha512-hB4GZnJGKa8m4efvTGNyii6qs76vTNl+3dKHTCAUaksN6KjYy4iEO3Q5ira405NW2PKb3EcqWiRaL9DrYJfMHg==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.11.tgz",
+      "integrity": "sha512-poUTsYKRwuG+eApDngouEiN6AGcAMq8TAQYP8Nou7iMS7x6+q3dFhhyhgodIzTF9acsEINl4cIzMaM9XJor8kw==",
       "cpu": [
         "x64"
       ],
@@ -1819,9 +1819,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.0.tgz",
-      "integrity": "sha512-E2IHMdE+C1k+nUgndM13/BY/iJY9KGCphCftMh7SXWcaQqExq/pJU/1Hgn8n/tFwSoLoYC/yUghOv97tAsIxqg==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.11.tgz",
+      "integrity": "sha512-Q9shvB+eLNrK/n8w+/ZTWSzbEIzJ56mP83ZVaqmHay6/Ulcn6THEId4gxfYCXmSwEG/xPAtv58FBWeZkp36XUA==",
       "cpu": [
         "arm64"
       ],
@@ -1835,9 +1835,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.0.tgz",
-      "integrity": "sha512-xzgl7c7BVk4+7PDWldU+On2nlwnGgFqJ1siWp3/8S0KBBLCjonB6zwJYPtl4MUY7YZJrzzumdUpUoquu5zk8vg==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.11.tgz",
+      "integrity": "sha512-rq+d/a0FZHVPEh3zismoQgfVkSIEzlTbNhD4Z8bToLMszUlggAh1D1syhJ4MHkYzXRszhjS2emy0PYXz7Uwttw==",
       "cpu": [
         "arm64"
       ],
@@ -1851,9 +1851,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.0.tgz",
-      "integrity": "sha512-sdyOg4cbiCw7YUr0F/7ya42oiVBXLD21EYkSwN+PhE4csJH4MSXUsYyslliiiBwkM+KsuQH/y9wuxVz6s7Nstg==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.11.tgz",
+      "integrity": "sha512-82Wroterii1p15O+ZF/DDsHPuxKptR1JGK+obgbAk13vrc3B/fTJ2qOOmdeoMwAQ15gb/9mN4LQl9+IzFje76Q==",
       "cpu": [
         "x64"
       ],
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.0.tgz",
-      "integrity": "sha512-IAXv3OBYqVaNOgyd3kxR4L3msuhmSy1bcchPHxDOjypG33i2yDWvGBwFD94OuuTjjTt/7cuIKtAmoOOml6kfbg==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.11.tgz",
+      "integrity": "sha512-YK9RoeZuHWBd+wHi5/7VLp6P5ZOldAjQfBjjtzcR4f14FNmwT0a3ozMMlG2txDxh53krAd5yOO601RbJxH0gCQ==",
       "cpu": [
         "x64"
       ],
@@ -1883,9 +1883,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.0.tgz",
-      "integrity": "sha512-bmo3ncIJKUS9PWK1JD9pEVv0yuvp1KPuOsyJTHXTv8KDrEmgV/K+U0C75rl9rhIaODcS7JEb6/7eJhdwXI0XmA==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.11.tgz",
+      "integrity": "sha512-pcDMpSckekV8xj2SSKO8PaqaJhrmDx84zUNip0kOWsT/ERhhDpnWkr6KXMqRXVp2y5CW9pp4LwOFdtpt3rhRgw==",
       "cpu": [
         "arm64"
       ],
@@ -1899,9 +1899,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.0.tgz",
-      "integrity": "sha512-O1cJbT+lZp+cTjYyZGiDwsOjO3UHHzSqobkPNipdlnnuPb1swfcuY6r3p8dsKU4hAIEO4cO67ZCfVVH/M1ETXA==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.11.tgz",
+      "integrity": "sha512-Zzo9NLLRzBSHw9zOGpER/gdc5rofZHLjR2OIUIfoBaN2Oo5zWRl43IF5rMSX2LX7MPLTx4Ww8+5lNHAhXgitnA==",
       "cpu": [
         "x64"
       ],
@@ -5681,13 +5681,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.0.0.tgz",
-      "integrity": "sha512-DWKT1YAO9ex2rK0/EeiPpKU++ghTiG59z6m08/ReLRECOYIaEv17maSCYT8zmFQLwIrY5lhJ+iaJPQdT4sJd4g==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.0.11.tgz",
+      "integrity": "sha512-FZOlXGIBvd9zcFlGl6WneiuazaNSjQod0QmAl/3BZlm8ZuDcj6T/7T+7eyCvg0/T3qDVEYGdSCGkxyS7hyHgtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.0.0",
+        "@next/eslint-plugin-next": "16.0.11",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5811,7 +5811,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7868,12 +7867,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.0.0.tgz",
-      "integrity": "sha512-nYohiNdxGu4OmBzggxy9rczmjIGI+TpR5vbKTsE1HqYwNm1B+YSiugSrFguX6omMOKnDHAmBPY4+8TNJk0Idyg==",
+      "version": "16.0.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.0.11.tgz",
+      "integrity": "sha512-Xlo2aFWaoypPzXr4PFLSNmxrzNptlp+hgxnG9Y2THYvHrvmXIuHUyNAWO6Q+F4rm4/bmTOukprXEyF/j4qsC2A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.0.0",
+        "@next/env": "16.0.11",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -7886,14 +7885,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.0.0",
-        "@next/swc-darwin-x64": "16.0.0",
-        "@next/swc-linux-arm64-gnu": "16.0.0",
-        "@next/swc-linux-arm64-musl": "16.0.0",
-        "@next/swc-linux-x64-gnu": "16.0.0",
-        "@next/swc-linux-x64-musl": "16.0.0",
-        "@next/swc-win32-arm64-msvc": "16.0.0",
-        "@next/swc-win32-x64-msvc": "16.0.0",
+        "@next/swc-darwin-arm64": "16.0.11",
+        "@next/swc-darwin-x64": "16.0.11",
+        "@next/swc-linux-arm64-gnu": "16.0.11",
+        "@next/swc-linux-arm64-musl": "16.0.11",
+        "@next/swc-linux-x64-gnu": "16.0.11",
+        "@next/swc-linux-x64-musl": "16.0.11",
+        "@next/swc-win32-arm64-msvc": "16.0.11",
+        "@next/swc-win32-x64-msvc": "16.0.11",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.548.0",
-    "next": "16.0.0",
+    "next": "16.0.11",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "tailwind-merge": "^3.3.1"
@@ -48,7 +48,7 @@
     "@vitest/coverage-v8": "^4.0.7",
     "@vitest/ui": "^4.0.7",
     "eslint": "^9",
-    "eslint-config-next": "16.0.0",
+    "eslint-config-next": "16.0.11",
     "jsdom": "^27.1.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",


### PR DESCRIPTION
## Why
**This is the actual fix for the 2026-06-18 production incident.** Next.js **16.0.0** is vulnerable to **React2Shell** (CVE-2025-55182 / CVE-2025-66478) — a **CVSS-10 pre-auth RCE** via RSC/Flight deserialization. On 2026-06-17 it was exploited to spawn a cryptominer (`/tmp/XXcaLafo`, XMRig) inside the frontend container, pegging the prod host for 17h. The frontend has been **stopped since** (hetzner-side containment + hardening already deployed).

## What
- `next` + `eslint-config-next`: **16.0.0 → 16.0.11** (latest 16.0.x — includes the 16.0.7 React2Shell fix; same minor → minimal breaking risk). The RSC runtime (`react-server-dom-*`) is vendored inside `next`, so bumping `next` is the fix.

## Verification
- `npm run build` ✅ clean (14 routes prerendered)
- `npx vitest run` ✅ **104/104** unit tests pass

## Follow-ups (separate)
- `npm audit` flags 15 pre-existing **dev-tooling** transitive vulns (picomatch ReDoS etc.) — not the runtime RCE, not introduced here; worth a Dependabot/audit-fix pass.
- After merge + release (new `EVEOPROVIT_TAG`), `deploy-app.sh eveoprovit` rebuilds + redeploys the **patched** frontend → it comes back online with the hetzner hardening applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)