### PR TITLE
fix(backend): run container as non-root (Phase C hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Backend-Container läuft non-root (Hardening).** Das `eve-o-provit-backend`-Image lief als root; jetzt als unprivilegierter `appuser` (uid 10001). Die API schreibt nichts auf Platte (liest die read-only SDE-Mount, spricht Postgres/Redis; `/tmp` ist zur Laufzeit tmpfs) → keine beschreibbaren Pfade im Image nötig. Teil der Incident-2026-06-18-Härtung (Defense-in-Depth zusätzlich zu cap_drop/read-only-rootfs/no-new-privileges im hetzner-Compose). `docker build` + Non-root-Lauf (uid 10001) verifiziert.
+
 ## [0.35.0] - 2026-06-08
 
 ### Fixed

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,10 +25,16 @@ FROM alpine:3.21
 
 RUN apk --no-cache add ca-certificates sqlite-libs wget
 
-WORKDIR /root/
+# Run as non-root (hardening). The api writes nothing to disk — it reads the
+# read-only SDE mount and talks to postgres/redis; /tmp is a tmpfs at runtime —
+# so a plain unprivileged user needs no writable paths in the image.
+RUN adduser -D -u 10001 appuser
+WORKDIR /app
 
-# Copy binary from builder
-COPY --from=builder /app/api .
+# Copy binary from builder, owned by the non-root user
+COPY --from=builder --chown=appuser:appuser /app/api .
+
+USER appuser
 
 EXPOSE 8080
 


### PR DESCRIPTION
Incident 2026-06-18 follow-up — **Phase C** (non-root). The `eve-o-provit-backend` image ran as root; now runs as unprivileged `appuser` (uid 10001). The api writes nothing to disk (reads the read-only SDE mount + talks to postgres/redis; `/tmp` is a runtime tmpfs), so no writable image paths are needed. Defense-in-depth on top of cap_drop / read-only rootfs / no-new-privileges already live in the hetzner compose.

**Verified:** `docker build` ✅, container runs as `uid=10001(appuser)`.

Note: kochen + foodlens also run as root but write SQLite to data volumes already root-owned on the host — those need a Dockerfile `USER` **plus** a one-time host volume chown (riskier on live data), tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)